### PR TITLE
SDKS-1009 Expose API to get all push notifications stored

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - New SDK modules, `FRGoogleSignIn` and `FRFacebookSignIn`, are now available to enable Social Login with AM using providers' native SDKs. [SDKS-879]
 - `WebAuthnRegistrationCallback`, and `WebAuthnAuthenticationCallback` are introduced to support AM's `WebAuthn Registration Node` and `WebAuthn Authentication Node`. [SDKS-782]
 - `FRUser.revokeAccessToken()` is introduced to revoke OAuth2 token only, and keep existing SSO token. [SDKS-979]
-
+- `FRAClient.getAllNotifications()` is introduced to retrieve all notifications across all mechanisms. [SDKS-1009]
 
 #### Changed
 - SDK now persists SSO Token through `FRSession` instance without OAuth2 configuration. [SDKS-873]

--- a/FRAuthenticator/FRAuthenticator/FRAClient.swift
+++ b/FRAuthenticator/FRAuthenticator/FRAClient.swift
@@ -2,7 +2,7 @@
 //  FRAuthenticator.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -124,6 +124,14 @@ public class FRAClient: NSObject {
     /// - Returns: An array of PushNotification that given PushMechanism received
     public func getAllNotifications(mechanism: PushMechanism) -> [PushNotification] {
         return self.authenticatorManager.getAllNotifications(mechanism: mechanism)
+    }
+    
+    
+    /// Retrieves an array of PushNotification objects across all PushMechanisms
+    /// - Parameter mechanism: PushMechanism object to retrieve all notifications
+    /// - Returns: An array of PushNotification
+    public func getAllNotifications() -> [PushNotification] {
+        return self.authenticatorManager.getAllNotifications()
     }
     
     

--- a/FRAuthenticator/FRAuthenticator/Manager/AuthenticatorManager.swift
+++ b/FRAuthenticator/FRAuthenticator/Manager/AuthenticatorManager.swift
@@ -2,7 +2,7 @@
 //  AuthenticatorManager.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -319,6 +319,13 @@ struct AuthenticatorManager {
     /// - Returns: An array of PushNotification object
     func getAllNotifications(mechanism: PushMechanism) -> [PushNotification] {
         return self.storageClient.getAllNotificationsForMechanism(mechanism: mechanism)
+    }
+    
+    
+    /// Retrieves All PushNotification across all mechanisms
+    /// - Returns: An array of PushNotification object
+    func getAllNotifications() -> [PushNotification] {
+        return self.storageClient.getAllNotifications()
     }
     
     

