### PR TITLE
SDKS-910-Remove_deprecated_methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,14 @@
 - `PlatformCollector`'s attribute names were changed from `timezone` and `jailbreakScore` to `timeZone` and `jailBreakScore` respectively to align with AM and Android SDK. [SDKS-908]
 - `Browser.validateBrowserLogin()` is now available in Objective-c as well. [SDKS-975]
 - Jailbreak detection logic was updated to prevent Jailbreak detection bypass. [SDKS-840]
-- Removed previously deprecated methods. [SDKS-910]
+
 
 #### Deprecated
--
+- Removed public var value from SingleValueCallback [SDKS-910]
+- Removed FRURLProtocolResponseEvaluationCallback [SDKS-910]
+- Removed FRURLProtocol.validatedURLs [SDKS-910]
+- Removed deprecated FRAuth.shared.next() (public func next<T>) method [SDKS-910]
+
 
 ## [2.2.0]
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - `PlatformCollector`'s attribute names were changed from `timezone` and `jailbreakScore` to `timeZone` and `jailBreakScore` respectively to align with AM and Android SDK. [SDKS-908]
 - `Browser.validateBrowserLogin()` is now available in Objective-c as well. [SDKS-975]
 - Jailbreak detection logic was updated to prevent Jailbreak detection bypass. [SDKS-840]
+- Removed previously deprecated methods. [SDKS-910]
 
 #### Deprecated
 -

