### PR TITLE
Sdks-1366_iOS make sure that deprecated "unarchiveObject(with:" methods are not used for iOS 11+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# Version 3.1.1
+# Version 3.2.0
+## [3.2.0]
+#### Changed
+- Added custom implementation for HTTPCookie, for iOS 11+ devices in order to support NSSecureCoding for storing cookies
+- Changed all instances of Archiving/Unarchiving to use NSSecureCoding
+
 ## [3.1.1]
 #### Changed
 - SecuredKey initializer supports passing a Keychain accessibility flag

--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -275,6 +275,7 @@
 		D5F3E10324D20FBF00536EA0 /* SuspendedTextOutputCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F3E10224D20FBF00536EA0 /* SuspendedTextOutputCallback.swift */; };
 		D5F8F9EE24B7D50600EC9AEB /* BooleanAttributeInputCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F8F9ED24B7D50600EC9AEB /* BooleanAttributeInputCallback.swift */; };
 		D5F8F9F024B7D85600EC9AEB /* NumberAttributeInputCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5F8F9EF24B7D85600EC9AEB /* NumberAttributeInputCallback.swift */; };
+		EC8BCAFF273C3EC100C3B2D8 /* FRHTTPCookie.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8BCAFD273C3EC100C3B2D8 /* FRHTTPCookie.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -598,6 +599,7 @@
 		D5F8F9EF24B7D85600EC9AEB /* NumberAttributeInputCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberAttributeInputCallback.swift; sourceTree = "<group>"; };
 		D5FBD8A224B930E30005DD0F /* BooleanAttributeInputCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BooleanAttributeInputCallbackTests.swift; sourceTree = "<group>"; };
 		D5FBD8A524B930F00005DD0F /* NumberAttributeInputCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NumberAttributeInputCallbackTests.swift; sourceTree = "<group>"; };
+		EC8BCAFD273C3EC100C3B2D8 /* FRHTTPCookie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRHTTPCookie.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1022,6 +1024,7 @@
 				D586CF3A23358EDF007A2194 /* NetworkReachabilityMonitor.swift */,
 				D512CD40240DC41E00AF520E /* FRRestClient.swift */,
 				D5EC34FA247B329D0005A50C /* FRRequestInterceptorRegistry.swift */,
+				EC8BCAFD273C3EC100C3B2D8 /* FRHTTPCookie.swift */,
 				D5E86BBC2481E5B800DFD5E0 /* FRURLProtocol.swift */,
 			);
 			path = Network;
@@ -1739,6 +1742,7 @@
 				D5F01B1D240F0B9F00BD48AA /* FRLog.swift in Sources */,
 				D586CFAD23358EE0007A2194 /* FRUser.swift in Sources */,
 				D586CF8423358EE0007A2194 /* FRJailbreakDetector.swift in Sources */,
+				EC8BCAFF273C3EC100C3B2D8 /* FRHTTPCookie.swift in Sources */,
 				D586CFB823358EE0007A2194 /* HardwareCollector.swift in Sources */,
 				D586CFAA23358EE0007A2194 /* ServerConfig.swift in Sources */,
 				D586CF7A23358EE0007A2194 /* TokenError.swift in Sources */,

--- a/FRAuth/FRAuth/Network/FRHTTPCookie.swift
+++ b/FRAuth/FRAuth/Network/FRHTTPCookie.swift
@@ -31,7 +31,7 @@ class FRHTTPCookie: HTTPCookie, NSSecureCoding {
         if #available(iOS 14.0, *) {
             portList = coder.decodeArrayOfObjects(ofClass: NSNumber.self, forKey: "portList")
         } else {
-            portList = coder.decodeObject(of: [NSNumber.self], forKey: "portList") as? [NSNumber]
+            portList = coder.decodeObject(of: [NSArray.self, NSNumber.self], forKey: "portList") as? [NSNumber]
         }
         
         let sameSitePolicy = coder.decodeObject(of: NSString.self, forKey: "sameSitePolicy") as String?
