### PR TITLE
SDKS 1186 Authenticator SDK notification enhancements

### DIFF
--- a/FRAuthenticator/FRAuthenticator.xcodeproj/project.pbxproj
+++ b/FRAuthenticator/FRAuthenticator.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1B4236BB26CDA3A3009AF58F /* FRDateUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4236BA26CDA3A3009AF58F /* FRDateUtil.swift */; };
 		D5230BE02457868B004AB6E9 /* FRAConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5230BDF2457868B004AB6E9 /* FRAConstants.swift */; };
 		D525BE01256765190012CE33 /* FRCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D525BDFC2567650B0012CE33 /* FRCore.framework */; };
 		D525BE02256765190012CE33 /* FRCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D525BDFC2567650B0012CE33 /* FRCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -178,6 +179,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1B4236BA26CDA3A3009AF58F /* FRDateUtil.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRDateUtil.swift; sourceTree = "<group>"; };
 		D5230BDF2457868B004AB6E9 /* FRAConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRAConstants.swift; sourceTree = "<group>"; };
 		D525BDF62567650B0012CE33 /* FRCore.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FRCore.xcodeproj; path = ../FRCore/FRCore.xcodeproj; sourceTree = "<group>"; };
 		D52D5C372412ECA800835035 /* MechanismError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MechanismError.swift; sourceTree = "<group>"; };
@@ -824,6 +826,7 @@
 				D5FFA057245FB319003680C1 /* CodableValue.swift */,
 				D5FFA058245FB319003680C1 /* FRJSONEncoder.swift */,
 				D5A9EC30246387F6002009E2 /* URLUtil.swift */,
+				1B4236BA26CDA3A3009AF58F /* FRDateUtil.swift */,
 			);
 			path = Util;
 			sourceTree = "<group>";
@@ -1020,6 +1023,7 @@
 				D52D5C5C241324AE00835035 /* FRAClient.swift in Sources */,
 				D5FFA05B245FB319003680C1 /* FRJSONEncoder.swift in Sources */,
 				D5FC33F92458CC1F00C77A52 /* FRAPushHandler.swift in Sources */,
+				1B4236BB26CDA3A3009AF58F /* FRDateUtil.swift in Sources */,
 				D52D5C642413305400835035 /* NotificationError.swift in Sources */,
 				D5C354A32412EC0600695A84 /* Mechanism.swift in Sources */,
 				D52D5C5A24131B3700835035 /* TOTPMechanism.swift in Sources */,

--- a/FRAuthenticator/FRAuthenticator/Constants/FRAConstants.swift
+++ b/FRAuthenticator/FRAuthenticator/Constants/FRAConstants.swift
@@ -33,4 +33,7 @@ struct FRAConstants {
     static let hotp = "hotp"
     static let totp = "totp"
     static let push = "push"
+    
+    static let oathAuth = "otpauth"
+    static let pushAuth = "pushauth"
 }