--- a/FRAuth/FRAuth/Callbacks/SingleValueCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/SingleValueCallback.swift
@@ -22,19 +22,11 @@ open class SingleValueCallback: Callback {
     @objc public var inputName: String?
     /// String value of prompt attribute in Callback response; prompt is usually human readable text that can be displayed in UI
     @objc public var prompt: String?
-    /// A value provided from user interaction for this particular callback; the value can be any type
-    @available(*, deprecated, message: "Callback.value propert is deprecated; use Callback.setValue() and Callback.getValue() method to set the input value of the Callback.") // Deprecated as of FRAuth: v2.1.0
-    @objc public var value: Any? {
-        get {
-            return _value
-        }
-        set {
-            _value = newValue
-        }
-    }
-    var _value: Any?
     /// Unique identifier for this particular callback in Node
     public var _id: Int?
+    
+    /// A value provided from user interaction for this particular callback; the value can be any type
+    var _value: Any?
     
     
     //  MARK: - Init

--- a/FRAuth/FRAuth/Config/ServerConfig.swift
+++ b/FRAuth/FRAuth/Config/ServerConfig.swift
@@ -41,34 +41,7 @@ public class ServerConfig: NSObject, Codable {
     /// Name of AM's SSO Token cookie;
     @objc var cookieName: String
     
-    
     //  MARK: - Init
-    
-    /// Constructs ServerConfig instance with URL, realm in OpenAM, and timeout for all requests
-    ///
-    /// - Parameters:
-    ///   - url: Base URL of OpenAM
-    ///   - realm: Designated 'realm' to be communicated in OpenAM
-    ///   - timeout: Timeout in seconds for all requests
-    ///   - enableCookie: Boolean value to enable cookie management in SDK's communication to AM. **Note** If SDK has not been initialized using (FRAuth.start(), this value will be ignored and not persist cookies.
-    ///   - cookieName: `Cookie Name` in AM configuration; defaulted to `iPlanetDirectoryPro`
-    @available(*, deprecated, message: "ServerConfig() has been deprecated; use ServerConfigBuilder instead to construct ServerConfig object.") // Deprecated as of FRAuth: v1.0.3
-    @objc
-    public init (url: URL, realm: String = "root", timeout: Double = 60.0, enableCookie: Bool = true, cookieName: String? = nil) {
-        self.baseURL = url
-        self.realm = realm
-        self.timeout = timeout
-        self.enableCookie = enableCookie
-        self.cookieName = cookieName ?? OpenAM.iPlanetDirectoryPro
-        self.authenticateURL = self.baseURL.absoluteString + "/json/realms/\(self.realm)/authenticate"
-        self.tokenURL = self.baseURL.absoluteString + "/oauth2/realms/\(self.realm)/access_token"
-        self.authorizeURL = self.baseURL.absoluteString + "/oauth2/realms/\(self.realm)/authorize"
-        self.userInfoURL = self.baseURL.absoluteString + "/oauth2/realms/\(self.realm)/userinfo"
-        self.tokenRevokeURL = self.baseURL.absoluteString + "/oauth2/realms/\(self.realm)/token/revoke"
-        self.sessionURL = self.baseURL.absoluteString + "/json/realms/\(self.realm)/sessions"
-        self.endSessionURL = self.baseURL.absoluteString + "/oauth2/realms/\(self.realm)/connect/endSession"
-    }
-    
     
     /// Constructs ServerConfig instance with URL, realm in AM, and timeout for all requests
     ///

--- a/FRAuth/FRAuth/Constants/Typealias.swift
+++ b/FRAuth/FRAuth/Constants/Typealias.swift
@@ -83,6 +83,3 @@ public typealias DeviceCollectorCallback = (_ result: [String: Any]) -> Void
 /// Callback definition for completion result
 public typealias FRCompletionResultCallback = (_ result: Bool) -> Void
 
-/// Callback definition for FRURLProtocol's refresh token policy; the callback is invoked to validate whether token refresh is required or not with given request result
-@available(*, deprecated, message: "FRURLProtocol.refreshTokenPolicy is deprecated; use TokenManagementPolicy(validatingURL:delegate:) to do TokenManagement.") // Deprecated as of FRAuth: v2.0.0
-public typealias FRURLProtocolResponseEvaluationCallback = (_ responseData: Data?, _ response: URLResponse?, _ error: Error?) -> Bool

--- a/FRAuth/FRAuth/FRAuth.swift
+++ b/FRAuth/FRAuth/FRAuth.swift
@@ -248,32 +248,4 @@ public final class FRAuth: NSObject {
             completion(value, node, error)
         }
     }
-    
-    
-    // - MARK: Deprecated
-    
-    /// Initiates Authentication or Registration flow with given flowType and expected result type
-    ///
-    /// - Parameters:
-    ///   - flowType: FlowType whether authentication, or registration
-    ///   - completion: NodeCompletion callback which returns the result of Node submission.
-    @available(*, deprecated, message: "FRAuth.shared.next() has been deprecated; use FRUser.login for authentication or FRSession.authenticat() instead to invoke Authentication Tree.") // Deprecated as of FRAuth: v1.0.2
-    public func next<T>(flowType: FRAuthFlowType, completion: @escaping NodeCompletion<T>) {
-        FRLog.v("Called")
-        
-        var serviceName = ""
-        switch flowType {
-        case .authentication:
-            serviceName = self.authServiceName
-            break
-        case .registration:
-            serviceName = self.registerServiceName
-            break
-        }
-        
-        let authService: AuthService = AuthService(authIndexValue: serviceName, serverConfig: self.serverConfig, oAuth2Config: self.oAuth2Client, keychainManager: self.keychainManager, tokenManager: self.tokenManager)
-        authService.next { (value: T?, node, error) in
-            completion(value, node, error)
-        }
-    }
 }

--- a/FRAuth/FRAuth/Network/FRURLProtocol.swift
+++ b/FRAuth/FRAuth/Network/FRURLProtocol.swift
@@ -22,10 +22,7 @@ import Foundation
     /// An array of URL to be validated and analyzed
     @available(*, deprecated, message: "FRURLProtocol.validatedURLs is deprecated; use TokenManagementPolicy(validatingURL:delegate:) to do TokenManagement.") // Deprecated as of FRAuth: v2.0.0
     @objc public static var validatedURLs: [URL] = []
-//    /// FRURLProtocolResponseEvaluationCallback callback to be analyzed and determined for token refresh
-//    @available(*, deprecated, message: "FRURLProtocol.refreshTokenPolicy is deprecated; use TokenManagementPolicy(validatingURL:delegate:) to do TokenManagement.") // Deprecated as of FRAuth: v2.0.0
-//    @objc public static var refreshTokenPolicy: FRURLProtocolResponseEvaluationCallback?
-//
+
     
     //  MARK: - Private Property
     