@@ -41,14 +41,14 @@ class FRHTTPCookie: HTTPCookie, NSSecureCoding {
         properties[HTTPCookiePropertyKey.value] = value
         properties[HTTPCookiePropertyKey.domain] = domain
         properties[HTTPCookiePropertyKey.path] = path
-        properties[HTTPCookiePropertyKey.secure] = isSecure
+        properties[HTTPCookiePropertyKey.secure] = isSecure ? "TRUE" : nil
         properties[HTTPCookiePropertyKey.expires] = expiresDate
         properties[HTTPCookiePropertyKey.comment] = comment
         properties[HTTPCookiePropertyKey.commentURL] = commentURL
-        properties[HTTPCookiePropertyKey.discard] = isSessionOnly
+        properties[HTTPCookiePropertyKey.discard] = isSessionOnly ? "TRUE" : nil
         properties[HTTPCookiePropertyKey.maximumAge] = expiresDate
         properties[HTTPCookiePropertyKey.port] = portList
-        properties[HTTPCookiePropertyKey("HttpOnly")] = isHTTPOnly
+        properties[HTTPCookiePropertyKey("HttpOnly")] = isHTTPOnly ? "TRUE" : nil
         if #available(iOS 13.0, *) {
             if let sameSitePolicyValue = sameSitePolicy {
                 properties[HTTPCookiePropertyKey.sameSitePolicy] = HTTPCookieStringPolicy(rawValue: sameSitePolicyValue)

--- a/FRAuth/FRAuth/Network/FRHTTPCookie.swift
+++ b/FRAuth/FRAuth/Network/FRHTTPCookie.swift
@@ -1,0 +1,88 @@
+// 
+//  FRHTTPCookie.swift
+//  FRAuth
+//
+//  Copyright (c) 2021 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+
+import Foundation
+
+class FRHTTPCookie: HTTPCookie, NSSecureCoding {
+    required init?(coder: NSCoder) {
+        var properties = [HTTPCookiePropertyKey: Any]()
+        let version = coder.decodeInteger(forKey: "version")
+        let name = coder.decodeObject(of: NSString.self, forKey: "name") as String?
+        let value = coder.decodeObject(of: NSString.self, forKey: "value") as String?
+        let expiresDate = coder.decodeObject(of: NSDate.self, forKey: "expiresDate") as Date?
+        let isSessionOnly = coder.decodeBool(forKey: "isSessionOnly")
+        let domain = coder.decodeObject(of: NSString.self, forKey: "domain") as String?
+        let path = coder.decodeObject(of: NSString.self, forKey: "path") as String?
+        let isSecure = coder.decodeBool(forKey: "isSecure")
+        let isHTTPOnly = coder.decodeBool(forKey: "isHTTPOnly")
+        
+        let comment = coder.decodeObject(of: NSString.self, forKey: "comment") as String?
+        let commentURL = coder.decodeObject(of: NSURL.self, forKey: "commentURL") as URL?
+        let portList: [NSNumber]?
+        if #available(iOS 14.0, *) {
+            portList = coder.decodeArrayOfObjects(ofClass: NSNumber.self, forKey: "portList")
+        } else {
+            portList = coder.decodeObject(of: [NSNumber.self], forKey: "portList") as? [NSNumber]
+        }
+        
+        let sameSitePolicy = coder.decodeObject(of: NSString.self, forKey: "sameSitePolicy") as String?
+        
+        properties[HTTPCookiePropertyKey.version] = version
+        properties[HTTPCookiePropertyKey.name] = name
+        properties[HTTPCookiePropertyKey.value] = value
+        properties[HTTPCookiePropertyKey.domain] = domain
+        properties[HTTPCookiePropertyKey.path] = path
+        properties[HTTPCookiePropertyKey.secure] = isSecure
+        properties[HTTPCookiePropertyKey.expires] = expiresDate
+        properties[HTTPCookiePropertyKey.comment] = comment
+        properties[HTTPCookiePropertyKey.commentURL] = commentURL
+        properties[HTTPCookiePropertyKey.discard] = isSessionOnly
+        properties[HTTPCookiePropertyKey.maximumAge] = expiresDate
+        properties[HTTPCookiePropertyKey.port] = portList
+        properties[HTTPCookiePropertyKey("HttpOnly")] = isHTTPOnly
+        if #available(iOS 13.0, *) {
+            if let sameSitePolicyValue = sameSitePolicy {
+                properties[HTTPCookiePropertyKey.sameSitePolicy] = HTTPCookieStringPolicy(rawValue: sameSitePolicyValue)
+            }
+        }
+        
+        super.init(properties: properties)
+    }
+    
+    public static var supportsSecureCoding: Bool {
+        return true
+    }
+    
+    public init?(with cookieProperties: [HTTPCookiePropertyKey : Any]) {
+        super.init(properties: cookieProperties)
+    }
+    
+    // Encodes FRUser object with NSCoder
+    ///
+    /// - Parameter aCoder: NSCoder
+    public func encode(with aCoder: NSCoder) {
+        aCoder.encode(self.version, forKey: "version")
+        aCoder.encode(self.name, forKey: "name")
+        aCoder.encode(self.value, forKey: "value")
+        aCoder.encode(self.expiresDate, forKey: "expiresDate")
+        aCoder.encode(self.isSessionOnly, forKey: "isSessionOnly")
+        aCoder.encode(self.domain, forKey: "domain")
+        aCoder.encode(self.path, forKey: "path")
+        aCoder.encode(self.isSecure, forKey: "isSecure")
+        aCoder.encode(self.isHTTPOnly, forKey: "isHTTPOnly")
+        aCoder.encode(self.comment, forKey: "comment")
+        aCoder.encode(self.commentURL, forKey: "commentURL")
+        aCoder.encode(self.portList, forKey: "portList")
+        if #available(iOS 13.0, *) {
+            aCoder.encode(self.sameSitePolicy, forKey: "sameSitePolicy")
+        }
+    }
+}

