### PR TITLE
Sdks 617 fr proximity location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@
 - `Node` now supports `pageHeader`, and `pageDescription` attributes from `Page Node`. [SDKS-517]
 - `NumberAttributeInputCallback`, and `BooleanAttributeInputCallback` are now supported for IDM integration `Callback`. [SDKS-494]
 - `AbstractValidatedCallback` supports updated `Policies` structures. [SDKS-460]
+- `FRProximity.setLocationAccuracy` is added to specify `CLLocationManager.desiredAccuracy` configuration used in `LocationCollector`. [SDKS-617]
 
 #### Changed
 - `FRUI` now longer asks for user's consent when `DeviceProfileCallback` is the only `Callback` in the `Node`. [SDKS-436]
 - `FRAuth` was mistakenly allowing other app's private Keychain Access storage when .entitlement is misconfigured. [SDKS-552]
+- `FRProximity` SDK's `LocationCollector` now requests for Location Authorization while collecting Device Profile information if the authorization has not been asked yet. [SDKS-617]
 
 #### Deprecated
 

--- a/FRAuth/FRAuth/Callbacks/DeviceProfileCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/DeviceProfileCallback.swift
@@ -62,7 +62,7 @@ import Foundation
     func prepareCollectors() {
         if locationRequired {
             for deviceCollector in FRDeviceCollector.shared.collectors {
-                if String(describing: deviceCollector) == "FRProximity.LocationCollector" {
+                if String(describing: deviceCollector).contains("FRProximity.LocationCollector") {
                     self.locationCollector = deviceCollector
                 }
             }
@@ -77,7 +77,7 @@ import Foundation
         
         if metadataRequired {
             for deviceCollector in FRDeviceCollector.shared.collectors {
-                if String(describing: deviceCollector) == "FRProximity.BluetoothCollector" {
+                if String(describing: deviceCollector).contains("FRProximity.BluetoothCollector") {
                     self.profileCollector.collectors.append(deviceCollector)
                 }
             }

--- a/FRAuth/FRAuth/Callbacks/MultipleValuesCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/MultipleValuesCallback.swift
@@ -2,7 +2,7 @@
 //  MultipleValuesCallback.swift
 //  FRAuth
 //
-//  Copyright (c) 2019 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2020 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/Callbacks/MultipleValuesCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/MultipleValuesCallback.swift
@@ -14,7 +14,7 @@ import Foundation
  MultipleValuesCallback is a base Callback implementation that has one or more user input values. Any Callback that accepts multiple values from user interaction without OpenAM's validation with policies may inherit from this class.
  */
 @objc(FRMultipleValuesCallback)
-public class MultipleValuesCallback: Callback {
+open class MultipleValuesCallback: Callback {
     
     //  MARK: - Property
     
@@ -40,7 +40,7 @@ public class MultipleValuesCallback: Callback {
     ///
     /// - Parameter json: JSON object of MultipleValuesCallback
     /// - Throws: AuthError.invalidCallbackResponse for invalid callback response
-    required init(json: [String : Any]) throws {
+    public required init(json: [String : Any]) throws {
         guard let callbackType = json["type"] as? String else {
             throw AuthError.invalidCallbackResponse(String(describing: json))
         }
@@ -81,7 +81,7 @@ public class MultipleValuesCallback: Callback {
     /// Any Callback inherits from this class may override *buildResponse()* method to construct the payload with any additional input value.
     ///
     /// - Returns: JSON request payload for the Callback
-    public override func buildResponse() -> [String : Any] {
+    open override func buildResponse() -> [String : Any] {
         var responsePayload = self.response
         
         var input: [[String: Any]] = []

--- a/FRAuth/FRAuth/Callbacks/SingleValueCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/SingleValueCallback.swift
@@ -2,7 +2,7 @@
 //  SingleStringValueCallback.swift
 //  FRAuth
 //
-//  Copyright (c) 2019 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2020 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/Callbacks/SingleValueCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/SingleValueCallback.swift
@@ -14,7 +14,7 @@ import Foundation
  SingleValueCallback is a base Callback implementation that has single user input value. Any Callback that accepts single value from user interaction without OpenAM's validation with policies may inherit from this class.
  */
 @objc(FRSingleValueCallback)
-public class SingleValueCallback: Callback {
+open class SingleValueCallback: Callback {
     
     //  MARK: - Property
     
@@ -46,7 +46,7 @@ public class SingleValueCallback: Callback {
     ///
     /// - Parameter json: JSON object of SingleValueCallback
     /// - Throws: AuthError.invalidCallbackResponse for invalid callback response
-    required init(json: [String : Any]) throws {
+    public required init(json: [String : Any]) throws {
         
         guard let callbackType = json["type"] as? String else {
             throw AuthError.invalidCallbackResponse(String(describing: json))
@@ -113,7 +113,7 @@ public class SingleValueCallback: Callback {
     /// Any Callback inherits from this class may override *buildResponse()* method to construct the payload with any additional input value.
     ///
     /// - Returns: JSON request payload for the Callback
-    public override func buildResponse() -> [String : Any] {
+    open override func buildResponse() -> [String : Any] {
         var responsePayload = self.response
         for (key, value) in responsePayload {
             if key == "input", var inputs = value as? [[String: Any]] {

--- a/FRAuth/FRAuth/Device/BrowserCollector.swift
+++ b/FRAuth/FRAuth/Device/BrowserCollector.swift
@@ -2,7 +2,7 @@
 //  BrowserCollector.swift
 //  FRAuth
 //
-//  Copyright (c) 2019 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2020 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -12,15 +12,15 @@ import Foundation
 import WebKit
 
 /// BrowserCollector is responsible for collecting browser information of the device.
-class BrowserCollector: DeviceCollector {
+public class BrowserCollector: DeviceCollector {
     
     /// Name of current collector
-    var name: String = "browser"
+    public var name: String = "browser"
     
     /// Collects browser information
     ///
     /// - Parameter completion: completion block
-    func collect(completion: @escaping DeviceCollectorCallback) {
+    public func collect(completion: @escaping DeviceCollectorCallback) {
         var result: [String: Any] = [:]
         result["userAgent"] = self.buildUserAgent()
         completion(result)

--- a/FRAuth/FRAuth/Device/HardwareCollector.swift
+++ b/FRAuth/FRAuth/Device/HardwareCollector.swift
@@ -2,7 +2,7 @@
 //  HardwareCollector.swift
 //  FRAuth
 //
-//  Copyright (c) 2019 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2020 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -13,15 +13,15 @@ import AVFoundation
 import UIKit
 
 /// HardwareCollector is responsible for collecting hardware information of the device using ProcessInfo.
-class HardwareCollector: DeviceCollector {
+public class HardwareCollector: DeviceCollector {
     
     /// Name of current collector
-    var name: String = "hardware"
+    public var name: String = "hardware"
     
     /// Collects hardware information using ProcessInfo
     ///
     /// - Parameter completion: completion block
-    func collect(completion: @escaping DeviceCollectorCallback) {
+    public func collect(completion: @escaping DeviceCollectorCallback) {
         var result: [String: Any] = [:]
         let pi = ProcessInfo.processInfo
         result["cpu"] = pi.processorCount

--- a/FRAuth/FRAuth/Device/NetworkCollector.swift
+++ b/FRAuth/FRAuth/Device/NetworkCollector.swift
@@ -2,7 +2,7 @@
 //  NetworkCollector.swift
 //  FRAuth
 //
-//  Copyright (c) 2019 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2020 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -11,15 +11,15 @@
 import Foundation
 
 /// NetworkCollector is responsible for collecting network information of the device using FRAuth.NetworkReachabilityMonitor.
-class NetworkCollector: DeviceCollector {
+public class NetworkCollector: DeviceCollector {
     
     /// Name of current collector
-    var name: String = "network"
+    public var name: String = "network"
     
     /// Collects network information using FRAuth.NetworkReachabilityMonitor
     ///
     /// - Parameter completion: completion block
-    func collect(completion: @escaping DeviceCollectorCallback) {
+    public func collect(completion: @escaping DeviceCollectorCallback) {
         var result: [String: Any] = [:]
         
         if let reachabilityMonitor = NetworkReachabilityMonitor() {

--- a/FRAuth/FRAuth/Device/PlatformCollector.swift
+++ b/FRAuth/FRAuth/Device/PlatformCollector.swift
@@ -2,7 +2,7 @@
 //  PlatformCollector.swift
 //  FRAuth
 //
-//  Copyright (c) 2019 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2020 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -12,15 +12,15 @@ import Foundation
 import UIKit
 
 /// PlatformCollector is responsible for collecting platform information of the device using UIDevice, and system information.
-class PlatformCollector: DeviceCollector {
+public class PlatformCollector: DeviceCollector {
     
     /// Name of current collector
-    var name: String = "platform"
+    public var name: String = "platform"
     
     /// Collects platform information using UIDevice, and system information
     ///
     /// - Parameter completion: completion block
-    func collect(completion: @escaping DeviceCollectorCallback) {
+    public func collect(completion: @escaping DeviceCollectorCallback) {
         
         var systemInfo = utsname()
         uname(&systemInfo)

--- a/FRAuth/FRAuth/Device/TelephonyCollector.swift
+++ b/FRAuth/FRAuth/Device/TelephonyCollector.swift
@@ -2,7 +2,7 @@
 //  TelephonyCollector.swift
 //  FRAuth
 //
-//  Copyright (c) 2019 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2020 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -12,15 +12,15 @@ import Foundation
 import CoreTelephony
 
 /// TelephonyCollector is responsible for collecting telephony information of the device using CTCarrier.
-class TelephonyCollector: DeviceCollector {
+public class TelephonyCollector: DeviceCollector {
     
     /// Name of current collector
-    var name: String = "telephony"
+    public var name: String = "telephony"
     
     /// Collects telephony information using CTCarrier
     ///
     /// - Parameter completion: completion block
-    func collect(completion: @escaping DeviceCollectorCallback) {
+    public func collect(completion: @escaping DeviceCollectorCallback) {
 
         var result: [String: Any] = [:]
         

--- a/FRProximity/FRProximity.xcodeproj/project.pbxproj
+++ b/FRProximity/FRProximity.xcodeproj/project.pbxproj
@@ -44,12 +44,17 @@
 		D548ECB4246A1359002DE328 /* BluetoothCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59FAE88234415AF005D34DA /* BluetoothCollector.swift */; };
 		D548ECB5246A135A002DE328 /* LocationCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59FAE87234415AF005D34DA /* LocationCollector.swift */; };
 		D54B7502246B51C500E6394E /* CustomCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D54B7501246B51C500E6394E /* CustomCollector.swift */; };
+		D5850E0024EE39B7004C9B98 /* FRPLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F1337E24EDCAB800737F14 /* FRPLog.swift */; };
+		D5850E0124EE39B7004C9B98 /* FRLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F1337A24EDBDAD00737F14 /* FRLocationManager.swift */; };
+		D5850E0324EE39C8004C9B98 /* FRProximity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59FAE81234414DB005D34DA /* FRProximity.swift */; };
 		D59FAE28234413D3005D34DA /* FRProximity.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D59FAE1E234413D3005D34DA /* FRProximity.framework */; };
 		D59FAE2F234413D3005D34DA /* FRProximity.h in Headers */ = {isa = PBXBuildFile; fileRef = D59FAE21234413D3005D34DA /* FRProximity.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D59FAE82234414DB005D34DA /* FRProximity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59FAE81234414DB005D34DA /* FRProximity.swift */; };
 		D59FAE89234415AF005D34DA /* LocationCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59FAE87234415AF005D34DA /* LocationCollector.swift */; };
 		D59FAE8A234415AF005D34DA /* BluetoothCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = D59FAE88234415AF005D34DA /* BluetoothCollector.swift */; };
 		D59FAE9F234418BD005D34DA /* FRAuth.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D59FAE40234413F3005D34DA /* FRAuth.framework */; };
+		D5F1337B24EDBDAD00737F14 /* FRLocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F1337A24EDBDAD00737F14 /* FRLocationManager.swift */; };
+		D5F1337F24EDCAB800737F14 /* FRPLog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F1337E24EDCAB800737F14 /* FRPLog.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -143,6 +148,8 @@
 		D59FAE87234415AF005D34DA /* LocationCollector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LocationCollector.swift; sourceTree = "<group>"; };
 		D59FAE88234415AF005D34DA /* BluetoothCollector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BluetoothCollector.swift; sourceTree = "<group>"; };
 		D5B68CE1248CDD7000CD2F5B /* FRTestHost.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FRTestHost.xcodeproj; path = ../FRTestHost/FRTestHost.xcodeproj; sourceTree = "<group>"; };
+		D5F1337A24EDBDAD00737F14 /* FRLocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRLocationManager.swift; sourceTree = "<group>"; };
+		D5F1337E24EDCAB800737F14 /* FRPLog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRPLog.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -165,6 +172,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		D505659224ECE8CC005E55BE /* Location */ = {
+			isa = PBXGroup;
+			children = (
+				D5F1337A24EDBDAD00737F14 /* FRLocationManager.swift */,
+			);
+			path = Location;
+			sourceTree = "<group>";
+		};
 		D548EC1F2469CCAA002DE328 /* TestUtil */ = {
 			isa = PBXGroup;
 			children = (
@@ -298,6 +313,8 @@
 		D59FAE20234413D3005D34DA /* FRProximity */ = {
 			isa = PBXGroup;
 			children = (
+				D5F1337D24EDCAAF00737F14 /* Log */,
+				D505659224ECE8CC005E55BE /* Location */,
 				D59FAE862344156A005D34DA /* Device */,
 				D59FAE21234413D3005D34DA /* FRProximity.h */,
 				D59FAE22234413D3005D34DA /* Info.plist */,
@@ -351,6 +368,14 @@
 				D5B68CE8248CDD7000CD2F5B /* FRTestHost.app */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		D5F1337D24EDCAAF00737F14 /* Log */ = {
+			isa = PBXGroup;
+			children = (
+				D5F1337E24EDCAB800737F14 /* FRPLog.swift */,
+			);
+			path = Log;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -524,8 +549,10 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5F1337F24EDCAB800737F14 /* FRPLog.swift in Sources */,
 				D59FAE8A234415AF005D34DA /* BluetoothCollector.swift in Sources */,
 				D59FAE89234415AF005D34DA /* LocationCollector.swift in Sources */,
+				D5F1337B24EDBDAD00737F14 /* FRLocationManager.swift in Sources */,
 				D59FAE82234414DB005D34DA /* FRProximity.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -534,6 +561,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D5850E0324EE39C8004C9B98 /* FRProximity.swift in Sources */,
+				D5850E0024EE39B7004C9B98 /* FRPLog.swift in Sources */,
+				D5850E0124EE39B7004C9B98 /* FRLocationManager.swift in Sources */,
 				D548ECB4246A1359002DE328 /* BluetoothCollector.swift in Sources */,
 				D548ECB5246A135A002DE328 /* LocationCollector.swift in Sources */,
 				D548ECB3246A1322002DE328 /* BluetoothCollectorTests.swift in Sources */,

--- a/FRProximity/FRProximity/Device/BluetoothCollector.swift
+++ b/FRProximity/FRProximity/Device/BluetoothCollector.swift
@@ -2,7 +2,7 @@
 //  BluetoothCollector.swift
 //  FRProximity
 //
-//  Copyright (c) 2019 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2020 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -13,10 +13,10 @@ import CoreBluetooth
 import FRAuth
 
 /// BluetoothCollector is responsible for collecting BLE information of the device using CBPeripheralManager.
-class BluetoothCollector: DeviceCollector {
+public class BluetoothCollector: DeviceCollector {
     
     /// Name of current collector
-    var name: String = "bluetooth"
+    public var name: String = "bluetooth"
     /// CBPeripheralManager to validate if the device can turn on BLE
     var manager = CBPeripheralManager()
     /// BluetoothManagerDelegation class for implementing CBPeripheralManagerDelegate protocols
@@ -25,7 +25,7 @@ class BluetoothCollector: DeviceCollector {
     /// Collects BLE information using CBPeripheralManager
     ///
     /// - Parameter completion: completion block
-    func collect(completion: @escaping DeviceCollectorCallback) {
+    public func collect(completion: @escaping DeviceCollectorCallback) {
         if self.manager.state == .unknown {
             self.managerDelegate.completionCallback = completion
             self.manager.delegate = self.managerDelegate

--- a/FRProximity/FRProximity/Device/LocationCollector.swift
+++ b/FRProximity/FRProximity/Device/LocationCollector.swift
@@ -2,7 +2,7 @@
 //  LocationCollector.swift
 //  FRProximity
 //
-//  Copyright (c) 2019 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2020 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -13,61 +13,29 @@ import CoreLocation
 import FRAuth
 
 /// LocationCollector is responsible for collecting location information of the device using CLLocationManager.
-/// - Note: LocationCollector does not explicitly request permission to collect location information. If the application is not authorized to collect location information, then location information will return lon: 0.0, lat: 0.0
-/// - Note: LocationCollector requests location information by using 'CLLocationManager.requestLocation()' which only retrieves the location once at the time of request. Accuracy of location is 'kCLLocationAccuracyBest'
-class LocationCollector: DeviceCollector {
+/// - Note: LocationCollector requests location information by using 'CLLocationManager.requestLocation()' which only retrieves the location once at the time of request. Accuracy of location is 'kCLLocationAccuracyBest' by default, and can be changed through `FRProximity.setLocationAccuracy(accuracy:)`
+public class LocationCollector: NSObject, DeviceCollector {
     
+    /// FRLocationManager that manages, and collects location authorization, and information
+    var locationManager: FRLocationManager = FRLocationManager.shared
     /// Name of current collector
-    var name: String = "location"
-    /// CLLocationManager to collect location information
-    var locationManager: CLLocationManager = CLLocationManager()
-    /// CLLocationManager's delegation class to collect information
-    var locationDelegate: LocationManagerDelegation = LocationManagerDelegation()
-    
-    var authorizationStatus: CLAuthorizationStatus {
-        get {
-            return CLLocationManager.authorizationStatus()
-        }
-    }
+    public var name: String = "location"
     
     /// Collects location information using CLLocationManager
     ///
     /// - Parameter completion: completion block
-    func collect(completion: @escaping DeviceCollectorCallback) {
-        
-        // If CLLocationManager's authorization status is not allowed, then do not request location information
-        if self.authorizationStatus == .authorizedAlways || self.authorizationStatus == .authorizedWhenInUse {
-            self.locationDelegate.completionCallback = completion
-            self.locationManager.delegate = self.locationDelegate
-            self.locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
-            self.locationManager.requestLocation()
-        }
-        else {
-            completion([:])
-        }
-    }
-}
-
-/// LocationManagerDelegation is responsible for implementation of CLLocationManagerDelegate
-class LocationManagerDelegation: NSObject, CLLocationManagerDelegate {
-    // Original completion callback received from LocationCollector
-    var completionCallback: DeviceCollectorCallback?
-    
-    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
-        if let completion = self.completionCallback, let location = locations.last {
-            var result: [String: Any] = [:]
-            result["latitude"] = location.coordinate.latitude
-            result["longitude"] = location.coordinate.longitude
-            completion(result)
-            self.completionCallback = nil
-        }
-    }
-    
-    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
-        if let completion = self.completionCallback {
-            completion([:])
-            self.completionCallback = nil
+    public func collect(completion: @escaping DeviceCollectorCallback) {
+        //  Requests CLLocation from FRLocationManager
+        locationManager.requestLocation { (location) in
+            if let location = location {
+                var result: [String: Any] = [:]
+                result["latitude"] = location.coordinate.latitude
+                result["longitude"] = location.coordinate.longitude
+                completion(result)
+            }
+            else {
+                completion([:])
+            }
         }
     }
 }
-

--- a/FRProximity/FRProximity/FRProximity.swift
+++ b/FRProximity/FRProximity/FRProximity.swift
@@ -38,7 +38,7 @@ import CoreLocation
     
     /// Sets CLLocationAccuracy for LocationCollector
     /// - Parameter accuracy: CLLocationAccuracy that LocationCollector will be using to fetch location
-    @objc static func setLocationAccuracy(accuracy: CLLocationAccuracy) {
+    @objc static public func setLocationAccuracy(accuracy: CLLocationAccuracy) {
         FRLocationManager.shared.locationManager.desiredAccuracy = accuracy
         FRPLog.i("CLLocationAccuracy has changed: \(accuracy)")
     }

--- a/FRProximity/FRProximity/FRProximity.swift
+++ b/FRProximity/FRProximity/FRProximity.swift
@@ -2,14 +2,14 @@
 //  FRProximity.swift
 //  FRProximity
 //
-//  Copyright (c) 2019 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2020 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
 //
 
-import UIKit
 import FRAuth
+import CoreLocation
 
 /**
  FRProximity SDK is subset of tools and functionalities consumed by FRAuth SDK related to proximity features (such as location, and BLE) in the device.
@@ -28,10 +28,18 @@ import FRAuth
     
     /// Starts FRProximity SDK
     @objc static public func startProximity() {
-        FRLog.i("Starting FRProximity SDK")
-        FRLog.i("Injecting FRProximity DeviceCollectors")
+        FRPLog.i("Starting FRProximity SDK")
+        FRPLog.i("Injecting FRProximity DeviceCollectors")
         // Adds FRProximity's DeviceCollector to central FRDeviceCollector
         FRDeviceCollector.shared.collectors.append(BluetoothCollector())
         FRDeviceCollector.shared.collectors.append(LocationCollector())
+    }
+    
+    
+    /// Sets CLLocationAccuracy for LocationCollector
+    /// - Parameter accuracy: CLLocationAccuracy that LocationCollector will be using to fetch location
+    @objc static func setLocationAccuracy(accuracy: CLLocationAccuracy) {
+        FRLocationManager.shared.locationManager.desiredAccuracy = accuracy
+        FRPLog.i("CLLocationAccuracy has changed: \(accuracy)")
     }
 }

--- a/FRProximity/FRProximity/Location/FRLocationManager.swift
+++ b/FRProximity/FRProximity/Location/FRLocationManager.swift
@@ -1,0 +1,210 @@
+// 
+//  FRLocationManager.swift
+//  FRProximity
+//
+//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import Foundation
+import CoreLocation
+
+
+/// FRLocationManager is responsible for requesting authorization, managing, and collecting the device's location information using CoreLocation framework
+class FRLocationManager: NSObject {
+    
+    /// typealias definition of CLLocation callback
+    typealias LocationCallback = (_ location: CLLocation?) -> Void
+    /// Shared singletone instance of FRLocationManager
+    static let shared: FRLocationManager = FRLocationManager()
+    /// Static constant for time in seconds to cache location information
+    static let LOCATION_CACHE_VALIDITY_IN_SEC: Double = 5
+    /// CLLocationManager instance to authorize and collect location information
+    var locationManager: CLLocationManager = CLLocationManager()
+    /// Location information that was most recently collected
+    var lastKnownLocation: CLLocation?
+    /// Boolean indicator whether or not CLLocationManager should proceed to fetch location after authorization
+    var shouldFetchLocation: Bool = false
+    /// An array of completion callback to notify upon retrieving location
+    var callbacks: [LocationCallback] = []
+    /// GCD concurrent queue for atomic property
+    let internalQueue = DispatchQueue(label: "concurrentQueue", attributes: .concurrent)
+    /// Internal Bool indicator of whether or not requesting/authorizing process is in progress
+    var inProgress: Bool = false
+    /// Instance property of whether or not requesting/authorizing process is in progress
+    var isRequesting: Bool {
+        get {
+            return internalQueue.sync{ inProgress }
+        }
+        set {
+            internalQueue.sync {
+                inProgress = newValue
+            }
+        }
+    }
+    /// Instance property of authorization status for CLLocationManager
+    var authorizationStatus: CLAuthorizationStatus {
+        get {
+            return CLLocationManager.authorizationStatus()
+        }
+    }
+    /// Human-readable status in String for authorization status
+    var authorizationStatusAsString: String {
+        switch authorizationStatus {
+        case .authorizedAlways:
+            return "authorizedAlways"
+        case .authorizedWhenInUse:
+            return "authorizedWhenInUse"
+        case .denied:
+            return "denied"
+        case .restricted:
+            return "restricted"
+        case .notDetermined:
+            return "notDetermined"
+        default:
+            return "unknown"
+        }
+    }
+    
+    
+    //  MARK: - Lifecycle
+    
+    /// Initializes FRLocationManager instance
+    override init() {
+        super.init()
+        locationManager.desiredAccuracy = kCLLocationAccuracyHundredMeters
+        locationManager.delegate = self
+    }
+    
+    
+    //  MARK: - Location Request
+    
+    /// Requests location information and authorization if needed
+    /// - Parameter completion: Completion callback to return location information
+    func requestLocation(completion: @escaping LocationCallback) {
+        
+        //  If CoreLocation service is not enabled, return nil
+        guard CLLocationManager.locationServicesEnabled() else {
+            FRPLog.w("CoreLocation service is not enabled; returning nil for location request")
+            completion(nil)
+            return
+        }
+        
+        //  If authorization is already granted
+        if authorizationStatus == .authorizedAlways || authorizationStatus == .authorizedWhenInUse {
+            // If the location information was fetched in the last <LOCATION_CACHE_VALIDITY_IN_SEC> seconds, return the last known location
+            if let lastLocation = lastKnownLocation, (Date().timeIntervalSince1970 - lastLocation.timestamp.timeIntervalSince1970) < FRLocationManager.LOCATION_CACHE_VALIDITY_IN_SEC {
+                FRPLog.v("Last fetched location was less than \(FRLocationManager.LOCATION_CACHE_VALIDITY_IN_SEC) seconds; returning cachced location")
+                completion(lastKnownLocation)
+                return
+            }
+            
+            callbacks.append(completion)
+            //  Only request location if the request is not already in the queue
+            if !isRequesting {
+                FRPLog.v("Location fetch request is started")
+                isRequesting = true
+                locationManager.requestLocation()
+            }
+        }
+        //  If authorization has not been asked yet
+        else if authorizationStatus == .notDetermined {
+            FRPLog.v("Location authorization has not been determined yet; requesting authorization")
+            callbacks.append(completion)
+            //  Run through authorization status check, and make authorization request if needed
+            requestAuthorizationIfNeeded()
+        }
+        //  If authorization has been declined or retricted for the app
+        else {
+            FRPLog.e("Failed to fetch location information; CLAuthorizationStatus is \(authorizationStatusAsString)")
+            completion(nil)
+        }
+    }
+    
+    
+    /// Requests for CoreLocation service authorization if needed; this method will validate whether or not the application has proper Privacy Consent in the application's `.plist` file and make corresponding request for authorization
+    func requestAuthorizationIfNeeded() {
+        
+        var shouldRequestAlways = false
+        var shouldRequestWhenInUse = false
+        
+        //  For iOS 11, search for NSLocationAlwaysAndWhenInUseUsageDescription, and NSLocationWhenInUseUsageDescription string keys in plist file
+        if #available(iOS 11.0, *) {
+            shouldRequestAlways = Bundle.main.object(forInfoDictionaryKey: "NSLocationAlwaysAndWhenInUseUsageDescription") != nil
+            shouldRequestWhenInUse = Bundle.main.object(forInfoDictionaryKey: "NSLocationWhenInUseUsageDescription") != nil
+        }
+        //  For iOS 11, search for NSLocationAlwaysUsageDescription, and NSLocationWhenInUseUsageDescription string keys in plist file
+        else {
+            shouldRequestAlways = Bundle.main.object(forInfoDictionaryKey: "NSLocationAlwaysUsageDescription") != nil
+            shouldRequestWhenInUse = Bundle.main.object(forInfoDictionaryKey: "NSLocationWhenInUseUsageDescription") != nil
+        }
+        
+        //  If Location for Always privacy consent is defined
+        if shouldRequestAlways {
+            if !isRequesting {
+                FRPLog.v("Privacy - Location Always Usage Description is found; requesting for authorization")
+                isRequesting = true
+                locationManager.requestAlwaysAuthorization()
+                shouldFetchLocation = true
+            }
+        }
+        //  If Location for When In Use privacy consent is defined
+        else if shouldRequestWhenInUse {
+            if !isRequesting {
+                FRPLog.v("Privacy - Location When In Use Usage Description is found; requesting for authorization")
+                isRequesting = true
+                locationManager.requestWhenInUseAuthorization()
+                shouldFetchLocation = true
+            }
+        }
+        //  If no privacy consent is defined in .plist, return nil
+        else {
+            FRPLog.e("Missing Privacy Consent in the application .plist file; SDK cannot proceed for authorization, and returning nil for location information")
+            notifyCallbacks(location: nil)
+        }
+    }
+    
+    
+    /// Notifies an array of Callbacks for the result
+    /// - Parameter location: optional CLLocation information that was collected
+    func notifyCallbacks(location: CLLocation?) {
+        for callback in callbacks {
+            callback(location)
+        }
+        callbacks.removeAll()
+    }
+}
+
+
+extension FRLocationManager: CLLocationManagerDelegate {
+    
+    func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        FRPLog.v("CLAuthorizationStatus did changed: \(authorizationStatusAsString)")
+        //  Upon completion of authorization, if the location should be fetched
+        if shouldFetchLocation {
+            //  If authorization is granted, request the location
+            if (status == .authorizedAlways || status == .authorizedWhenInUse) {
+                locationManager.requestLocation()
+            }
+            //  otherwise, return nil
+            else {
+                notifyCallbacks(location: nil)
+            }
+        }
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
+        FRPLog.v("Location is fetched, and will be cached for \(FRLocationManager.LOCATION_CACHE_VALIDITY_IN_SEC) seconds - \(locations)")
+        isRequesting = false
+        lastKnownLocation = locations.last
+        notifyCallbacks(location: lastKnownLocation)
+    }
+    
+    func locationManager(_ manager: CLLocationManager, didFailWithError error: Error) {
+        isRequesting = false
+        notifyCallbacks(location: nil)
+        FRPLog.e("Failed to fetch the location information: \(error.localizedDescription)")
+    }
+}

--- a/FRProximity/FRProximity/Log/FRPLog.swift
+++ b/FRProximity/FRProximity/Log/FRPLog.swift
@@ -1,0 +1,57 @@
+//
+//  FRPLog.swift
+//  FRProximity
+//
+//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import Foundation
+import FRCore
+
+/**
+FRPLog is a class responsible for Logging functionalities of FRProximity SDK. FRPLog can also be used in the application layer which then be displayed through FRPLog SDK, and through OSLog with FRPLog SDK's system label and LogLevel.
+
+## Note ##
+By default, FRPLog uses OSLog to display the log entry in the debug console, and in the log system of iOS; however, when *OS_ACTIVITY_MODE* is *disabled* in the environment variable, FRPLog then uses default system *print()* method to display the log entry in the console only.
+*/
+public struct FRPLog {
+    
+    /// Module name of FRLog
+    static var ModuleName: String {
+        get {
+            var versionStr = ""
+            if let version = Bundle(for: FRProximity.self).infoDictionary?["CFBundleShortVersionString"] as? String {
+                versionStr = "[\(version)]"
+            }
+            return "[FRProximity]" + versionStr
+        }
+    }
+    
+    //  MARK: - Method
+    
+    /// Sets LogLevel
+    ///
+    /// - Parameter logLevel: Designated LogLevel to be displayed
+    public static func setLogLevel(_ logLevel: LogLevel) {
+        Log.setLogLevel(logLevel)
+    }
+    
+    public static func v(_ message: String, _ includeCallStack: Bool? = true, file: String = #file, line: Int = #line, function: String = #function) {
+        Log.v(message, includeCallStack, module: ModuleName, file: file, line: line, function: function)
+    }
+    
+    public static func i(_ message: String, _ includeCallStack: Bool? = true, file: String = #file, line: Int = #line, function: String = #function) {
+        Log.i(message, includeCallStack, module: ModuleName, file: file, line: line, function: function)
+    }
+    
+    public static func w(_ message: String, _ includeCallStack: Bool? = true, file: String = #file, line: Int = #line, function: String = #function) {
+        Log.w(message, includeCallStack, module: ModuleName, file: file, line: line, function: function)
+    }
+    
+    public static func e(_ message: String, file: String = #file, line: Int = #line, function: String = #function) {
+        Log.e(message, module: ModuleName, file: file, line: line, function: function)
+    }
+}

--- a/FRProximity/FRProximityTests/E2ETests/DeviceCollectorNodeTests.swift
+++ b/FRProximity/FRProximityTests/E2ETests/DeviceCollectorNodeTests.swift
@@ -47,10 +47,10 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             // Provide input value for callbacks
             for callback in firstNode.callbacks {
                 if callback is NameCallback, let nameCallback = callback as? NameCallback {
-                    nameCallback.value = "username"
+                    nameCallback.setValue("username")
                 }
                 else if callback is PasswordCallback, let passwordCallback = callback as? PasswordCallback {
-                    passwordCallback.value = "password"
+                    passwordCallback.setValue("password")
                 }
                 else {
                     XCTFail("Received unexpected callback \(callback)")
@@ -95,8 +95,8 @@ class DeviceCollectorNodeTests: FRPBaseTest {
                 XCTAssertTrue(response.keys.contains("metadata"))
                 XCTAssertTrue(response.keys.contains("identifier"))
                 XCTAssertFalse(response.keys.contains("location"))
-                XCTAssertNotNil(deviceProfileCallback.value)
-                let requestPayload = FRPTestUtils.parseStringToDictionary(deviceProfileCallback.value as! String)
+                XCTAssertNotNil(deviceProfileCallback.getValue())
+                let requestPayload = FRPTestUtils.parseStringToDictionary(deviceProfileCallback.getValue() as! String)
                 XCTAssertEqual(response.keys, requestPayload.keys)
                 ex.fulfill()
             }
@@ -150,10 +150,10 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             // Provide input value for callbacks
             for callback in firstNode.callbacks {
                 if callback is NameCallback, let nameCallback = callback as? NameCallback {
-                    nameCallback.value = "username"
+                    nameCallback.setValue("username")
                 }
                 else if callback is PasswordCallback, let passwordCallback = callback as? PasswordCallback {
-                    passwordCallback.value = "password"
+                    passwordCallback.setValue("password")
                 }
                 else {
                     XCTFail("Received unexpected callback \(callback)")
@@ -193,12 +193,13 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             let fakeLocationManager = FakeLocationManager()
             fakeLocationManager.fakeLocation = [CLLocation(latitude: 49.2827, longitude: 123.1207)]
             let location = FakeLocationCollector()
-            location.locationManager = fakeLocationManager
-            location.changeStatus(status: .authorizedWhenInUse)
+            location.locationManager.locationManager = fakeLocationManager
+            location.locationManager.locationManager.delegate = location.locationManager
+            FakeFRLocationManager.changeStatus(status: .authorizedWhenInUse)
 
             // Assign FakeLocationCollector to callback
             for (index, collector) in deviceProfileCallback.collector.collectors.enumerated() {
-                if String(describing:collector) == "FRProximity.LocationCollector" {
+                if String(describing:collector).contains("FRProximity.LocationCollector") {
                     deviceProfileCallback.collector.collectors.remove(at: index)
                     deviceProfileCallback.collector.collectors.append(location)
                 }
@@ -222,8 +223,8 @@ class DeviceCollectorNodeTests: FRPBaseTest {
                 XCTAssertEqual(lat, 49.2827)
                 XCTAssertEqual(long, 123.1207)
                 
-                XCTAssertNotNil(deviceProfileCallback.value)
-                let requestPayload = FRPTestUtils.parseStringToDictionary(deviceProfileCallback.value as! String)
+                XCTAssertNotNil(deviceProfileCallback.getValue())
+                let requestPayload = FRPTestUtils.parseStringToDictionary(deviceProfileCallback.getValue() as! String)
                 XCTAssertEqual(response.keys, requestPayload.keys)
                 ex.fulfill()
             }
@@ -277,10 +278,10 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             // Provide input value for callbacks
             for callback in firstNode.callbacks {
                 if callback is NameCallback, let nameCallback = callback as? NameCallback {
-                    nameCallback.value = "username"
+                    nameCallback.setValue("username")
                 }
                 else if callback is PasswordCallback, let passwordCallback = callback as? PasswordCallback {
-                    passwordCallback.value = "password"
+                    passwordCallback.setValue("password")
                 }
                 else {
                     XCTFail("Received unexpected callback \(callback)")
@@ -317,9 +318,12 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             }
             
             // Fake location collector
+            let fakeLocationManager = FakeLocationManager()
             let location = FakeLocationCollector()
-            location.changeStatus(status: .denied)
-
+            location.locationManager.locationManager = fakeLocationManager
+            location.locationManager.locationManager.delegate = location.locationManager
+            FakeFRLocationManager.changeStatus(status: .denied)
+            
             // Assign FakeLocationCollector to callback
             for (index, collector) in deviceProfileCallback.collector.collectors.enumerated() {
                 if String(describing:collector) == "FRProximity.LocationCollector" {
@@ -337,8 +341,8 @@ class DeviceCollectorNodeTests: FRPBaseTest {
                 XCTAssertTrue(response.keys.contains("metadata"))
                 XCTAssertTrue(response.keys.contains("identifier"))
                 XCTAssertFalse(response.keys.contains("location"))
-                XCTAssertNotNil(deviceProfileCallback.value)
-                let requestPayload = FRPTestUtils.parseStringToDictionary(deviceProfileCallback.value as! String)
+                XCTAssertNotNil(deviceProfileCallback.getValue())
+                let requestPayload = FRPTestUtils.parseStringToDictionary(deviceProfileCallback.getValue() as! String)
                 XCTAssertEqual(response.keys, requestPayload.keys)
                 ex.fulfill()
             }
@@ -392,10 +396,10 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             // Provide input value for callbacks
             for callback in firstNode.callbacks {
                 if callback is NameCallback, let nameCallback = callback as? NameCallback {
-                    nameCallback.value = "username"
+                    nameCallback.setValue("username")
                 }
                 else if callback is PasswordCallback, let passwordCallback = callback as? PasswordCallback {
-                    passwordCallback.value = "password"
+                    passwordCallback.setValue("password")
                 }
                 else {
                     XCTFail("Received unexpected callback \(callback)")
@@ -433,14 +437,15 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             
             // Fake location collector
             let fakeLocationManager = FakeLocationManager()
+            FakeFRLocationManager.changeStatus(status: .authorizedWhenInUse)
             fakeLocationManager.fakeLocation = [CLLocation(latitude: 49.2827, longitude: 123.1207)]
             let location = FakeLocationCollector()
-            location.locationManager = fakeLocationManager
-            location.changeStatus(status: .authorizedWhenInUse)
+            location.locationManager.locationManager = fakeLocationManager
+            location.locationManager.locationManager.delegate = location.locationManager
 
             // Assign FakeLocationCollector to callback
             for (index, collector) in deviceProfileCallback.collector.collectors.enumerated() {
-                if String(describing:collector) == "FRProximity.LocationCollector" {
+                if String(describing:collector).contains("FRProximity.LocationCollector") {
                     deviceProfileCallback.collector.collectors.remove(at: index)
                     deviceProfileCallback.collector.collectors.append(location)
                 }
@@ -464,8 +469,8 @@ class DeviceCollectorNodeTests: FRPBaseTest {
                 XCTAssertEqual(lat, 49.2827)
                 XCTAssertEqual(long, 123.1207)
                 
-                XCTAssertNotNil(deviceProfileCallback.value)
-                let requestPayload = FRPTestUtils.parseStringToDictionary(deviceProfileCallback.value as! String)
+                XCTAssertNotNil(deviceProfileCallback.getValue())
+                let requestPayload = FRPTestUtils.parseStringToDictionary(deviceProfileCallback.getValue() as! String)
                 XCTAssertEqual(response.keys, requestPayload.keys)
                 ex.fulfill()
             }
@@ -519,10 +524,10 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             // Provide input value for callbacks
             for callback in firstNode.callbacks {
                 if callback is NameCallback, let nameCallback = callback as? NameCallback {
-                    nameCallback.value = "username"
+                    nameCallback.setValue("username")
                 }
                 else if callback is PasswordCallback, let passwordCallback = callback as? PasswordCallback {
-                    passwordCallback.value = "password"
+                    passwordCallback.setValue("password")
                 }
                 else {
                     XCTFail("Received unexpected callback \(callback)")
@@ -559,8 +564,11 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             }
             
             // Fake location collector
+            let fakeLocationManager = FakeLocationManager()
             let location = FakeLocationCollector()
-            location.changeStatus(status: .denied)
+            location.locationManager.locationManager = fakeLocationManager
+            location.locationManager.locationManager.delegate = location.locationManager
+            FakeFRLocationManager.changeStatus(status: .denied)
 
             // Assign FakeLocationCollector to callback
             for (index, collector) in deviceProfileCallback.collector.collectors.enumerated() {
@@ -579,8 +587,8 @@ class DeviceCollectorNodeTests: FRPBaseTest {
                 XCTAssertFalse(response.keys.contains("metadata"))
                 XCTAssertTrue(response.keys.contains("identifier"))
                 XCTAssertFalse(response.keys.contains("location"))
-                XCTAssertNotNil(deviceProfileCallback.value)
-                let requestPayload = FRPTestUtils.parseStringToDictionary(deviceProfileCallback.value as! String)
+                XCTAssertNotNil(deviceProfileCallback.getValue())
+                let requestPayload = FRPTestUtils.parseStringToDictionary(deviceProfileCallback.getValue() as! String)
                 XCTAssertEqual(response.keys, requestPayload.keys)
                 ex.fulfill()
             }
@@ -635,10 +643,10 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             // Provide input value for callbacks
             for callback in firstNode.callbacks {
                 if callback is NameCallback, let nameCallback = callback as? NameCallback {
-                    nameCallback.value = "username"
+                    nameCallback.setValue("username")
                 }
                 else if callback is PasswordCallback, let passwordCallback = callback as? PasswordCallback {
-                    passwordCallback.value = "password"
+                    passwordCallback.setValue("password")
                 }
                 else {
                     XCTFail("Received unexpected callback \(callback)")
@@ -678,8 +686,9 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             let fakeLocationManager = FakeLocationManager()
             fakeLocationManager.fakeLocation = [CLLocation(latitude: 49.2827, longitude: 123.1207)]
             let location = FakeLocationCollector()
-            location.locationManager = fakeLocationManager
-            location.changeStatus(status: .authorizedWhenInUse)
+            location.locationManager.locationManager = fakeLocationManager
+            location.locationManager.locationManager.delegate = location.locationManager
+            FakeFRLocationManager.changeStatus(status: .authorizedWhenInUse)
 
             // Assign FakeLocationCollector to callback
             for (index, collector) in deviceProfileCallback.collector.collectors.enumerated() {
@@ -731,10 +740,10 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             // Provide input value for callbacks
             for callback in firstNode.callbacks {
                 if callback is NameCallback, let nameCallback = callback as? NameCallback {
-                    nameCallback.value = "james.go@forgerock.com"
+                    nameCallback.setValue("james.go@forgerock.com")
                 }
                 else if callback is PasswordCallback, let passwordCallback = callback as? PasswordCallback {
-                    passwordCallback.value = "Password123!"
+                    passwordCallback.setValue("Password123!")
                 }
                 else {
                     XCTFail("Received unexpected callback \(callback)")
@@ -774,8 +783,9 @@ class DeviceCollectorNodeTests: FRPBaseTest {
             let fakeLocationManager = FakeLocationManager()
             fakeLocationManager.fakeLocation = [CLLocation(latitude: 49.2827, longitude: 123.1207)]
             let location = FakeLocationCollector()
-            location.locationManager = fakeLocationManager
-            location.changeStatus(status: .authorizedWhenInUse)
+            location.locationManager.locationManager = fakeLocationManager
+            location.locationManager.locationManager.delegate = location.locationManager
+            FakeFRLocationManager.changeStatus(status: .authorizedWhenInUse)
 
             // Assign FakeLocationCollector to callback
             deviceProfileCallback.collector.collectors.removeAll()
@@ -801,7 +811,7 @@ class DeviceCollectorNodeTests: FRPBaseTest {
                 XCTAssertEqual(long, 123.1207)
                 
                 XCTAssertNotNil(deviceProfileCallback.value)
-                let requestPayload = FRPTestUtils.parseStringToDictionary(deviceProfileCallback.value as! String)
+                let requestPayload = FRPTestUtils.parseStringToDictionary(deviceProfileCallback.getValue() as! String)
                 XCTAssertEqual(response.keys, requestPayload.keys)
                 ex.fulfill()
             }

--- a/FRProximity/FRProximityTests/UnitTests/DeviceProfileCallbackTests.swift
+++ b/FRProximity/FRProximityTests/UnitTests/DeviceProfileCallbackTests.swift
@@ -56,14 +56,15 @@ class DeviceProfileCallbackTests: FRPBaseTest {
             // Fake location collector
             let fakeLocationManager = FakeLocationManager()
             fakeLocationManager.fakeLocation = [CLLocation(latitude: 49.2827, longitude: 123.1207)]
+            FakeFRLocationManager.changeStatus(status: .authorizedWhenInUse)
             let location = FakeLocationCollector()
-            location.locationManager = fakeLocationManager
-            location.changeStatus(status: .authorizedWhenInUse)
+            location.locationManager.locationManager = fakeLocationManager
+            location.locationManager.locationManager.delegate = location.locationManager
             callback.collector.collectors.append(location)
 
             // Assign FakeLocationCollector to callback
             for (index, collector) in callback.collector.collectors.enumerated() {
-                if String(describing:collector) == "FRProximity.LocationCollector" {
+                if String(describing:collector).contains("FRProximity.LocationCollector") {
                     callback.collector.collectors.remove(at: index)
                 }
             }
@@ -136,9 +137,10 @@ class DeviceProfileCallbackTests: FRPBaseTest {
             
             // Fake location collector
             let fakeLocationManager = FakeLocationManager()
+            FakeFRLocationManager.changeStatus(status: .denied)
             let location = FakeLocationCollector()
-            location.locationManager = fakeLocationManager
-            location.changeStatus(status: .denied)
+            location.locationManager.locationManager = fakeLocationManager
+            location.locationManager.locationManager.delegate = location.locationManager
             callback.collector.collectors.append(location)
 
             // Assign FakeLocationCollector to callback

--- a/FRProximity/FRProximityTests/UnitTests/FRProximityTests.swift
+++ b/FRProximity/FRProximityTests/UnitTests/FRProximityTests.swift
@@ -10,6 +10,7 @@
 
 
 import XCTest
+import CoreLocation
 @testable import FRAuth
 
 class FRProximityTests: FRPBaseTest {
@@ -31,5 +32,16 @@ class FRProximityTests: FRPBaseTest {
         catch {
             XCTFail("SDK init failed with unexpected error: \(error.localizedDescription)")
         }
+    }
+    
+    
+    func test_02_location_accuracy_default() {
+        XCTAssertEqual(FRLocationManager.shared.locationManager.desiredAccuracy, kCLLocationAccuracyHundredMeters)
+    }
+    
+    
+    func test_03_update_location_accuracy() {
+        FRProximity.setLocationAccuracy(accuracy: kCLLocationAccuracyHundredMeters)
+        XCTAssertEqual(FRLocationManager.shared.locationManager.desiredAccuracy, kCLLocationAccuracyHundredMeters)
     }
 }

--- a/SampleApps/FRExample/FRExample/ViewController.swift
+++ b/SampleApps/FRExample/FRExample/ViewController.swift
@@ -141,6 +141,7 @@ class ViewController: UIViewController {
             "FRUser.getAccessToken()",
             "Login with UI (Accesstoken)",
             "FRSession.authenticate with UI (Token)",
+            "FRSession.logout()",
             "Register User with UI (FRUser)",
             "Register User with UI (Accesstoken)",
             "Login without UI (FRUser)",
@@ -149,7 +150,6 @@ class ViewController: UIViewController {
             "Display Configurations"
         ]
         self.commandField?.setTitle("Login with UI (FRUser)", for: .normal)
-
         
         // - MARK: Token Management - Example
         // Register FRURLProtocol
@@ -636,6 +636,8 @@ class ViewController: UIViewController {
             let responseStr = String(decoding: responseData, as: UTF8.self)
             self.displayLog("Response Data: \(responseStr)")
             self.displayLog("Response Header: \n\(httpresponse.allHeaderFields)")
+            FRLog.i("Response Data: \(responseStr)")
+            FRLog.i("Response Header: \n\(httpresponse.allHeaderFields)")
         }.resume()
     }
     
@@ -695,26 +697,30 @@ class ViewController: UIViewController {
             self.performSessionAuthenticate(handleWithUI: true)
             break
         case 10:
+            // FRSession.logout
+            FRSession.currentSession?.logout()
+            break
+        case 11:
             // Register a user for FRUser
             self.performActionHelperWithUI(auth: frAuth, flowType: .registration, expectedType: FRUser.self)
             break
-        case 11:
+        case 12:
             // Register a user for AccessToken
             self.performActionHelperWithUI(auth: frAuth, flowType: .registration, expectedType: AccessToken.self)
             break
-        case 12:
+        case 13:
             // Login for FRUser without UI
             self.performActionHelper(auth: frAuth, flowType: .authentication, expectedType: FRUser.self)
             break
-        case 13:
+        case 14:
             // Login for AccessToken without UI
             self.performActionHelper(auth: frAuth, flowType: .authentication, expectedType: AccessToken.self)
             break
-        case 14:
+        case 15:
             // FRSession.authenticate without UI (Token)
             self.performSessionAuthenticate(handleWithUI: false)
             break
-        case 15:
+        case 16:
             // Display current Configuration
             self.displayCurrentConfig()
             break


### PR DESCRIPTION
Following items were changed to align location collection behavior of iOS SDK to Android and JavaScript SDK:
- Change LocationCollector class to request for authorization when the authorization is not asked yet
- Create FRLocationManager class to manage and collect location and/or authorization 
- FRLocationManager checks Privacy Consent in .plist file of the application to determine if SDK can request for authorization
- If the location permission is denied, or restricted, still proceed with LocationCollector with null
- Exposing some of DeviceCollector classes that were private
- Update all FRProximity test cases to reflect changes
- Allow developers to change location accuracy configuration used by CLLocationManager within FRProximity SDK