--- a/FRAuth/FRAuth/Network/FRURLProtocol.swift
+++ b/FRAuth/FRAuth/Network/FRURLProtocol.swift
@@ -22,10 +22,10 @@ import Foundation
     /// An array of URL to be validated and analyzed
     @available(*, deprecated, message: "FRURLProtocol.validatedURLs is deprecated; use TokenManagementPolicy(validatingURL:delegate:) to do TokenManagement.") // Deprecated as of FRAuth: v2.0.0
     @objc public static var validatedURLs: [URL] = []
-    /// FRURLProtocolResponseEvaluationCallback callback to be analyzed and determined for token refresh
-    @available(*, deprecated, message: "FRURLProtocol.refreshTokenPolicy is deprecated; use TokenManagementPolicy(validatingURL:delegate:) to do TokenManagement.") // Deprecated as of FRAuth: v2.0.0
-    @objc public static var refreshTokenPolicy: FRURLProtocolResponseEvaluationCallback?
-    
+//    /// FRURLProtocolResponseEvaluationCallback callback to be analyzed and determined for token refresh
+//    @available(*, deprecated, message: "FRURLProtocol.refreshTokenPolicy is deprecated; use TokenManagementPolicy(validatingURL:delegate:) to do TokenManagement.") // Deprecated as of FRAuth: v2.0.0
+//    @objc public static var refreshTokenPolicy: FRURLProtocolResponseEvaluationCallback?
+//
     
     //  MARK: - Private Property
     
@@ -85,15 +85,6 @@ import Foundation
         //  AuthorizationPolicy evaluation
         else if let authPolicy = FRURLProtocol.authorizationPolicy, authPolicy.validateURL(request: request) {
             return true
-        }
-        //  For backward compatibility; if validatedURLs, and refreshTokenPolicy is defined, convert them into TokenManagementPolicy
-        //  MARK: - Deprecated as of 2.0.0 - to be removed
-        else if FRURLProtocol.validatedURLs.count > 0 {
-            let tokenManagementPolicy = TokenManagementPolicy(validatingURL: FRURLProtocol.validatedURLs, evaluationCallback: FRURLProtocol.refreshTokenPolicy)
-            FRURLProtocol.tokenManagementPolicy = tokenManagementPolicy
-            if tokenManagementPolicy.validateURL(request: request) {
-                return true
-            }
         }
         
         return false

--- a/FRAuth/FRAuth/Network/FRURLProtocol.swift
+++ b/FRAuth/FRAuth/Network/FRURLProtocol.swift
@@ -19,10 +19,6 @@ import Foundation
     @objc public static var tokenManagementPolicy: TokenManagementPolicy?
     /// AuthorizationPolicy for URLProtocol
     @objc public static var authorizationPolicy: AuthorizationPolicy?
-    /// An array of URL to be validated and analyzed
-    @available(*, deprecated, message: "FRURLProtocol.validatedURLs is deprecated; use TokenManagementPolicy(validatingURL:delegate:) to do TokenManagement.") // Deprecated as of FRAuth: v2.0.0
-    @objc public static var validatedURLs: [URL] = []
-
     
     //  MARK: - Private Property
     

--- a/FRAuth/FRAuth/Policy/TokenManagementPolicy.swift
+++ b/FRAuth/FRAuth/Policy/TokenManagementPolicy.swift
@@ -54,25 +54,11 @@ import FRCore
     public var validatingURL: [URL]
     //  Delegation of TokenManagementPolicy evaluation
     public var delegate: TokenManagementPolicyDelegate?
-    //  MARK: - To be deprecated; for backward comaptibility
-    //  Backward compatibility callback for token refresh policy
-    var evaluationCallback: FRURLProtocolResponseEvaluationCallback?
-    
     
     //  MARK: - Init
     
     /// Prevents default init
     private override init() { fatalError("TokenManagementPolicy() is prohibited. Use TokenManagementPolicy(validatingURL:delegate:)") }
-    
-    
-    /// Initializes TokenManagementPolicy with delegate
-    /// - Parameters:
-    ///   - validatingURL: URLs to be validated for TokenManagementPolicy
-    ///   - evaluationCallback: refresh token evaluation callback for backward compatibility
-    init(validatingURL: [URL], evaluationCallback: FRURLProtocolResponseEvaluationCallback? = nil) {
-        self.validatingURL = validatingURL
-        self.evaluationCallback = evaluationCallback
-    }
     
     
     /// Initializes TokenManagementPolicy with delegation