--- a/FRAuth/FRAuth/Network/FRHTTPCookie.swift
+++ b/FRAuth/FRAuth/Network/FRHTTPCookie.swift
@@ -11,6 +11,7 @@
 
 import Foundation
 
+@available(iOS 11, *)
 class FRHTTPCookie: HTTPCookie, NSSecureCoding {
     required init?(coder: NSCoder) {
         var properties = [HTTPCookiePropertyKey: Any]()

--- a/FRAuth/FRAuth/Network/FRRestClient.swift
+++ b/FRAuth/FRAuth/Network/FRRestClient.swift
@@ -112,9 +112,16 @@ class FRRestClient: NSObject {
                     FRLog.v("[Cookies] Delete - Cookie Name: \(cookie.name)")
                 }
                 else {
-                    let cookieData = NSKeyedArchiver.archivedData(withRootObject: cookie)
-                    frAuth.keychainManager.cookieStore.set(cookieData, key: cookie.name + "-" + cookie.domain)
-                    FRLog.v("[Cookies] Update - Cookie Name: \(cookie.name) | Cookie Value: \(cookie.value)")
+                    if #available(iOS 11.0, *) {
+                        if let properties = cookie.properties, let frHTTPCookie = FRHTTPCookie(with: properties), let cookieData = try? NSKeyedArchiver.archivedData(withRootObject: frHTTPCookie, requiringSecureCoding: true) {
+                            frAuth.keychainManager.cookieStore.set(cookieData, key: cookie.name + "-" + cookie.domain)
+                            FRLog.v("[Cookies] Update - Cookie Name: \(cookie.name) | Cookie Value: \(cookie.value)")
+                        }
+                    } else {
+                        let cookieData = NSKeyedArchiver.archivedData(withRootObject: cookie)
+                        frAuth.keychainManager.cookieStore.set(cookieData, key: cookie.name + "-" + cookie.domain)
+                        FRLog.v("[Cookies] Update - Cookie Name: \(cookie.name) | Cookie Value: \(cookie.value)")
+                    }
                 }
             }
         }
