### PR TITLE
SDKS-1209-Metadata callback overrides stage property of node

### DIFF
--- a/FRAuth/FRAuth/Authentication/Node.swift
+++ b/FRAuth/FRAuth/Authentication/Node.swift
@@ -106,11 +106,13 @@ public class Node: NSObject {
                 let callbackObj = try Node.transformCallback(callbackType: callbackType, json: callback)
                 self.callbacks.append(callbackObj)
                 
-                // Support AM 6.5.2 stage property workaround with MetadataCallback
-                if let metadataCallback = callbackObj as? MetadataCallback, let outputs = metadataCallback.response[CBConstants.output] as? [[String: Any]] {
-                    for output in outputs {
-                        if let outputName = output[CBConstants.name] as? String, outputName == CBConstants.data, let outputValue = output[CBConstants.value] as? [String: String] {
-                            self.stage = outputValue[CBConstants.stage]
+                if self.stage == nil { //Fix for SDKS-1209
+                    // Support AM 6.5.2 stage property workaround with MetadataCallback
+                    if let metadataCallback = callbackObj as? MetadataCallback, let outputs = metadataCallback.response[CBConstants.output] as? [[String: Any]] {
+                        for output in outputs {
+                            if let outputName = output[CBConstants.name] as? String, outputName == CBConstants.data, let outputValue = output[CBConstants.value] as? [String: String] {
+                                self.stage = outputValue[CBConstants.stage]
+                            }
                         }
                     }
                 }

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA_04_PageCallback_SDKS_1209.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA_04_PageCallback_SDKS_1209.swift
@@ -1,0 +1,80 @@
+// 
+//  AA_04_PageCallback_SDKS_1209.swift
+//  FRAuthTests
+//
+//  Copyright (c) 2021 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import FRAuth
+
+class AA_04_PageCallback_SDKS_1209: FRAuthBaseTest {
+    
+    override func setUp() {
+        self.configFileName = "Config-live-01"
+        super.setUp()
+        self.config.authServiceName = "SDKS-1209"
+        self.shouldLoadMockResponses = false;
+    }
+    
+    // MARK: - Helper Method
+    func test_01_test_page_node_SDKS_1209()  {
+        
+        // Start SDK
+        self.startSDK()
+        var currentNode: Node?
+        
+        var ex = self.expectation(description: "First Node submit")
+        FRSession.authenticate(authIndexValue: self.config.authServiceName!) { (token: Token?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        guard let node = currentNode else {
+            XCTFail("Failed to get Node from the first request")
+            return
+        }
+        
+        // When both page node and metadata callbacks are present, then the stage from the page node should take
+        // precedence. In our case, in the test tree, the stage is set to "Test", and in the metadata callback
+        // it is set to "UsernamePassword"
+        XCTAssertEqual(node.stage, "Test");
+        
+        // Provide input values for the name and password callbacks
+        for callback in node.callbacks {
+            if callback is NameCallback, let nameCallback = callback as? NameCallback {
+                nameCallback.setValue(config.username)
+            }
+            else if callback is PasswordCallback, let passwordCallback = callback as? PasswordCallback {
+                passwordCallback.setValue(config.password)
+            }
+            else if callback is MetadataCallback {
+                continue // ignore the MetadataCallback callback...
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Second Node submit")
+        currentNode?.next { (token: AccessToken?, node, error) in
+            
+            // Validate result
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+}


### PR DESCRIPTION
Checking if the stage property has been set before going through the MetadataCallback to set the stage of the node.