@@ -112,12 +98,6 @@ import FRCore
         FRLog.v("[TokenManagementPolicy] Evaluating Token Refresh Policy started")
         if let delegate = self.delegate, let evaluation = delegate.evaluateTokenRefresh?(responseData: responseData, response: response, error: error) {
             FRLog.i("[TokenManagementPolicy] TokenManagementPolicy.evaluateTokenRefresh found, and refresh policy result received from delegate: \(evaluation)")
-            return evaluation
-        }
-        //  MARK: - To be deprecated
-        else if let callback = self.evaluationCallback {
-            let evaluation = callback(responseData, response, error)
-            FRLog.i("[TokenManagementPolicy] TokenManagementPolicy.evaluationCallback found, and refresh policy result received from callback: \(evaluation)")
             return evaluation
         }
         FRLog.w("[TokenManagementPolicy] No delegation, nor evaluationCallback found; returning false for token refresh evaluation")

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Policy/TokenManagementPolicyTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Policy/TokenManagementPolicyTests.swift
@@ -34,16 +34,6 @@ class TokenManagementPolicyTests: FRAuthBaseTest {
         policy = TokenManagementPolicy(validatingURL: urls, delegate: self)
         XCTAssertNotNil(policy)
         policy = nil
-        
-        policy = TokenManagementPolicy(validatingURL: urls, evaluationCallback: nil)
-        XCTAssertNotNil(policy)
-        policy = nil
-        
-        let evaluationCallback: FRURLProtocolResponseEvaluationCallback = { (responseData, response, error) in
-            return false
-        }
-        policy = TokenManagementPolicy(validatingURL: urls, evaluationCallback: evaluationCallback)
-        XCTAssertNotNil(policy)
     }
     
     
@@ -89,20 +79,7 @@ class TokenManagementPolicyTests: FRAuthBaseTest {
         XCTAssertEqual(self.list.last, "TokenManagementPolicyTests.evaluateTokenRefresh")
     }
     
-    
-    func test_04_evaluation_callback() {
-        
-        let evaluationCallback: FRURLProtocolResponseEvaluationCallback = { (responseData, response, error) in
-            return true
-        }
-        let urls: [URL] = [URL(string: "http://openam.example.com/anything")!]
-        let policy = TokenManagementPolicy(validatingURL: urls, evaluationCallback: evaluationCallback)
-        let result = policy.evalulateRefreshToken(responseData: nil, response: nil, error: nil)
-        XCTAssertTrue(result)
-        XCTAssertEqual(self.list.count, 0)
-    }
-    
-    
+    //test_04 removed due to removed deprecated calls
     func test_05_no_callback_and_delegate() {
         let urls: [URL] = [URL(string: "http://openam.example.com/anything")!]
         let policy = TokenManagementPolicy(validatingURL: urls, delegate: nil)

--- a/FRProximity/FRProximityTests/E2ETests/DeviceCollectorNodeTests.swift
+++ b/FRProximity/FRProximityTests/E2ETests/DeviceCollectorNodeTests.swift
@@ -810,7 +810,7 @@ class DeviceCollectorNodeTests: FRAuthBaseTest {
                 XCTAssertEqual(lat, 49.2827)
                 XCTAssertEqual(long, 123.1207)
                 
-                XCTAssertNotNil(deviceProfileCallback.value)
+                XCTAssertNotNil(deviceProfileCallback.getValue())
                 let requestPayload = self.parseStringToDictionary(deviceProfileCallback.getValue() as! String)
                 XCTAssertEqual(response.keys, requestPayload.keys)
                 ex.fulfill()


### PR DESCRIPTION
- Removed ServerConfig deprecated public initializer
- Deleting deprecated FRAuth.shared.next() (public func next<T>) method from FRAuth.swift
- Removed FRURLProtocol.validatedURLs from FRURLProtocol.swift
- Removed deprecated FRURLProtocolResponseEvaluationCallback and dependencies from Typealias.swift, FRURLProtocol.swift, TokenManagementPolicy.swift
- Removed public var value from SingleValueCallback. The var has been replaced by getValue and setValue methods