--- a/FRAuthenticator/FRAuthenticator/Storage/KeychainServiceClient.swift
+++ b/FRAuthenticator/FRAuthenticator/Storage/KeychainServiceClient.swift
@@ -2,7 +2,7 @@
 //  KeychainServiceStorageClient.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -175,6 +175,21 @@ struct KeychainServiceClient: StorageClient {
                if let notificationData = item.value as? Data,
                 let notification = NSKeyedUnarchiver.unarchiveObject(with: notificationData) as? PushNotification,
                 notification.mechanismUUID == mechanism.mechanismUUID {
+                   notifications.append(notification)
+               }
+           }
+        }
+        return notifications.sorted { (lhs, rhs) -> Bool in
+            return lhs.timeAdded.timeIntervalSince1970 < rhs.timeAdded.timeIntervalSince1970
+        }
+    }
+    
+    
+    func getAllNotifications() -> [PushNotification] {
+        var notifications: [PushNotification] = []
+        if let items = self.notificationStorage.allItems() {
+           for item in items {
+               if let notificationData = item.value as? Data, let notification = NSKeyedUnarchiver.unarchiveObject(with: notificationData) as? PushNotification {
                    notifications.append(notification)
                }
            }

--- a/FRAuthenticator/FRAuthenticator/Storage/StorageClient.swift
+++ b/FRAuthenticator/FRAuthenticator/Storage/StorageClient.swift
@@ -2,7 +2,7 @@
 //  StorageClient.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -56,6 +56,9 @@ public protocol StorageClient {
     /// Retrieves all Notification objects from Storage Client with given Mechanism object
     /// - Parameter mechanism: Mechanism object that is associated with Notification(s)
     func getAllNotificationsForMechanism(mechanism: Mechanism) -> [PushNotification]
+    
+    /// Retrieves all Notification objects from Storage Client
+    func getAllNotifications() -> [PushNotification]
     
     /// Returns whether or not StorageClient has any data stored
     @discardableResult func isEmpty() -> Bool

--- a/FRAuthenticator/FRAuthenticatorTests/E2ETests/FRAClient/FRAClientTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/E2ETests/FRAClient/FRAClientTests.swift
@@ -2,7 +2,7 @@
 //  FRAClientTests.swift
 //  FRAuthenticatorTests
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -194,7 +194,6 @@ class FRAClientTests: FRABaseTests {
         XCTAssertEqual(storageClient.defaultStorageClient.accountStorage.allItems()?.count, 0)
         XCTAssertEqual(storageClient.defaultStorageClient.mechanismStorage.allItems()?.count, 0)
     }
-    
     
     
     func test_05_push_mechanism_tests() {
@@ -424,8 +423,7 @@ class FRAClientTests: FRABaseTests {
     }
     
     
-    
-    func test_05_remove_mechanism_notification() {
+    func test_06_remove_mechanism_notification() {
         do {
             self.loadMockResponses(["AM_Push_Registration_Successful", "AM_Push_Authentication_Successful", "AM_Push_Authentication_Successful", "AM_Push_Authentication_Successful"])
             // Set DeviceToken before PushMechnaism registration
@@ -672,7 +670,7 @@ class FRAClientTests: FRABaseTests {
     }
     
     
-    func test_06_get_all_notifications() {
+    func test_07_get_all_notifications_for_mechanism() {
         
         let storageClient = DummyStorageClient()
         let authenticatorManager = AuthenticatorManager(storageClient: storageClient)
@@ -800,7 +798,160 @@ class FRAClientTests: FRABaseTests {
     }
     
     
-    func test_07_get_account_from_mechanism() {
+    func test_08_get_all_notifications() {
+        
+        let storageClient = DummyStorageClient()
+        let authenticatorManager = AuthenticatorManager(storageClient: storageClient)
+
+        self.loadMockResponses(["AM_Push_Registration_Successful", "AM_Push_Registration_Successful"])
+        // Set DeviceToken before PushMechnaism registration
+        let deviceTokenStr = "PJ6d7k8uM2AvK+T1jJTMBYD5so+SrHnvVLoGz2Mte3A="
+        guard let deviceToken = deviceTokenStr.decodeBase64() else {
+           XCTFail("Failed to parse device token data")
+           return
+        }
+        FRAPushHandler.shared.application(UIApplication.shared, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
+
+        let push = URL(string: "pushauth://push/forgerock:pushtestuser?a=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1hdXRoZW50aWNhdGU&b=519387&r=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1yZWdpc3Rlcg&s=-3xGWaKjfls_ZHFRnGeIvFHn--GxzjQyg1RVG_Pak1s&c=esDK4G8eYce0_Gdf4p9XGGg2cIYYoxf6CTlL_O_1aF8&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:593b6a92-f5c1-4ac0-a94a-a63e05451dd51589138620791&issuer=Rm9yZ2VSb2NrU2FuZGJveA")!
+
+        let push2 = URL(string: "pushauth://push/forgerock:pushtestuser2?a=aHR0cDovL2Rldi5vcGVuYW0uZXhhbXBsZS5jb206ODA4MS9vcGVuYW0vanNvbi9kZXYvcHVzaC9zbnMvbWVzc2FnZT9fYWN0aW9uPWF1dGhlbnRpY2F0ZQ&b=519387&r=aHR0cDovL2Rldi5vcGVuYW0uZXhhbXBsZS5jb206ODA4MS9vcGVuYW0vanNvbi9kZXYvcHVzaC9zbnMvbWVzc2FnZT9fYWN0aW9uPXJlZ2lzdGVy&s=b3uYLkQ7dRPjBaIzV0t_aijoXRgMq-NP5AwVAvRfa_E&c=9giiBAdUHjqpo0XE4YdZ7pRlv0hrQYwDz8Z1wwLLbkg&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:8be951c6-af83-438d-8f74-421bd18650421570561063169&issuer=Rm9yZ2VSb2Nr")!
+        
+        //  Store first Mechanism
+        let ex = self.expectation(description: "FRAClient.createMechanismFromUri")
+        authenticatorManager.createMechanismFromUri(uri: push, onSuccess: { (mechanism) in
+           ex.fulfill()
+        }, onError: { (error) in
+           XCTFail("authenticatorManager.createMechanismFromUri failed with unexpected reason: \(error.localizedDescription)")
+           ex.fulfill()
+        })
+        waitForExpectations(timeout: 60, handler: nil)
+
+        
+        //  Store second Mechanism
+        let ex2 = self.expectation(description: "FRAClient.createMechanismFromUri")
+        authenticatorManager.createMechanismFromUri(uri: push2, onSuccess: { (mechanism) in
+           ex2.fulfill()
+        }, onError: { (error) in
+           XCTFail("authenticatorManager.createMechanismFromUri failed with unexpected reason: \(error.localizedDescription)")
+           ex2.fulfill()
+        })
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertEqual(authenticatorManager.getAllAccounts().count, 2)
+        XCTAssertNotNil(authenticatorManager.getAccount(identifier: "ForgeRockSandbox-pushtestuser"))
+        XCTAssertEqual(authenticatorManager.getAccount(identifier: "ForgeRockSandbox-pushtestuser")?.mechanisms.count, 1)
+        XCTAssertNotNil(authenticatorManager.getAccount(identifier: "ForgeRock-pushtestuser2"))
+        XCTAssertEqual(authenticatorManager.getAccount(identifier: "ForgeRock-pushtestuser2")?.mechanisms.count, 1)
+        
+        XCTAssertEqual(storageClient.defaultStorageClient.accountStorage.allItems()?.count, 2)
+        XCTAssertEqual(storageClient.defaultStorageClient.mechanismStorage.allItems()?.count, 2)
+        XCTAssertEqual(storageClient.defaultStorageClient.notificationStorage.allItems()?.count, 0)
+
+
+        //  Make sure to mimic MechanismUUID
+        guard let account = authenticatorManager.getAccount(identifier: "ForgeRockSandbox-pushtestuser"),
+           let mechanism = account.mechanisms.first as? PushMechanism else {
+           XCTFail("Failed to retrieve PushMechanism")
+           return
+        }
+        //  Update Mechanism with UUID
+        mechanism.mechanismUUID = "759ACE9D-C64B-43E6-981D-97F7B54C3B01"
+        XCTAssertTrue(FRAClient.storage.setMechanism(mechanism: mechanism))
+
+        guard let account2 = authenticatorManager.getAccount(identifier: "ForgeRock-pushtestuser2"),
+           let mechanism2 = account2.mechanisms.first as? PushMechanism else {
+           XCTFail("Failed to retrieve PushMechanism")
+           return
+        }
+        //  Update Mechanism with UUID
+        mechanism2.mechanismUUID = "862BCE9A-A74A-33D2-181D-77F6B54C3A10"
+        XCTAssertTrue(FRAClient.storage.setMechanism(mechanism: mechanism2))
+        
+        //  Fake first remote-message receive action
+        var payload: [String: Any] = [:]
+        var aps: [String: Any] = [:]
+        aps["messageId"] = "AUTHENTICATE:64e909a2-84db-4ee8-b244-f0dbbeb8b0ff1589151035455"
+        aps["content-available"] = true
+        aps["alert"] = "Login attempt from user at ForgeRockSandbox"
+        aps["data"] = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJjIjoicGtJZm1rZDFSbDNJWnFhSmNZSUhLUzJic2wvZnhiWGNPYTEvNE83Z2pMTT0iLCJ0IjoiMTIwIiwidSI6Ijc1OUFDRTlELUM2NEItNDNFNi05ODFELTk3RjdCNTRDM0IwMSIsImwiOiJZVzFzWW1OdmIydHBaVDB3TVE9PSJ9.o_F0jvSiQlcpInyexi5ED4pjKNHxoHknPIsowYbpyYQ"
+        aps["sound"] = "default"
+
+        payload["aps"] = aps
+
+        guard let _ = FRAPushHandler.shared.application(UIApplication.shared, didReceiveRemoteNotification: payload) else {
+          XCTFail("Failed to parse notification payload and construct PushNotification object")
+          return
+        }
+
+        var pushAccount = authenticatorManager.getAccount(identifier: "ForgeRockSandbox-pushtestuser")
+        var pushMechanism = pushAccount?.mechanisms.first as? PushMechanism
+
+        XCTAssertEqual(pushMechanism?.notifications.count, 1)
+        XCTAssertEqual(storageClient.defaultStorageClient.accountStorage.allItems()?.count, 2)
+        XCTAssertEqual(storageClient.defaultStorageClient.mechanismStorage.allItems()?.count, 2)
+        XCTAssertEqual(storageClient.defaultStorageClient.notificationStorage.allItems()?.count, 1)
+
+        //  Fake second remote-message receive action
+        payload = [:]
+        aps = [:]
+        aps["messageId"] = "AUTHENTICATE:0666696b-859d-4565-b069-f13c800c5e3c1589151071515"
+        aps["content-available"] = true
+        aps["alert"] = "Login attempt from user at ForgeRockSandbox"
+        aps["data"] = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJjIjoiK2ZreklzbG1PN01GcHYzZEppQVY4Sm5yRzFra0hUdDA2NkRaaEcxamJwbz0iLCJ0IjoiMTIwIiwidSI6Ijc1OUFDRTlELUM2NEItNDNFNi05ODFELTk3RjdCNTRDM0IwMSIsImwiOiJZVzFzWW1OdmIydHBaVDB3TVE9PSJ9.1zuEgWy1gN7QAaJscGKgAqGxt_58Ad5HAZjOe8PLMBo"
+        aps["sound"] = "default"
+
+        payload["aps"] = aps
+
+        guard let _ = FRAPushHandler.shared.application(UIApplication.shared, didReceiveRemoteNotification: payload) else {
+          XCTFail("Failed to parse notification payload and construct PushNotification object")
+          return
+        }
+
+
+        pushAccount = authenticatorManager.getAccount(identifier: "ForgeRockSandbox-pushtestuser")
+        pushMechanism = pushAccount?.mechanisms.first as? PushMechanism
+
+        XCTAssertEqual(pushMechanism?.notifications.count, 2)
+
+        XCTAssertEqual(storageClient.defaultStorageClient.accountStorage.allItems()?.count, 2)
+        XCTAssertEqual(storageClient.defaultStorageClient.mechanismStorage.allItems()?.count, 2)
+        XCTAssertEqual(storageClient.defaultStorageClient.notificationStorage.allItems()?.count, 2)
+
+
+        //  Fake third remote-message receive action
+        payload = [:]
+        aps = [:]
+        aps["messageId"] = "AUTHENTICATE:929d72b7-c3e6-4460-a7b6-8e1c950b43361589151096771"
+        aps["content-available"] = true
+        aps["alert"] = "Login attempt from user at ForgeRockSandbox"
+        aps["data"] = "eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJjIjoiTVkzR01Fbkl6M3EweHFkR0wrMUdBaWNKdGxFVkhGenRsaVpTS1ZqdEZpaz0iLCJ0IjoiMTIwIiwidSI6Ijg2MkJDRTlBLUE3NEEtMzNEMi0xODFELTc3RjZCNTRDM0ExMCIsImwiOiJZVzFzWW1OdmIydHBaVDB3TVE9PSJ9.bcQqQ3zl0U9pvQEryEDtcJhrVbYxbVTLPvm9kcfyF5Y"
+        aps["sound"] = "default"
+
+        payload["aps"] = aps
+
+        guard let _ = FRAPushHandler.shared.application(UIApplication.shared, didReceiveRemoteNotification: payload) else {
+            XCTFail("Failed to parse notification payload and construct PushNotification object")
+            return
+        }
+        
+        pushAccount = authenticatorManager.getAccount(identifier: "ForgeRock-pushtestuser2")
+        pushMechanism = pushAccount?.mechanisms.first as? PushMechanism
+
+        XCTAssertEqual(pushMechanism?.notifications.count, 1)
+        
+        FRAClient.start()
+        guard let notifications = FRAClient.shared?.getAllNotifications() else {
+            XCTFail("Failed to retrieve PushNotification array")
+            return
+        }
+        XCTAssertEqual(notifications.count, 3)
+        XCTAssertEqual(notifications[0].messageId, "AUTHENTICATE:64e909a2-84db-4ee8-b244-f0dbbeb8b0ff1589151035455")
+        XCTAssertEqual(notifications[1].messageId, "AUTHENTICATE:0666696b-859d-4565-b069-f13c800c5e3c1589151071515")
+        XCTAssertEqual(notifications[2].messageId, "AUTHENTICATE:929d72b7-c3e6-4460-a7b6-8e1c950b43361589151096771")
+    }
+    
+    
+    func test_09_get_account_from_mechanism() {
         let hotp = URL(string: "otpauth://hotp/Forgerock:demo?secret=IJQWIZ3FOIQUEYLE&issuer=Forgerock&counter=4&algorithm=SHA256")!
         
         do {
@@ -838,7 +989,7 @@ class FRAClientTests: FRABaseTests {
     }
     
     
-    func test_07_get_push_mechanism_from_notification() {
+    func test_10_get_push_mechanism_from_notification() {
         do {
             self.loadMockResponses(["AM_Push_Registration_Successful", "AM_Push_Authentication_Successful"])
             // Set DeviceToken before PushMechnaism registration

--- a/FRAuthenticator/FRAuthenticatorTests/TestUtils/DummyStorageClient.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/TestUtils/DummyStorageClient.swift
@@ -2,7 +2,7 @@
 //  DummyStorageClient.swift
 //  FRAuthenticatorTests
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -26,6 +26,7 @@ class DummyStorageClient: StorageClient {
     var setNotificationResult: Bool?
     var removeNotificationResult: Bool?
     var getAllNotificationsForMechanismResult: [PushNotification]?
+    var getAllNotificationsResult: [PushNotification]?
     var isEmptyResult: Bool?
     var defaultStorageClient: KeychainServiceClient
     
@@ -121,6 +122,14 @@ class DummyStorageClient: StorageClient {
             return mockResult
         }
         return self.defaultStorageClient.getAllNotificationsForMechanism(mechanism: mechanism)
+    }
+    
+    
+    func getAllNotifications() -> [PushNotification] {
+        if let mockResult = self.getAllNotificationsResult {
+            return mockResult
+        }
+        return self.defaultStorageClient.getAllNotifications()
     }
     
     


### PR DESCRIPTION
On this change a new getAllNotifications() method is exposed on the FRAClient class. This will allow developers to retrieve a single list of notifications across all mechanisms.