@@ -129,25 +136,40 @@ class FRRestClient: NSObject {
             
             var cookieList: [HTTPCookie] = []
             
-            // Iterate Cookie List and validate
-            for cookieObj in cookieItems {
-                if let cookieData = cookieObj.value as? Data, let cookie = NSKeyedUnarchiver.unarchiveObject(with: cookieData) as? HTTPCookie {
-                    // When Cookie is expired, remove it from the Cookie Store
-                    if cookie.isExpired {
-                        frAuth.keychainManager.cookieStore.delete(cookie.name + "-" + cookie.domain)
-                        FRLog.v("[Cookies] Delete - Expired - Cookie Name: \(cookie.name)")
+            func checkCookie(_ cookie: HTTPCookie) {
+                // When Cookie is expired, remove it from the Cookie Store
+                if cookie.isExpired {
+                    frAuth.keychainManager.cookieStore.delete(cookie.name + "-" + cookie.domain)
+                    FRLog.v("[Cookies] Delete - Expired - Cookie Name: \(cookie.name)")
+                }
+                else {
+                    if !cookie.validateIsSecure(url) {
+                        FRLog.v("[Cookies] Ignore - isSecure validation failed - Domain: \(url)\n\nCookie: \(cookie.name)")
+                    }
+                    else if !cookie.validateURL(url) {
+                        FRLog.v("[Cookies] Ignore - Domain validation failed - Domain: \(url)\n\nCookie: \(cookie.name)")
                     }
                     else {
-                        if !cookie.validateIsSecure(url) {
-                            FRLog.v("[Cookies] Ignore - isSecure validation failed - Domain: \(url)\n\nCookie: \(cookie.name)")
-                        }
-                        else if !cookie.validateURL(url) {
-                            FRLog.v("[Cookies] Ignore - Domain validation failed - Domain: \(url)\n\nCookie: \(cookie.name)")
-                        }
-                        else {
-                            FRLog.v("[Cookies] Injected for the request - Cookie Name: \(cookie.name) | Cookie Value \(cookie.value)")
-                            cookieList.append(cookie)
-                        }
+                        FRLog.v("[Cookies] Injected for the request - Cookie Name: \(cookie.name) | Cookie Value \(cookie.value)")
+                        cookieList.append(cookie)
+                    }
+                }
+            }
+            
+            // Iterate Cookie List and validate
+            for cookieObj in cookieItems {
+                if #available(iOS 11.0, *) {
+                    do {
+                    if let cookieData = cookieObj.value as? Data, let cookie = try NSKeyedUnarchiver.unarchivedObject(ofClass: FRHTTPCookie.self, from: cookieData) {
+                        checkCookie(cookie)
+                    }
+                    } catch {
+                        FRLog.e("[Cookies] unarchiving failed with error: \(error.localizedDescription)")
+                    }
+                }
+                else {
+                    if let cookieData = cookieObj.value as? Data, let cookie = NSKeyedUnarchiver.unarchiveObject(with: cookieData) as? HTTPCookie {
+                        checkCookie(cookie)
                     }
                 }
             }

--- a/FRAuth/FRAuth/Network/FRRestClient.swift
+++ b/FRAuth/FRAuth/Network/FRRestClient.swift
@@ -2,7 +2,7 @@
 //  FRRestClient.swift
 //  FRAuth
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020 - 2021 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Cookie/CookieValidationTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Cookie/CookieValidationTests.swift
@@ -202,7 +202,7 @@ class CookieValidationTests: FRAuthBaseTest {
     
     
     func test_10_cookie_is_expired_validation_not_expired() {
-        let setCookie: [String: String] = ["Set-Cookie":"iPlanetDirectoryPro=token; Expires=Wed, 21 Oct 2021 01:00:00 GMT; Domain=openam.example.com"]
+        let setCookie: [String: String] = ["Set-Cookie":"iPlanetDirectoryPro=token; Expires=Wed, 21 Oct 2022 01:00:00 GMT; Domain=openam.example.com"]
         let cookies = HTTPCookie.cookies(withResponseHeaderFields: setCookie, for: URL(string: "https://openam.example.com")!)
         guard let cookie = cookies.first else {
             XCTFail("Failed to parse Cookies from response header")

--- a/FRAuthenticator/FRAuthenticator/Storage/KeychainServiceClient.swift
+++ b/FRAuthenticator/FRAuthenticator/Storage/KeychainServiceClient.swift
@@ -66,12 +66,22 @@ struct KeychainServiceClient: StorageClient {
     
     
     func getAccount(accountIdentifier: String) -> Account? {
-        if let accountData = self.accountStorage.getData(accountIdentifier),
-            let account = NSKeyedUnarchiver.unarchiveObject(with: accountData) as? Account {
-            return account
+        guard let accountData = self.accountStorage.getData(accountIdentifier) else { return nil }
+        if #available(iOS 11.0, *) {
+            if let account = try? NSKeyedUnarchiver.unarchivedObject(ofClass: Account.self, from: accountData) {
+                return account
+            }
+            else {
+                return nil
+            }
         }
         else {
-            return nil
+            if let account = NSKeyedUnarchiver.unarchiveObject(with: accountData) as? Account {
+                return account
+            }
+            else {
+                return nil
+            }
         }
     }
     
@@ -80,8 +90,14 @@ struct KeychainServiceClient: StorageClient {
         var accounts: [Account] = []
         if let items = self.accountStorage.allItems() {
             for item in items {
-                if let accountData = item.value as? Data, let account = NSKeyedUnarchiver.unarchiveObject(with: accountData) as? Account {
-                    accounts.append(account)
+                if #available(iOS 11.0, *) {
+                    if let accountData = item.value as? Data, let account = try? NSKeyedUnarchiver.unarchivedObject(ofClass: Account.self, from: accountData) {
+                        accounts.append(account)
+                    }
+                } else {
+                    if let accountData = item.value as? Data, let account = NSKeyedUnarchiver.unarchiveObject(with: accountData) as? Account {
+                        accounts.append(account)
+                    }
                 }
             }
         }
@@ -117,10 +133,19 @@ struct KeychainServiceClient: StorageClient {
         var mechanisms: [Mechanism] = []
         if let items = self.mechanismStorage.allItems() {
             for item in items {
-                if let mechanismData = item.value as? Data,
-                let mechanism = NSKeyedUnarchiver.unarchiveObject(with: mechanismData) as? Mechanism {
-                    if mechanism.issuer == account.issuer && mechanism.accountName == account.accountName {
-                        mechanisms.append(mechanism)
+                if #available(iOS 11.0, *) {
+                    if let mechanismData = item.value as? Data,
+                       let mechanism = try? NSKeyedUnarchiver.unarchivedObject(ofClass: Mechanism.self, from: mechanismData) {
+                        if mechanism.issuer == account.issuer && mechanism.accountName == account.accountName {
+                            mechanisms.append(mechanism)
+                        }
+                    }
+                } else {
+                    if let mechanismData = item.value as? Data,
+                    let mechanism = NSKeyedUnarchiver.unarchiveObject(with: mechanismData) as? Mechanism {
+                        if mechanism.issuer == account.issuer && mechanism.accountName == account.accountName {
+                            mechanisms.append(mechanism)
+                        }
                     }
                 }
             }
@@ -134,10 +159,19 @@ struct KeychainServiceClient: StorageClient {
     func getMechanismForUUID(uuid: String) -> Mechanism? {
         if let items = self.mechanismStorage.allItems() {
             for item in items {
-                if let mechanismData = item.value as? Data,
-                let mechanism = NSKeyedUnarchiver.unarchiveObject(with: mechanismData) as? Mechanism {
-                    if mechanism.mechanismUUID == uuid {
-                        return mechanism
+                if #available(iOS 11.0, *) {
+                    if let mechanismData = item.value as? Data,
+                       let mechanism = try? NSKeyedUnarchiver.unarchivedObject(ofClass: Mechanism.self, from: mechanismData) {
+                        if mechanism.mechanismUUID == uuid {
+                            return mechanism
+                        }
+                    }
+                } else {
+                    if let mechanismData = item.value as? Data,
+                    let mechanism = NSKeyedUnarchiver.unarchiveObject(with: mechanismData) as? Mechanism {
+                        if mechanism.mechanismUUID == uuid {
+                            return mechanism
+                        }
                     }
                 }
             }
@@ -147,12 +181,21 @@ struct KeychainServiceClient: StorageClient {
     
     
     func getNotification(notificationIdentifier: String) -> PushNotification? {
-        if let notificationData = self.notificationStorage.getData(notificationIdentifier),
-            let notification = NSKeyedUnarchiver.unarchiveObject(with: notificationData) as? PushNotification {
-            return notification
-        }
-        else {
-            return nil
+        guard let notificationData = self.notificationStorage.getData(notificationIdentifier) else { return nil }
+        if #available(iOS 11.0, *) {
+            if let notification = try? NSKeyedUnarchiver.unarchivedObject(ofClass: PushNotification.self, from: notificationData) {
+                return notification
+            }
+            else {
+                return nil
+            }
+        } else {
+            if let notification = NSKeyedUnarchiver.unarchiveObject(with: notificationData) as? PushNotification {
+                return notification
+            }
+            else {
+                return nil
+            }
         }
     }
     
@@ -183,11 +226,19 @@ struct KeychainServiceClient: StorageClient {
         var notifications: [PushNotification] = []
         if let items = self.notificationStorage.allItems() {
            for item in items {
-               if let notificationData = item.value as? Data,
-                let notification = NSKeyedUnarchiver.unarchiveObject(with: notificationData) as? PushNotification,
-                notification.mechanismUUID == mechanism.mechanismUUID {
-                   notifications.append(notification)
-               }
+            if #available(iOS 11.0, *) {
+                if let notificationData = item.value as? Data,
+                 let notification = try? NSKeyedUnarchiver.unarchivedObject(ofClass: PushNotification.self, from: notificationData),
+                 notification.mechanismUUID == mechanism.mechanismUUID {
+                    notifications.append(notification)
+                }
+            } else {
+                if let notificationData = item.value as? Data,
+                 let notification = NSKeyedUnarchiver.unarchiveObject(with: notificationData) as? PushNotification,
+                 notification.mechanismUUID == mechanism.mechanismUUID {
+                    notifications.append(notification)
+                }
+            }
            }
         }
         return notifications.sorted { (lhs, rhs) -> Bool in
@@ -200,9 +251,15 @@ struct KeychainServiceClient: StorageClient {
         var notifications: [PushNotification] = []
         if let items = self.notificationStorage.allItems() {
            for item in items {
-               if let notificationData = item.value as? Data, let notification = NSKeyedUnarchiver.unarchiveObject(with: notificationData) as? PushNotification {
-                   notifications.append(notification)
-               }
+            if #available(iOS 11.0, *) {
+                if let notificationData = item.value as? Data, let notification = try? NSKeyedUnarchiver.unarchivedObject(ofClass: PushNotification.self, from: notificationData) {
+                    notifications.append(notification)
+                }
+            } else {
+                if let notificationData = item.value as? Data, let notification = NSKeyedUnarchiver.unarchiveObject(with: notificationData) as? PushNotification {
+                    notifications.append(notification)
+                }
+            }
            }
         }
         return notifications.sorted { (lhs, rhs) -> Bool in

--- a/FRCore/FRCore/Keychain/SecuredKey.swift
+++ b/FRCore/FRCore/Keychain/SecuredKey.swift
@@ -132,7 +132,7 @@ public struct SecuredKey {
         // If the device supports Secure Enclave, create a keypair using Secure Enclave TokenID
         if SecuredKey.isAvailable() {
             query[String(kSecAttrTokenID)] = String(kSecAttrTokenIDSecureEnclave)
-            let accessControl = SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleFlag.rawValue as CFString, .privateKeyUsage, nil)!
+            let accessControl = SecAccessControlCreateWithFlags(kCFAllocatorDefault, accessibility.rawValue as CFString, .privateKeyUsage, nil)!
             keyAttr[String(kSecAttrAccessControl)] = accessControl
         }
         #endif


### PR DESCRIPTION
OS make sure that deprecated "unarchiveObject(with:" methods are not used for iOS 11+
Based on the report from: https://forgerock.zendesk.com/agent/tickets/67734

- Added FRHTTPCookie class to support NSSecureCoding
- Fixed FRRestClient to only unarchive using NSSecureCoding methods for iOS 11+
- Fixed KeychainServiceClient to only unarchive using NSSecureCoding methods for iOS 11+