### PR TITLE
SDKS-993 Image attribute in QRCode not persisted by SDK

### DIFF
--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/OathQRCodeParser.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/OathQRCodeParser.swift
@@ -2,7 +2,7 @@
 //  QRCodeParser.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -97,8 +97,13 @@ struct OathQRCodeParser {
                         self.period = intVal
                     }
                 }
-                if item.name == "image", let imgUrlEncoded = item.value, let imgUrlDecodedData = imgUrlEncoded.decodeURL(), let imageUrlStr = String(data: imgUrlDecodedData, encoding: .utf8) {
-                    self.image = imageUrlStr
+                if item.name == "image", let imgUrl = item.value {
+                    if let imgUrlDecodedData = imgUrl.decodeURL() {
+                        let imageUrlStr = String(data: imgUrlDecodedData, encoding: .utf8)
+                        self.image = imageUrlStr
+                    } else {
+                        self.image = imgUrl
+                    }
                 }
                 if item.name == "counter", let strVal = item.value, let intVal = Int(strVal) {
                     self.counter = intVal

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Util/OathQRCodeParserTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Util/OathQRCodeParserTests.swift
@@ -2,7 +2,7 @@
 //  OathQRCodeParserTests.swift
 //  FRAuthenticatorTests
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -235,6 +235,45 @@ class OathQRCodeParserTests: FRABaseTests {
             XCTAssertNotNil(parser.oathAlgorithm)
             XCTAssertEqual(parser.algorithm, "sha512")
             XCTAssertEqual(parser.oathAlgorithm, .sha512)
+        }
+        catch {
+            XCTFail("Failed with unexpected error: \(error.localizedDescription)")
+        }
+    }
+    
+    
+    func test_12_parse_qrcode_with_image_base64_encoded() {
+        let qrCode = URL(string: "otpauth://hotp/Forgerock:demo?secret=IJQWIZ3FOIQUEYLE&issuer=Forgerock&image=aHR0cHM6Ly91cGxvYWQud2lraW1lZGlhLm9yZy93aWtpcGVkaWEvY29tbW9ucy9lL2U1L0Zvcmdlcm9ja19Mb2dvXzE5MHB4LnBuZw==")!
+        
+        do {
+            let parser = try OathQRCodeParser(url: qrCode)
+            XCTAssertEqual(parser.image, "https://upload.wikimedia.org/wikipedia/commons/e/e5/Forgerock_Logo_190px.png")
+        }
+        catch {
+            XCTFail("Failed with unexpected error: \(error.localizedDescription)")
+        }
+    }
+    
+    
+    func test_13_parse_qrcode_with_image_plain_text() {
+        let qrCode = URL(string: "otpauth://hotp/Forgerock:demo?secret=IJQWIZ3FOIQUEYLE&issuer=Forgerock&image=https://upload.wikimedia.org/wikipedia/commons/e/e5/Forgerock_Logo_190px.png")!
+        
+        do {
+            let parser = try OathQRCodeParser(url: qrCode)
+            XCTAssertEqual(parser.image, "https://upload.wikimedia.org/wikipedia/commons/e/e5/Forgerock_Logo_190px.png")
+        }
+        catch {
+            XCTFail("Failed with unexpected error: \(error.localizedDescription)")
+        }
+    }
+    
+    
+    func test_14_parse_qrcode_with_image_url_encoded() {
+        let qrCode = URL(string: "otpauth://hotp/Forgerock:demo?secret=IJQWIZ3FOIQUEYLE&issuer=Forgerock&image=https%3A%2F%2Fupload.wikimedia.org%2Fwikipedia%2Fcommons%2Fe%2Fe5%2FForgerock_Logo_190px.png")!
+        
+        do {
+            let parser = try OathQRCodeParser(url: qrCode)
+            XCTAssertEqual(parser.image, "https://upload.wikimedia.org/wikipedia/commons/e/e5/Forgerock_Logo_190px.png")
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")


### PR DESCRIPTION
This fix address an issue on persist the `image` attribute from a QRCode for OATH registration. The SDK was expecting the attribute to be Base64 encoded. It's only the case for Push accounts, OATH accounts usually has the image value as URL encoded or plain text. Support for image value as Base64 was kept as well.

Unit tests were added to test the changes.