--- a/FRAuthenticator/FRAuthenticator/FRAClient.swift
+++ b/FRAuthenticator/FRAuthenticator/FRAClient.swift
@@ -98,6 +98,14 @@ public class FRAClient: NSObject {
     
     //  MARK: - Mechanism
     
+    /// Retrieves Mechanism object with given Mechanism UUID
+    /// - Parameter uuid: UUID of Mechanism
+    /// - Returns: Mechanism object that is associated with given UUID
+    func getMechanismForUUID(uuid: String) -> Mechanism? {
+        return self.authenticatorManager.getMechanismForUUID(uuid: uuid)
+    }
+    
+    
     /// Retrieves a PushMechanism object with given PushNotification object
     ///
     /// **Note:** This getMechanism with PushNotification object does not retrieve all PushNotification object associated with PushMechanism. This only returns PushMechanism object without the array.
@@ -132,6 +140,14 @@ public class FRAClient: NSObject {
     /// - Returns: An array of PushNotification
     public func getAllNotifications() -> [PushNotification] {
         return self.authenticatorManager.getAllNotifications()
+    }
+    
+    
+    /// Retrieves PushNotification object with given PushNotification Identifier; Identifier of PushNotification object is **"<mechanismUUID>-<timeAdded>"**
+    /// - Parameter identifier: String value of PushNotification object's identifier as in **"<mechanismUUID>-<timeAdded>"**
+    /// - Returns: PushNotification object with given identifier
+    public func getNotification(identifier: String) -> PushNotification? {
+        return self.authenticatorManager.getNotification(identifier: identifier)
     }
     
     

--- a/FRAuthenticator/FRAuthenticator/Manager/AuthenticatorManager.swift
+++ b/FRAuthenticator/FRAuthenticator/Manager/AuthenticatorManager.swift
@@ -281,6 +281,14 @@ struct AuthenticatorManager {
     //  MARK: - Mechanism
     
     
+    /// Retrieves Mechanism object with given Mechanism UUID
+    /// - Parameter uuid: UUID of Mechanism
+    /// - Returns: Mechanism object that is associated with given UUID
+    func getMechanismForUUID(uuid: String) -> Mechanism? {
+        return self.storageClient.getMechanismForUUID(uuid: uuid)
+    }
+    
+    
     /// Retrieves PushMechanism object with given PushNotification object
     /// - Parameter notification: PushNotification object to obtain associated PushMechanism
     /// - Returns: PushMechanism object that is associated with given PushNotification object
@@ -326,6 +334,14 @@ struct AuthenticatorManager {
     /// - Returns: An array of PushNotification object
     func getAllNotifications() -> [PushNotification] {
         return self.storageClient.getAllNotifications()
+    }
+    
+    
+    /// Retrieves PushNotification object with given PushNotification Identifier; Identifier of PushNotification object is "<mechanismUUID>-<timeAdded>"
+    /// - Parameter identifier: String value of PushNotification object's identifier as in "<mechanismUUID>-<timeAdded>"
+    /// - Returns: PushNotification object with given identifier
+    func getNotification(identifier: String) -> PushNotification? {
+        return self.storageClient.getNotification(notificationIdentifier: identifier)
     }
     
     

--- a/FRAuthenticator/FRAuthenticator/Model/Account/Account.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Account/Account.swift
@@ -137,8 +137,8 @@ public class Account: NSObject, NSSecureCoding, Codable {
         
         let issuer = try values.decode(String.self, forKey: .issuer)
         let accountName = try values.decode(String.self, forKey: .accountName)
-        let imageUrl = try values.decode(String.self, forKey: .imageUrl)
-        let backgroundColor = try values.decode(String.self, forKey: .backgroundColor)
+        let imageUrl = try values.decodeIfPresent(String.self, forKey: .imageUrl)
+        let backgroundColor = try values.decodeIfPresent(String.self, forKey: .backgroundColor)
         let milliseconds = try values.decode(Double.self, forKey: .timeAdded)
         let timeAdded = milliseconds / 1000
 

--- a/FRAuthenticator/FRAuthenticator/Model/Account/Account.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Account/Account.swift
@@ -148,7 +148,7 @@ public class Account: NSObject, NSSecureCoding, Codable {
     
     //  MARK: - Public
     
-    /// Serializes `Account` object into JSON String. Sensitive information are not exposed.
+    /// Serializes `Account` object into JSON String.
     /// - Returns: JSON String value of `Account` object
     public func toJson() -> String? {
         if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {

--- a/FRAuthenticator/FRAuthenticator/Model/Account/Account.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Account/Account.swift
@@ -109,15 +109,17 @@ public class Account: NSObject, NSSecureCoding, Codable {
     
     //  MARK: - Public
     
-    /// Serializes `Account` object into JSON String
+    /// Serializes `Account` object into JSON String. Sensitive information are not exposed.
     /// - Returns: JSON String value of `Account` object
     public func toJson() -> String? {
-        if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {
-            return serializedStr
-        }
-        else {
-            return nil
-        }
+        return """
+           {"id":"\(self.identifier)",
+           "issuer":"\(self.issuer)",
+           "accountName":"\(self.accountName)",
+           "imageURL":"\(self.imageUrl ?? "")",
+           "backgroundColor":"\(self.backgroundColor ?? "")",
+           "timeAdded":\(self.timeAdded.millisecondsSince1970)}
+           """
     }
 }
 

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/Mechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/Mechanism.swift
@@ -38,6 +38,21 @@ public class Mechanism: NSObject, NSSecureCoding, Codable {
         }
     }
     
+    
+    // MARK: - Coding Keys
+
+    /// CodingKeys customize the keys when this object is encoded and decoded
+    enum CodingKeys: String, CodingKey {
+        case mechanismUUID = "mechanismUID"
+        case issuer
+        case accountName
+        case secret
+        case timeAdded
+        case type
+        case version
+    }
+    
+    
     //  MARK: - Init
     
     /// Prevents init
@@ -114,8 +129,37 @@ public class Mechanism: NSObject, NSSecureCoding, Codable {
         let issuer = coder.decodeObject(of: NSString.self, forKey: "issuer") as String?
         let secret = coder.decodeObject(of: NSString.self, forKey: "secret") as String?
         let accountName = coder.decodeObject(of: NSString.self, forKey: "accountName") as String?
-        let timeAdded = coder.decodeDouble(forKey: "timeAdded")
+        let milliseconds = coder.decodeDouble(forKey: "timeAdded")
+        let timeAdded = milliseconds / 1000
         
         self.init(mechanismUUID: mechanismUUID, type: type, version: version, issuer: issuer, secret: secret, accountName: accountName, timeAdded: timeAdded)
     }
+    
+    
+    //  MARK: - Codable
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(mechanismUUID, forKey: .mechanismUUID)
+        try container.encode(issuer, forKey: .issuer)
+        try container.encode(accountName, forKey: .accountName)
+        try container.encode(secret, forKey: .secret)
+        try container.encode(type, forKey: .type)
+        try container.encode(version, forKey: .version)
+        try container.encode(self.timeAdded.millisecondsSince1970, forKey: .timeAdded)
+    }
+    
+    
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        mechanismUUID = try container.decode(String.self, forKey: .mechanismUUID)
+        secret = try container.decode(String.self, forKey: .secret)
+        issuer = try container.decode(String.self, forKey: .issuer)
+        accountName = try container.decode(String.self, forKey: .accountName)
+        type = try container.decode(String.self, forKey: .type)
+        version = try container.decode(Int.self, forKey: .version)
+        let milliseconds = try container.decode(Double.self, forKey: .timeAdded)
+        timeAdded = Date(timeIntervalSince1970: Double(milliseconds / 1000))
+    }
+    
 }

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/Mechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/Mechanism.swift
@@ -17,7 +17,7 @@ public class Mechanism: NSObject, NSSecureCoding, Codable {
     //  MARK: - Properties
     
     /// uniquely identifiable UUID for current mechanism
-    var mechanismUUID: String
+    public var mechanismUUID: String
     /// type of auth
     public var type: String
     /// version of auth

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/Mechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/Mechanism.swift
@@ -21,7 +21,7 @@ public class Mechanism: NSObject, NSSecureCoding, Codable {
     /// type of auth
     public var type: String
     /// version of auth
-    var version: Int
+    var version: Int = 1
     /// issuer of auth
     public var issuer: String
     /// shared secret of auth
@@ -43,13 +43,14 @@ public class Mechanism: NSObject, NSSecureCoding, Codable {
 
     /// CodingKeys customize the keys when this object is encoded and decoded
     enum CodingKeys: String, CodingKey {
+        case identifier = "id"
         case mechanismUUID = "mechanismUID"
         case issuer
         case accountName
         case secret
         case timeAdded
-        case type
-        case version
+        case oathAuth = "type"
+        case type = "oathType"
     }
     
     
@@ -70,7 +71,6 @@ public class Mechanism: NSObject, NSSecureCoding, Codable {
     init(type: String, issuer: String, accountName: String, secret: String) {
         
         self.mechanismUUID = UUID().uuidString
-        self.version = 1
         
         self.type = type
         self.issuer = issuer
@@ -140,12 +140,13 @@ public class Mechanism: NSObject, NSSecureCoding, Codable {
     
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.identifier, forKey: .identifier)
         try container.encode(mechanismUUID, forKey: .mechanismUUID)
         try container.encode(issuer, forKey: .issuer)
         try container.encode(accountName, forKey: .accountName)
         try container.encode(secret, forKey: .secret)
         try container.encode(type, forKey: .type)
-        try container.encode(version, forKey: .version)
+        try container.encode(FRAConstants.oathAuth, forKey: .oathAuth)
         try container.encode(self.timeAdded.millisecondsSince1970, forKey: .timeAdded)
     }
     
@@ -157,7 +158,7 @@ public class Mechanism: NSObject, NSSecureCoding, Codable {
         issuer = try container.decode(String.self, forKey: .issuer)
         accountName = try container.decode(String.self, forKey: .accountName)
         type = try container.decode(String.self, forKey: .type)
-        version = try container.decode(Int.self, forKey: .version)
+        
         let milliseconds = try container.decode(Double.self, forKey: .timeAdded)
         timeAdded = Date(timeIntervalSince1970: Double(milliseconds / 1000))
     }

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/Mechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/Mechanism.swift
@@ -49,8 +49,8 @@ public class Mechanism: NSObject, NSSecureCoding, Codable {
         case accountName
         case secret
         case timeAdded
-        case oathAuth = "type"
-        case type = "oathType"
+        case oathType
+        case type
     }
     
     
@@ -129,8 +129,7 @@ public class Mechanism: NSObject, NSSecureCoding, Codable {
         let issuer = coder.decodeObject(of: NSString.self, forKey: "issuer") as String?
         let secret = coder.decodeObject(of: NSString.self, forKey: "secret") as String?
         let accountName = coder.decodeObject(of: NSString.self, forKey: "accountName") as String?
-        let milliseconds = coder.decodeDouble(forKey: "timeAdded")
-        let timeAdded = milliseconds / 1000
+        let timeAdded = coder.decodeDouble(forKey: "timeAdded")
         
         self.init(mechanismUUID: mechanismUUID, type: type, version: version, issuer: issuer, secret: secret, accountName: accountName, timeAdded: timeAdded)
     }
@@ -146,7 +145,12 @@ public class Mechanism: NSObject, NSSecureCoding, Codable {
         try container.encode(accountName, forKey: .accountName)
         try container.encode(secret, forKey: .secret)
         try container.encode(type, forKey: .type)
-        try container.encode(FRAConstants.oathAuth, forKey: .oathAuth)
+        if (type == FRAConstants.push) {
+            try container.encode(FRAConstants.pushAuth, forKey: .type)
+        } else {
+            try container.encode(type, forKey: .oathType)
+            try container.encode(FRAConstants.oathAuth, forKey: .type)
+        }
         try container.encode(self.timeAdded.millisecondsSince1970, forKey: .timeAdded)
     }
     
@@ -157,7 +161,13 @@ public class Mechanism: NSObject, NSSecureCoding, Codable {
         secret = try container.decode(String.self, forKey: .secret)
         issuer = try container.decode(String.self, forKey: .issuer)
         accountName = try container.decode(String.self, forKey: .accountName)
-        type = try container.decode(String.self, forKey: .type)
+        
+        let type_value = try container.decode(String.self, forKey: .type)
+        if(type_value == FRAConstants.pushAuth) {
+            type = FRAConstants.push
+        } else {
+            type = try container.decode(String.self, forKey: .oathType)
+        }
         
         let milliseconds = try container.decode(Double.self, forKey: .timeAdded)
         timeAdded = Date(timeIntervalSince1970: Double(milliseconds / 1000))

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/HOTPMechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/HOTPMechanism.swift
@@ -123,12 +123,19 @@ public class HOTPMechanism: OathMechanism {
     /// Serializes `HOTPMechanism` object into JSON String
     /// - Returns: JSON String value of `HOTPMechanism` object
     public func toJson() -> String? {
-        if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {
-            return serializedStr
-        }
-        else {
-            return nil
-        }
+        return """
+           {"id":"\(self.identifier)",
+           "issuer":"\(self.issuer)",
+           "accountName":"\(self.accountName)",
+           "mechanismUID":"\(self.mechanismUUID)",
+           "secret":"REMOVED",
+           "type":"\(FRAConstants.oathAuth)",
+           "oathType":"\(self.type)",
+           "algorithm":"\(self.algorithm)",
+           "digits":\(self.digits),
+           "counter":\(self.counter),
+           "timeAdded":\(self.timeAdded.millisecondsSince1970)}
+           """
     }
 }
 

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/HOTPMechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/HOTPMechanism.swift
@@ -123,19 +123,12 @@ public class HOTPMechanism: OathMechanism {
     /// Serializes `HOTPMechanism` object into JSON String
     /// - Returns: JSON String value of `HOTPMechanism` object
     public func toJson() -> String? {
-        return """
-           {"id":"\(self.identifier)",
-           "issuer":"\(self.issuer)",
-           "accountName":"\(self.accountName)",
-           "mechanismUID":"\(self.mechanismUUID)",
-           "secret":"REMOVED",
-           "type":"\(FRAConstants.oathAuth)",
-           "oathType":"\(self.type)",
-           "algorithm":"\(self.algorithm)",
-           "digits":\(self.digits),
-           "counter":\(self.counter),
-           "timeAdded":\(self.timeAdded.millisecondsSince1970)}
-           """
+        if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {
+            return serializedStr
+        }
+        else {
+            return nil
+        }
     }
 }
 

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/OathMechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/OathMechanism.swift
@@ -21,6 +21,15 @@ public class OathMechanism: Mechanism {
     public var digits: Int
 
     
+    // MARK: - Coding Keys
+
+    /// CodingKeys customize the keys when this object is encoded and decoded
+    enum CodingKeys: String, CodingKey {
+        case algorithm
+        case digits
+    }
+    
+    
     //  MARK: - Init
     
     /// Initializes OathMechanism with given data
@@ -91,13 +100,6 @@ public class OathMechanism: Mechanism {
     
     //  MARK: - Codable
     
-    public required init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        algorithm = try container.decode(OathAlgorithm.self, forKey: .algorithm)
-        digits = try container.decode(Int.self, forKey: .digits)
-        try super.init(from: decoder)
-    }
-    
     
     public override func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
@@ -105,12 +107,14 @@ public class OathMechanism: Mechanism {
         try container.encode(digits, forKey: .digits)
         try super.encode(to: encoder)
     }
-}
-
-
-extension OathMechanism {
-    enum CodingKeys: String, CodingKey {
-        case algorithm = "algorithm"
-        case digits = "digits"
+    
+    
+    public required init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        algorithm = try container.decode(OathAlgorithm.self, forKey: .algorithm)
+        digits = try container.decode(Int.self, forKey: .digits)
+        try super.init(from: decoder)
     }
+    
 }
+

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/TOTPMechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/TOTPMechanism.swift
@@ -119,18 +119,24 @@ public class TOTPMechanism: OathMechanism {
     
     //  MARK: - Public
     
-    /// Serializes `TOTPMechanism` object into JSON String
+    /// Serializes `TOTPMechanism` object into JSON String. Sensitive information are not exposed.
     /// - Returns: JSON String value of `TOTPMechanism` object
     public func toJson() -> String? {
-        if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {
-            return serializedStr
-        }
-        else {
-            return nil
-        }
+        return """
+           {"id":"\(self.identifier)",
+           "issuer":"\(self.issuer)",
+           "accountName":"\(self.accountName)",
+           "mechanismUID":"\(self.mechanismUUID)",
+           "secret":"REMOVED",
+           "type":"\(FRAConstants.oathAuth)",
+           "oathType":"\(self.type)",
+           "algorithm":"\(self.algorithm)",
+           "digits":\(self.digits),
+           "period":\(self.period),
+           "timeAdded":\(self.timeAdded.millisecondsSince1970)}
+           """
     }
 }
-
 
 extension TOTPMechanism {
     enum CodingKeys: String, CodingKey {

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/TOTPMechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/TOTPMechanism.swift
@@ -119,7 +119,7 @@ public class TOTPMechanism: OathMechanism {
     
     //  MARK: - Public
     
-    /// Serializes `TOTPMechanism` object into JSON String. Sensitive information are not exposed.
+    /// Serializes `TOTPMechanism` object into JSON String.
     /// - Returns: JSON String value of `TOTPMechanism` object
     public func toJson() -> String? {
         if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/TOTPMechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/TOTPMechanism.swift
@@ -122,19 +122,12 @@ public class TOTPMechanism: OathMechanism {
     /// Serializes `TOTPMechanism` object into JSON String. Sensitive information are not exposed.
     /// - Returns: JSON String value of `TOTPMechanism` object
     public func toJson() -> String? {
-        return """
-           {"id":"\(self.identifier)",
-           "issuer":"\(self.issuer)",
-           "accountName":"\(self.accountName)",
-           "mechanismUID":"\(self.mechanismUUID)",
-           "secret":"REMOVED",
-           "type":"\(FRAConstants.oathAuth)",
-           "oathType":"\(self.type)",
-           "algorithm":"\(self.algorithm)",
-           "digits":\(self.digits),
-           "period":\(self.period),
-           "timeAdded":\(self.timeAdded.millisecondsSince1970)}
-           """
+        if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {
+            return serializedStr
+        }
+        else {
+            return nil
+        }
     }
 }
 

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/Push/PushMechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/Push/PushMechanism.swift
@@ -236,15 +236,20 @@ public class PushMechanism: Mechanism {
 
     //  MARK: - Public
     
-    /// Serializes `PushMechanism` object into JSON String
+    /// Serializes `PushMechanism` object into JSON String. Sensitive information are not exposed.
     /// - Returns: JSON String value of `PushMechanism` object
     public func toJson() -> String? {
-        if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {
-            return serializedStr
-        }
-        else {
-            return nil
-        }
+        return """
+           {"id":"\(self.identifier)",
+           "issuer":"\(self.issuer)",
+           "accountName":"\(self.accountName)",
+           "mechanismUID":"\(self.mechanismUUID)",
+           "secret":"REMOVED",
+           "type":"\(FRAConstants.pushAuth)",
+           "registrationEndpoint":"\(self.regEndpoint.absoluteString)",
+           "authenticationEndpoint":"\(self.authEndpoint.absoluteString)",
+           "timeAdded":\(self.timeAdded.millisecondsSince1970)}
+           """
     }
 }
 

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/Push/PushMechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/Push/PushMechanism.swift
@@ -45,6 +45,20 @@ public class PushMechanism: Mechanism {
     }
     
     
+    // MARK: - Coding Keys
+
+    /// CodingKeys customize the keys when this object is encoded and decoded
+    enum CodingKeys: String, CodingKey {
+        case authEndpoint = "authenticationEndpoint"
+        case regEndpoint = "registrationEndpoint"
+        case messageId
+        case challenge
+        case loadBalancer
+        case type
+        case version
+    }
+    
+    
     //  MARK: - Init    
     
     /// Initializes PushMechanism with given data
@@ -139,7 +153,19 @@ public class PushMechanism: Mechanism {
     
     
     //  MARK: - Codable
-    
+
+    public override func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(authEndpoint, forKey: .authEndpoint)
+        try container.encode(regEndpoint, forKey: .regEndpoint)
+        try container.encode(messageId, forKey: .messageId)
+        try container.encode(challenge, forKey: .challenge)
+        try container.encode(loadBalancer, forKey: .loadBalancer)
+        try container.encode(type, forKey: .type)
+        try container.encode(version, forKey: .version)
+        try super.encode(to: encoder)
+    }
+
     public required init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         authEndpoint = try container.decode(URL.self, forKey: .authEndpoint)
@@ -150,17 +176,6 @@ public class PushMechanism: Mechanism {
         try super.init(from: decoder)
     }
     
-    
-    public override func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        try container.encode(authEndpoint, forKey: .authEndpoint)
-        try container.encode(regEndpoint, forKey: .regEndpoint)
-        try container.encode(messageId, forKey: .messageId)
-        try container.encode(challenge, forKey: .challenge)
-        try container.encode(loadBalancer, forKey: .loadBalancer)
-        try super.encode(to: encoder)
-    }
-
     
     //  MARK: - Register
     
@@ -239,27 +254,12 @@ public class PushMechanism: Mechanism {
     /// Serializes `PushMechanism` object into JSON String. Sensitive information are not exposed.
     /// - Returns: JSON String value of `PushMechanism` object
     public func toJson() -> String? {
-        return """
-           {"id":"\(self.identifier)",
-           "issuer":"\(self.issuer)",
-           "accountName":"\(self.accountName)",
-           "mechanismUID":"\(self.mechanismUUID)",
-           "secret":"REMOVED",
-           "type":"\(FRAConstants.pushAuth)",
-           "registrationEndpoint":"REMOVED",
-           "authenticationEndpoint":"REMOVED",
-           "timeAdded":\(self.timeAdded.millisecondsSince1970)}
-           """
+        if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {
+            return serializedStr
+        }
+        else {
+            return nil
+        }
     }
 }
 
-
-extension PushMechanism {
-    enum CodingKeys: String, CodingKey {
-        case authEndpoint = "authEndpoint"
-        case regEndpoint = "regEndpoint"
-        case messageId = "messageId"
-        case challenge = "challenge"
-        case loadBalancer = "loadBalancer"
-    }
-}

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/Push/PushMechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/Push/PushMechanism.swift
@@ -54,8 +54,6 @@ public class PushMechanism: Mechanism {
         case messageId
         case challenge
         case loadBalancer
-        case type
-        case version
     }
     
     
@@ -161,8 +159,6 @@ public class PushMechanism: Mechanism {
         try container.encode(messageId, forKey: .messageId)
         try container.encode(challenge, forKey: .challenge)
         try container.encode(loadBalancer, forKey: .loadBalancer)
-        try container.encode(type, forKey: .type)
-        try container.encode(version, forKey: .version)
         try super.encode(to: encoder)
     }
 

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/Push/PushMechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/Push/PushMechanism.swift
@@ -246,8 +246,8 @@ public class PushMechanism: Mechanism {
            "mechanismUID":"\(self.mechanismUUID)",
            "secret":"REMOVED",
            "type":"\(FRAConstants.pushAuth)",
-           "registrationEndpoint":"\(self.regEndpoint.absoluteString)",
-           "authenticationEndpoint":"\(self.authEndpoint.absoluteString)",
+           "registrationEndpoint":"REMOVED",
+           "authenticationEndpoint":"REMOVED",
            "timeAdded":\(self.timeAdded.millisecondsSince1970)}
            """
     }

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/Push/PushMechanism.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/Push/PushMechanism.swift
@@ -247,7 +247,7 @@ public class PushMechanism: Mechanism {
 
     //  MARK: - Public
     
-    /// Serializes `PushMechanism` object into JSON String. Sensitive information are not exposed.
+    /// Serializes `PushMechanism` object into JSON String.
     /// - Returns: JSON String value of `PushMechanism` object
     public func toJson() -> String? {
         if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {

--- a/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
@@ -273,7 +273,7 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
            "mechanismUID":"\(self.mechanismUUID)",
            "messageId":"\(self.messageId)",
            "challenge":"REMOVED",
-           "loadBalanceKey":"REMOVED",
+           "amlbCookie":"REMOVED",
            "timeAdded":\(self.timeAdded.millisecondsSince1970),
            "timeExpired":\(self.timeAdded.millisecondsSince1970 + Int64(self.ttl * 1000)),
            "ttl":\(self.ttl),

--- a/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
@@ -276,7 +276,7 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
            "amlbCookie":"REMOVED",
            "timeAdded":\(self.timeAdded.millisecondsSince1970),
            "timeExpired":\(self.timeAdded.millisecondsSince1970 + Int64(self.ttl * 1000)),
-           "ttl":\(self.ttl),
+           "ttl":\(Int(self.ttl)),
            "approved":\(self.approved),
            "pending":\(self.pending)}
            """

--- a/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
@@ -316,7 +316,7 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
     
     //  MARK: - Public
     
-    /// Serializes `PushNotification` object into JSON String. Sensitive information are not exposed.
+    /// Serializes `PushNotification` object into JSON String.
     /// - Returns: JSON String value of `PushNotification` object
     public func toJson() -> String? {
         if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {

--- a/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
@@ -20,7 +20,7 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
     /// Message Identifier for Push
     var messageId: String
     /// MechanismUUID of PushMechanism that Notification belongs to
-    var mechanismUUID: String
+    public var mechanismUUID: String
     /// Load balance key for Push
     var loadBalanceKey: String?
     /// Time to live for push
@@ -40,7 +40,7 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
     /// Unique identifier for Notification object associated with PushMechanism
     public var identifier: String {
         get {
-            return self.mechanismUUID + "-" + "\(self.timeAdded.timeIntervalSince1970)"
+            return self.mechanismUUID + "-" + "\(self.timeAdded.millisecondsSince1970)"
         }
     }
     
@@ -265,14 +265,20 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
     
     //  MARK: - Public
     
-    /// Serializes `PushNotification` object into JSON String
+    /// Serializes `PushNotification` object into JSON String. Sensitive information are not exposed.
     /// - Returns: JSON String value of `PushNotification` object
     public func toJson() -> String? {
-        if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {
-            return serializedStr
-        }
-        else {
-            return nil
-        }
+        return """
+           {"id":"\(self.identifier)",
+           "mechanismUID":"\(self.mechanismUUID)",
+           "messageId":"\(self.messageId)",
+           "challenge":"REMOVED",
+           "loadBalanceKey":"REMOVED",
+           "timeAdded":\(self.timeAdded.millisecondsSince1970),
+           "timeExpired":\(self.timeAdded.millisecondsSince1970 + Int64(self.ttl * 1000)),
+           "ttl":\(self.ttl),
+           "approved":\(self.approved),
+           "pending":\(self.pending)}
+           """
     }
 }

--- a/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
@@ -73,6 +73,23 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
     }
     
     
+    // MARK: - Coding Keys
+    
+    /// CodingKeys customize the keys when this object is encoded and decoded
+    enum CodingKeys: String, CodingKey {
+        case identifier = "id"
+        case messageId
+        case mechanismUUID = "mechanismUID"
+        case loadBalanceKey = "amlbCookie"
+        case ttl
+        case timeAdded
+        case timeExpired
+        case challenge
+        case pending
+        case approved
+    }
+    
+    
     //  MARK: - Init
     
     /// Initializes Notification object with given Message Identifier, and Notification Payload from APNS
@@ -159,6 +176,40 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         let approved = coder.decodeBool(forKey: "approved") as Bool
         
         self.init(messageId: messageId, challenge: challenge, loadBalanceKey: loadBalanceKey, ttl: ttl, mechanismUUID: mechanismUUID, timeAdded: timeAdded, pending: pending, approved: approved)
+    }
+    
+    
+    //  MARK: - Codable
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.messageId, forKey: .messageId)
+        try container.encode(self.challenge, forKey: .challenge)
+        try container.encode(self.loadBalanceKey, forKey: .loadBalanceKey)
+        try container.encode(self.ttl, forKey: .ttl)
+        try container.encode(self.mechanismUUID, forKey: .mechanismUUID)
+        try container.encode(self.timeAdded.millisecondsSince1970, forKey: .timeAdded)
+        try container.encode(self.timeAdded.millisecondsSince1970 + Int64(self.ttl * 1000), forKey: .timeExpired)
+        try container.encode(self.pending, forKey: .pending)
+        try container.encode(self.approved, forKey: .approved)
+        try container.encode(self.identifier, forKey: .identifier)
+    }
+
+    
+    public required convenience init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let messageId = try values.decode(String.self, forKey: .messageId)
+        let challenge = try values.decode(String.self, forKey: .challenge)
+        let loadBalanceKey = try values.decode(String.self, forKey: .loadBalanceKey)
+        let mechanismUUID = try values.decode(String.self, forKey: .mechanismUUID)
+        let ttl = try values.decode(Double.self, forKey: .ttl)
+        let pending = try values.decode(Bool.self, forKey: .pending)
+        let approved = try values.decode(Bool.self, forKey: .approved)
+        let milliseconds = try values.decode(Double.self, forKey: .timeAdded)
+        let timeAdded = milliseconds / 1000
+
+        self.init(messageId: messageId, challenge: challenge, loadBalanceKey: loadBalanceKey, ttl: ttl, mechanismUUID: mechanismUUID, timeAdded: timeAdded, pending: pending, approved: approved)!
     }
     
     
@@ -268,17 +319,11 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
     /// Serializes `PushNotification` object into JSON String. Sensitive information are not exposed.
     /// - Returns: JSON String value of `PushNotification` object
     public func toJson() -> String? {
-        return """
-           {"id":"\(self.identifier)",
-           "mechanismUID":"\(self.mechanismUUID)",
-           "messageId":"\(self.messageId)",
-           "challenge":"REMOVED",
-           "amlbCookie":"REMOVED",
-           "timeAdded":\(self.timeAdded.millisecondsSince1970),
-           "timeExpired":\(self.timeAdded.millisecondsSince1970 + Int64(self.ttl * 1000)),
-           "ttl":\(Int(self.ttl)),
-           "approved":\(self.approved),
-           "pending":\(self.pending)}
-           """
+        if let objData = try? JSONEncoder().encode(self), let serializedStr = String(data: objData, encoding: .utf8) {
+            return serializedStr
+        }
+        else {
+            return nil
+        }
     }
 }

--- a/FRAuthenticator/FRAuthenticator/Storage/KeychainServiceClient.swift
+++ b/FRAuthenticator/FRAuthenticator/Storage/KeychainServiceClient.swift
@@ -13,7 +13,7 @@ import Foundation
 import FRCore
 
 struct KeychainServiceClient: StorageClient {
-    
+
     
     /// Keychain Service types for all storages in SDK
     enum KeychainStoreType: String {
@@ -143,6 +143,17 @@ struct KeychainServiceClient: StorageClient {
             }
         }
         return nil
+    }
+    
+    
+    func getNotification(notificationIdentifier: String) -> PushNotification? {
+        if let notificationData = self.notificationStorage.getData(notificationIdentifier),
+            let notification = NSKeyedUnarchiver.unarchiveObject(with: notificationData) as? PushNotification {
+            return notification
+        }
+        else {
+            return nil
+        }
     }
     
     

--- a/FRAuthenticator/FRAuthenticator/Storage/StorageClient.swift
+++ b/FRAuthenticator/FRAuthenticator/Storage/StorageClient.swift
@@ -45,6 +45,10 @@ public protocol StorageClient {
     /// - Parameter uuid: UUID of Mechanism
     func getMechanismForUUID(uuid: String) -> Mechanism?
     
+    /// Retrieves PushNotification object with its unique identifier
+    /// - Parameter notificationIdentifier: String value of PushNotification's unique identifier
+    func getNotification(notificationIdentifier: String) -> PushNotification?
+    
     /// Stores PushNotification object into Storage Client, and returns discardable Boolean result of operation
     /// - Parameter notification: PushNotification object to be stored
     @discardableResult func setNotification(notification: PushNotification) -> Bool

--- a/FRAuthenticator/FRAuthenticator/Util/FRDateUtil.swift
+++ b/FRAuthenticator/FRAuthenticator/Util/FRDateUtil.swift
@@ -1,0 +1,23 @@
+// 
+//  FRDateUtil.swift
+//  FRAuthenticator
+//
+//  Copyright (c) 2021 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+
+import Foundation
+
+extension Date {
+    var millisecondsSince1970:Int64 {
+        return Int64((self.timeIntervalSince1970 * 1000.0).rounded())
+    }
+
+    init(milliseconds:Int64) {
+        self = Date(timeIntervalSince1970: TimeInterval(milliseconds) / 1000)
+    }
+}
+

--- a/FRAuthenticator/FRAuthenticator/Util/FRJSONEncoder.swift
+++ b/FRAuthenticator/FRAuthenticator/Util/FRJSONEncoder.swift
@@ -2,7 +2,7 @@
 //  FRJSONEncoder.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -21,4 +21,34 @@ class FRJSONEncoder: JSONEncoder {
     public func encodeToString<T: Encodable>(value: T) throws -> String {
         return try Base64Utils.base64EncodeURLSafe(data: try super.encode(value))
     }
+    
+    
+    /// Convert Dictionary to JSON string
+    /// - Throws: exception if dictionary cannot be converted to JSON data or when data cannot be converted to UTF8 string
+    /// - Returns: JSON string
+    static func dictionaryToJsonString(dictionary: [String: Any]) -> String? {
+        if let theJSONData = try?  JSONSerialization.data(withJSONObject: dictionary),
+           let jsonString = String(data: theJSONData, encoding: String.Encoding.utf8) {
+            return jsonString
+          }
+
+        return nil
+    }
+    
+    
+    /// Convert  JSON string to Dictionary
+    /// - Throws: exception if JSON string cannot be converted to dictionary
+    /// - Returns: Dictionary
+    static func jsonStringToDictionary(jsonString: String) -> [String:AnyObject]? {
+        if let data = jsonString.data(using: .utf8) {
+           do {
+               let json = try JSONSerialization.jsonObject(with: data, options: .mutableContainers) as? [String:AnyObject]
+               return json
+           } catch {
+               return nil
+           }
+        }
+        return nil
+    }
+    
 }

--- a/FRAuthenticator/FRAuthenticatorTests/TestUtils/DummyStorageClient.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/TestUtils/DummyStorageClient.swift
@@ -13,6 +13,7 @@ import UIKit
 @testable import FRAuthenticator
 
 class DummyStorageClient: StorageClient {
+
     var setAccountResult: Bool?
     var removeAccountResult: Bool?
     var shouldMockGetAccountResult: Bool = false
@@ -23,6 +24,8 @@ class DummyStorageClient: StorageClient {
     var getMechanismsForAccountResult: [Mechanism]?
     var shouldMockGetMechanismsForUUIDResult: Bool = false
     var getMechanismForUUIDResult: Mechanism?
+    var shouldMockGetNotificationResult: Bool = false
+    var getNotificationResult: PushNotification?
     var setNotificationResult: Bool?
     var removeNotificationResult: Bool?
     var getAllNotificationsForMechanismResult: [PushNotification]?
@@ -98,6 +101,14 @@ class DummyStorageClient: StorageClient {
             return self.getMechanismForUUIDResult
         }
         return self.defaultStorageClient.getMechanismForUUID(uuid: uuid)
+    }
+    
+    
+    func getNotification(notificationIdentifier: String) -> PushNotification? {
+        if self.shouldMockGetNotificationResult {
+            return self.getNotificationResult
+        }
+        return self.defaultStorageClient.getNotification(notificationIdentifier: notificationIdentifier)
     }
     
     

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/AccountTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/AccountTests.swift
@@ -149,18 +149,16 @@ class AccountTests: FRABaseTests {
             return
         }
         
-        do {
-            let decodedAccount = try JSONDecoder().decode(Account.self, from: jsonString.data(using: .utf8) ?? Data())
+        //  Covert jsonString to Dictionary
+        let jsonDictionary = FRJSONEncoder.jsonStringToDictionary(jsonString: jsonString)
             
-            XCTAssertEqual(account.issuer, decodedAccount.issuer)
-            XCTAssertEqual(account.accountName, decodedAccount.accountName)
-            XCTAssertEqual(account.imageUrl, decodedAccount.imageUrl)
-            XCTAssertEqual(account.backgroundColor, decodedAccount.backgroundColor)
-            XCTAssertEqual(account.timeAdded, decodedAccount.timeAdded)
-            XCTAssertEqual(account.identifier, decodedAccount.identifier)
-        }
-        catch {
-            XCTFail(error.localizedDescription)
-        }
+        //  Then
+        XCTAssertEqual(account.issuer, jsonDictionary?["issuer"] as! String)
+        XCTAssertEqual(account.accountName, jsonDictionary?["accountName"] as! String)
+        XCTAssertEqual(account.imageUrl, (jsonDictionary?["imageURL"] as! String))
+        XCTAssertEqual(account.backgroundColor, (jsonDictionary?["backgroundColor"] as! String))
+        XCTAssertEqual(account.timeAdded.millisecondsSince1970, jsonDictionary?["timeAdded"] as! Int64)
+        XCTAssertEqual(account.identifier, jsonDictionary?["id"] as! String)
     }
+    
 }

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/AccountTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/AccountTests.swift
@@ -122,12 +122,12 @@ class AccountTests: FRABaseTests {
             
             // Decode
             let decodedAccount = try JSONDecoder().decode(Account.self, from: jsonData)
-            
+
             XCTAssertEqual(account.issuer, decodedAccount.issuer)
             XCTAssertEqual(account.accountName, decodedAccount.accountName)
             XCTAssertEqual(account.imageUrl, decodedAccount.imageUrl)
             XCTAssertEqual(account.backgroundColor, decodedAccount.backgroundColor)
-            XCTAssertEqual(account.timeAdded, decodedAccount.timeAdded)
+            XCTAssertEqual(account.timeAdded.millisecondsSince1970, decodedAccount.timeAdded.millisecondsSince1970)
             XCTAssertEqual(account.identifier, decodedAccount.identifier)
         }
         catch {

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/HOTPMechanismTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/HOTPMechanismTests.swift
@@ -263,19 +263,19 @@ class HOTPMechanismTests: FRABaseTests {
                 return
             }
             
-            //  Decode
-            let decodedMechanism = try JSONDecoder().decode(HOTPMechanism.self, from: jsonString.data(using: .utf8) ?? Data())
-            
-            XCTAssertEqual(mechanism.mechanismUUID, decodedMechanism.mechanismUUID)
-            XCTAssertEqual(mechanism.issuer, decodedMechanism.issuer)
-            XCTAssertEqual(mechanism.type, decodedMechanism.type)
-            XCTAssertEqual(mechanism.secret, decodedMechanism.secret)
-            XCTAssertEqual(mechanism.version, decodedMechanism.version)
-            XCTAssertEqual(mechanism.accountName, decodedMechanism.accountName)
-            XCTAssertEqual(mechanism.algorithm, decodedMechanism.algorithm)
-            XCTAssertEqual(mechanism.digits, decodedMechanism.digits)
-            XCTAssertEqual(mechanism.counter, decodedMechanism.counter)
-            XCTAssertEqual(mechanism.timeAdded.timeIntervalSince1970, decodedMechanism.timeAdded.timeIntervalSince1970)
+            //  Covert jsonString to Dictionary
+            let jsonDictionary = FRJSONEncoder.jsonStringToDictionary(jsonString: jsonString)
+                
+            //  Then
+            XCTAssertEqual(mechanism.mechanismUUID, jsonDictionary?["mechanismUID"] as! String)
+            XCTAssertEqual(mechanism.issuer, jsonDictionary?["issuer"] as! String)
+            XCTAssertEqual(mechanism.type, jsonDictionary?["oathType"] as! String)
+            XCTAssertEqual("REMOVED", jsonDictionary?["secret"] as! String)
+            XCTAssertEqual(FRAConstants.oathAuth, jsonDictionary?["type"] as! String)
+            XCTAssertEqual(mechanism.accountName, jsonDictionary?["accountName"] as! String)
+            XCTAssertEqual(mechanism.digits, jsonDictionary?["digits"] as! Int)
+            XCTAssertEqual(mechanism.counter, jsonDictionary?["counter"] as! Int)
+            XCTAssertEqual(mechanism.timeAdded.millisecondsSince1970, jsonDictionary?["timeAdded"] as! Int64)
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/HOTPMechanismTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/HOTPMechanismTests.swift
@@ -244,7 +244,7 @@ class HOTPMechanismTests: FRABaseTests {
             XCTAssertEqual(mechanism.algorithm, decodedMechanism.algorithm)
             XCTAssertEqual(mechanism.digits, decodedMechanism.digits)
             XCTAssertEqual(mechanism.counter, decodedMechanism.counter)
-            XCTAssertEqual(mechanism.timeAdded.timeIntervalSince1970, decodedMechanism.timeAdded.timeIntervalSince1970)
+            XCTAssertEqual(mechanism.timeAdded.millisecondsSince1970, decodedMechanism.timeAdded.millisecondsSince1970)
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")
@@ -268,13 +268,14 @@ class HOTPMechanismTests: FRABaseTests {
                 
             //  Then
             XCTAssertEqual(mechanism.mechanismUUID, jsonDictionary?["mechanismUID"] as! String)
+            XCTAssertEqual(mechanism.identifier, jsonDictionary?["id"] as! String)
+            XCTAssertEqual(mechanism.algorithm.rawValue, jsonDictionary?["algorithm"] as! String)
             XCTAssertEqual(mechanism.issuer, jsonDictionary?["issuer"] as! String)
             XCTAssertEqual(mechanism.type, jsonDictionary?["oathType"] as! String)
-            XCTAssertEqual("REMOVED", jsonDictionary?["secret"] as! String)
+            XCTAssertEqual(mechanism.secret, jsonDictionary?["secret"] as! String)
             XCTAssertEqual(FRAConstants.oathAuth, jsonDictionary?["type"] as! String)
             XCTAssertEqual(mechanism.accountName, jsonDictionary?["accountName"] as! String)
             XCTAssertEqual(mechanism.digits, jsonDictionary?["digits"] as! Int)
-            XCTAssertEqual(mechanism.counter, jsonDictionary?["counter"] as! Int)
             XCTAssertEqual(mechanism.timeAdded.millisecondsSince1970, jsonDictionary?["timeAdded"] as! Int64)
         }
         catch {

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/MechanismTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/MechanismTests.swift
@@ -89,7 +89,7 @@ class MechanismTests: FRABaseTests {
             XCTAssertEqual(mechanism.issuer, decodedMechanism.issuer)
             XCTAssertEqual(mechanism.secret, decodedMechanism.secret)
             XCTAssertEqual(mechanism.accountName, decodedMechanism.accountName)
-            XCTAssertEqual(mechanism.timeAdded.timeIntervalSince1970, decodedMechanism.timeAdded.timeIntervalSince1970)
+            XCTAssertEqual(mechanism.timeAdded.millisecondsSince1970, decodedMechanism.timeAdded.millisecondsSince1970)
         }
         catch {
             XCTFail("Failed with an unexpected error: \(error.localizedDescription)")

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/NotificationTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/NotificationTests.swift
@@ -241,16 +241,20 @@ class NotificationTests: FRABaseTests {
                 return
             }
             
-            //  Decode
-            let decodedNotification = try JSONDecoder().decode(PushNotification.self, from: jsonString.data(using: .utf8) ?? Data())
+            //  Covert jsonString to Dictionary
+            let jsonDictionary = FRJSONEncoder.jsonStringToDictionary(jsonString: jsonString)
             
             //  Then
-            XCTAssertEqual(notification.messageId, decodedNotification.messageId)
-            XCTAssertEqual(notification.challenge, decodedNotification.challenge)
-            XCTAssertEqual(notification.loadBalanceKey, decodedNotification.loadBalanceKey)
-            XCTAssertEqual(notification.ttl, decodedNotification.ttl)
-            XCTAssertEqual(notification.mechanismUUID, decodedNotification.mechanismUUID)
-            XCTAssertEqual(notification.timeAdded.timeIntervalSince1970, decodedNotification.timeAdded.timeIntervalSince1970)
+            XCTAssertEqual(notification.identifier, jsonDictionary?["id"] as! String)
+            XCTAssertEqual(notification.messageId, jsonDictionary?["messageId"] as! String)
+            XCTAssertEqual("REMOVED", jsonDictionary?["challenge"] as! String)
+            XCTAssertEqual("REMOVED", jsonDictionary?["loadBalanceKey"] as! String)
+            XCTAssertEqual(notification.ttl, jsonDictionary?["ttl"] as! Double)
+            XCTAssertEqual(notification.mechanismUUID, jsonDictionary?["mechanismUID"] as! String)
+            XCTAssertEqual(notification.approved, jsonDictionary?["approved"] as! Bool)
+            XCTAssertEqual(notification.pending, jsonDictionary?["pending"] as! Bool)
+            XCTAssertEqual(notification.timeAdded.millisecondsSince1970, jsonDictionary?["timeAdded"] as! Int64)
+            XCTAssertEqual(notification.timeAdded.millisecondsSince1970 + Int64(notification.ttl * 1000), jsonDictionary?["timeExpired"] as! Int64)
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/NotificationTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/NotificationTests.swift
@@ -223,7 +223,7 @@ class NotificationTests: FRABaseTests {
             XCTAssertEqual(notification.loadBalanceKey, decodedNotification.loadBalanceKey)
             XCTAssertEqual(notification.ttl, decodedNotification.ttl)
             XCTAssertEqual(notification.mechanismUUID, decodedNotification.mechanismUUID)
-            XCTAssertEqual(notification.timeAdded.timeIntervalSince1970, decodedNotification.timeAdded.timeIntervalSince1970)
+            XCTAssertEqual(notification.timeAdded.millisecondsSince1970, decodedNotification.timeAdded.millisecondsSince1970)
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")
@@ -247,8 +247,8 @@ class NotificationTests: FRABaseTests {
             //  Then
             XCTAssertEqual(notification.identifier, jsonDictionary?["id"] as! String)
             XCTAssertEqual(notification.messageId, jsonDictionary?["messageId"] as! String)
-            XCTAssertEqual("REMOVED", jsonDictionary?["challenge"] as! String)
-            XCTAssertEqual("REMOVED", jsonDictionary?["amlbCookie"] as! String)
+            XCTAssertEqual(notification.challenge, jsonDictionary?["challenge"] as! String)
+            XCTAssertEqual(notification.loadBalanceKey, jsonDictionary?["amlbCookie"] as? String)
             XCTAssertEqual(notification.ttl, jsonDictionary?["ttl"] as! Double)
             XCTAssertEqual(notification.mechanismUUID, jsonDictionary?["mechanismUID"] as! String)
             XCTAssertEqual(notification.approved, jsonDictionary?["approved"] as! Bool)

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/NotificationTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/NotificationTests.swift
@@ -248,7 +248,7 @@ class NotificationTests: FRABaseTests {
             XCTAssertEqual(notification.identifier, jsonDictionary?["id"] as! String)
             XCTAssertEqual(notification.messageId, jsonDictionary?["messageId"] as! String)
             XCTAssertEqual("REMOVED", jsonDictionary?["challenge"] as! String)
-            XCTAssertEqual("REMOVED", jsonDictionary?["loadBalanceKey"] as! String)
+            XCTAssertEqual("REMOVED", jsonDictionary?["amlbCookie"] as! String)
             XCTAssertEqual(notification.ttl, jsonDictionary?["ttl"] as! Double)
             XCTAssertEqual(notification.mechanismUUID, jsonDictionary?["mechanismUID"] as! String)
             XCTAssertEqual(notification.approved, jsonDictionary?["approved"] as! Bool)

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/OathMechanismTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/OathMechanismTests.swift
@@ -78,7 +78,7 @@ class OathMechanismTests: FRABaseTests {
             XCTAssertEqual(mechanism.accountName, decodedMechanism.accountName)
             XCTAssertEqual(mechanism.algorithm, decodedMechanism.algorithm)
             XCTAssertEqual(mechanism.digits, decodedMechanism.digits)
-            XCTAssertEqual(mechanism.timeAdded.timeIntervalSince1970, decodedMechanism.timeAdded.timeIntervalSince1970)
+            XCTAssertEqual(mechanism.timeAdded.millisecondsSince1970, decodedMechanism.timeAdded.millisecondsSince1970)
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/PushMechanismTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/PushMechanismTests.swift
@@ -142,18 +142,18 @@ class PushMechanismTests: FRABaseTests {
                 return
             }
             
-            //  Decode
-            let decodedMechanism = try JSONDecoder().decode(PushMechanism.self, from: jsonStr.data(using: .utf8) ?? Data())
-            
-            XCTAssertEqual(mechanism.mechanismUUID, decodedMechanism.mechanismUUID)
-            XCTAssertEqual(mechanism.issuer, decodedMechanism.issuer)
-            XCTAssertEqual(mechanism.type, decodedMechanism.type)
-            XCTAssertEqual(mechanism.secret, decodedMechanism.secret)
-            XCTAssertEqual(mechanism.version, decodedMechanism.version)
-            XCTAssertEqual(mechanism.accountName, decodedMechanism.accountName)
-            XCTAssertEqual(mechanism.regEndpoint, decodedMechanism.regEndpoint)
-            XCTAssertEqual(mechanism.authEndpoint, decodedMechanism.authEndpoint)
-            XCTAssertEqual(mechanism.timeAdded.timeIntervalSince1970, decodedMechanism.timeAdded.timeIntervalSince1970)
+            //  Covert jsonString to Dictionary
+            let jsonDictionary = FRJSONEncoder.jsonStringToDictionary(jsonString: jsonStr)
+                
+            //  Then
+            XCTAssertEqual(mechanism.mechanismUUID, jsonDictionary?["mechanismUID"] as! String)
+            XCTAssertEqual(mechanism.issuer, jsonDictionary?["issuer"] as! String)
+            XCTAssertEqual("REMOVED", jsonDictionary?["secret"] as! String)
+            XCTAssertEqual(FRAConstants.pushAuth, jsonDictionary?["type"] as! String)
+            XCTAssertEqual(mechanism.accountName, jsonDictionary?["accountName"] as! String)
+            XCTAssertEqual(mechanism.regEndpoint.absoluteString, jsonDictionary?["registrationEndpoint"] as! String)
+            XCTAssertEqual(mechanism.authEndpoint.absoluteString, jsonDictionary?["authenticationEndpoint"] as! String)
+            XCTAssertEqual(mechanism.timeAdded.millisecondsSince1970, jsonDictionary?["timeAdded"] as! Int64)
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/PushMechanismTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/PushMechanismTests.swift
@@ -122,7 +122,7 @@ class PushMechanismTests: FRABaseTests {
             XCTAssertEqual(mechanism.accountName, decodedMechanism.accountName)
             XCTAssertEqual(mechanism.regEndpoint, decodedMechanism.regEndpoint)
             XCTAssertEqual(mechanism.authEndpoint, decodedMechanism.authEndpoint)
-            XCTAssertEqual(mechanism.timeAdded.timeIntervalSince1970, decodedMechanism.timeAdded.timeIntervalSince1970)
+            XCTAssertEqual(mechanism.timeAdded.millisecondsSince1970, decodedMechanism.timeAdded.millisecondsSince1970)
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")
@@ -148,11 +148,11 @@ class PushMechanismTests: FRABaseTests {
             //  Then
             XCTAssertEqual(mechanism.mechanismUUID, jsonDictionary?["mechanismUID"] as! String)
             XCTAssertEqual(mechanism.issuer, jsonDictionary?["issuer"] as! String)
-            XCTAssertEqual("REMOVED", jsonDictionary?["secret"] as! String)
-            XCTAssertEqual(FRAConstants.pushAuth, jsonDictionary?["type"] as! String)
+            XCTAssertEqual(mechanism.secret, jsonDictionary?["secret"] as! String)
+            XCTAssertEqual(mechanism.type, jsonDictionary?["type"] as! String)
             XCTAssertEqual(mechanism.accountName, jsonDictionary?["accountName"] as! String)
-            XCTAssertEqual("REMOVED", jsonDictionary?["registrationEndpoint"] as! String)
-            XCTAssertEqual("REMOVED", jsonDictionary?["authenticationEndpoint"] as! String)
+            XCTAssertEqual(mechanism.regEndpoint.absoluteString, jsonDictionary?["registrationEndpoint"] as! String)
+            XCTAssertEqual(mechanism.authEndpoint.absoluteString, jsonDictionary?["authenticationEndpoint"] as! String)
             XCTAssertEqual(mechanism.timeAdded.millisecondsSince1970, jsonDictionary?["timeAdded"] as! Int64)
         }
         catch {

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/PushMechanismTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/PushMechanismTests.swift
@@ -151,8 +151,8 @@ class PushMechanismTests: FRABaseTests {
             XCTAssertEqual("REMOVED", jsonDictionary?["secret"] as! String)
             XCTAssertEqual(FRAConstants.pushAuth, jsonDictionary?["type"] as! String)
             XCTAssertEqual(mechanism.accountName, jsonDictionary?["accountName"] as! String)
-            XCTAssertEqual(mechanism.regEndpoint.absoluteString, jsonDictionary?["registrationEndpoint"] as! String)
-            XCTAssertEqual(mechanism.authEndpoint.absoluteString, jsonDictionary?["authenticationEndpoint"] as! String)
+            XCTAssertEqual("REMOVED", jsonDictionary?["registrationEndpoint"] as! String)
+            XCTAssertEqual("REMOVED", jsonDictionary?["authenticationEndpoint"] as! String)
             XCTAssertEqual(mechanism.timeAdded.millisecondsSince1970, jsonDictionary?["timeAdded"] as! Int64)
         }
         catch {

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/PushMechanismTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/PushMechanismTests.swift
@@ -149,7 +149,7 @@ class PushMechanismTests: FRABaseTests {
             XCTAssertEqual(mechanism.mechanismUUID, jsonDictionary?["mechanismUID"] as! String)
             XCTAssertEqual(mechanism.issuer, jsonDictionary?["issuer"] as! String)
             XCTAssertEqual(mechanism.secret, jsonDictionary?["secret"] as! String)
-            XCTAssertEqual(mechanism.type, jsonDictionary?["type"] as! String)
+            XCTAssertEqual(FRAConstants.pushAuth, jsonDictionary?["type"] as! String)
             XCTAssertEqual(mechanism.accountName, jsonDictionary?["accountName"] as! String)
             XCTAssertEqual(mechanism.regEndpoint.absoluteString, jsonDictionary?["registrationEndpoint"] as! String)
             XCTAssertEqual(mechanism.authEndpoint.absoluteString, jsonDictionary?["authenticationEndpoint"] as! String)

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/TOTPMechanismTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/TOTPMechanismTests.swift
@@ -244,7 +244,7 @@ class TOTPMechanismTests: FRABaseTests {
             XCTAssertEqual(mechanism.algorithm, deocdedMechanism.algorithm)
             XCTAssertEqual(mechanism.digits, deocdedMechanism.digits)
             XCTAssertEqual(mechanism.period, deocdedMechanism.period)
-            XCTAssertEqual(mechanism.timeAdded.timeIntervalSince1970, deocdedMechanism.timeAdded.timeIntervalSince1970)
+            XCTAssertEqual(mechanism.timeAdded.millisecondsSince1970, deocdedMechanism.timeAdded.millisecondsSince1970)
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")
@@ -268,10 +268,14 @@ class TOTPMechanismTests: FRABaseTests {
             let jsonDictionary = FRJSONEncoder.jsonStringToDictionary(jsonString: jsonStr)
                 
             //  Then
+            
+            
             XCTAssertEqual(mechanism.mechanismUUID, jsonDictionary?["mechanismUID"] as! String)
+            XCTAssertEqual(mechanism.identifier, jsonDictionary?["id"] as! String)
+            XCTAssertEqual(mechanism.algorithm.rawValue, jsonDictionary?["algorithm"] as! String)
             XCTAssertEqual(mechanism.issuer, jsonDictionary?["issuer"] as! String)
             XCTAssertEqual(mechanism.type, jsonDictionary?["oathType"] as! String)
-            XCTAssertEqual("REMOVED", jsonDictionary?["secret"] as! String)
+            XCTAssertEqual(mechanism.secret, jsonDictionary?["secret"] as! String)
             XCTAssertEqual(FRAConstants.oathAuth, jsonDictionary?["type"] as! String)
             XCTAssertEqual(mechanism.accountName, jsonDictionary?["accountName"] as! String)
             XCTAssertEqual(mechanism.digits, jsonDictionary?["digits"] as! Int)

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/TOTPMechanismTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/TOTPMechanismTests.swift
@@ -264,19 +264,19 @@ class TOTPMechanismTests: FRABaseTests {
                 return
             }
             
-            //  Decode
-            let deocdedMechanism = try JSONDecoder().decode(TOTPMechanism.self, from: jsonStr.data(using: .utf8) ?? Data())
-            
-            XCTAssertEqual(mechanism.mechanismUUID, deocdedMechanism.mechanismUUID)
-            XCTAssertEqual(mechanism.issuer, deocdedMechanism.issuer)
-            XCTAssertEqual(mechanism.type, deocdedMechanism.type)
-            XCTAssertEqual(mechanism.secret, deocdedMechanism.secret)
-            XCTAssertEqual(mechanism.version, deocdedMechanism.version)
-            XCTAssertEqual(mechanism.accountName, deocdedMechanism.accountName)
-            XCTAssertEqual(mechanism.algorithm, deocdedMechanism.algorithm)
-            XCTAssertEqual(mechanism.digits, deocdedMechanism.digits)
-            XCTAssertEqual(mechanism.period, deocdedMechanism.period)
-            XCTAssertEqual(mechanism.timeAdded.timeIntervalSince1970, deocdedMechanism.timeAdded.timeIntervalSince1970)
+            //  Covert jsonString to Dictionary
+            let jsonDictionary = FRJSONEncoder.jsonStringToDictionary(jsonString: jsonStr)
+                
+            //  Then
+            XCTAssertEqual(mechanism.mechanismUUID, jsonDictionary?["mechanismUID"] as! String)
+            XCTAssertEqual(mechanism.issuer, jsonDictionary?["issuer"] as! String)
+            XCTAssertEqual(mechanism.type, jsonDictionary?["oathType"] as! String)
+            XCTAssertEqual("REMOVED", jsonDictionary?["secret"] as! String)
+            XCTAssertEqual(FRAConstants.oathAuth, jsonDictionary?["type"] as! String)
+            XCTAssertEqual(mechanism.accountName, jsonDictionary?["accountName"] as! String)
+            XCTAssertEqual(mechanism.digits, jsonDictionary?["digits"] as! Int)
+            XCTAssertEqual(mechanism.period, jsonDictionary?["period"] as! Int)
+            XCTAssertEqual(mechanism.timeAdded.millisecondsSince1970, jsonDictionary?["timeAdded"] as! Int64)
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Storage/KeychainServiceStorageClientTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Storage/KeychainServiceStorageClientTests.swift
@@ -209,6 +209,7 @@ class KeychainServiceStorageClientTests: FRABaseTests {
             let messageId2 = "AUTHENTICATE:e84233f8-9ecf-4456-91ad-2649c4103bc01562382721826"
 
             let notification1 = try PushNotification(messageId: messageId1, payload: payload1)
+            sleep(1) // Waiting 1s to avoid have two PushNotifications with same id
             let notification2 = try PushNotification(messageId: messageId2, payload: payload2)
             
             storage.setNotification(notification: notification1)
@@ -254,6 +255,7 @@ class KeychainServiceStorageClientTests: FRABaseTests {
             let messageId2 = "AUTHENTICATE:e84233f8-9ecf-4456-91ad-2649c4103bc01562382721826"
 
             let notification1 = try PushNotification(messageId: messageId1, payload: payload1)
+            sleep(1) // Waiting 1s to avoid have two PushNotifications with same id
             let notification2 = try PushNotification(messageId: messageId2, payload: payload2)
             storage.setNotification(notification: notification1)
             storage.setNotification(notification: notification2)


### PR DESCRIPTION
**Summary of changes:**

- Make `mechanismUUID` public on `PushNotification` and `Mechanism` objects
- Make notificationId use `timeAdded` in milliseconds
- Added new `getNotification()` API
- Refactored `toJson()` method on Models. It was not supposed to expose sensitive information. Also, it will align the output with Android SDK. So, some attributes may have different names in the json string.