### PR TITLE
Add sdkVersion constant to FRCore.Log class and use it instead of CFBundleShortVersionString

### DIFF
--- a/FRAuth/FRAuth/Log/FRLog.swift
+++ b/FRAuth/FRAuth/Log/FRLog.swift
@@ -23,11 +23,7 @@ By default, FRLog uses OSLog to display the log entry in the debug console, and 
     /// Module name of FRLog
     static var ModuleName: String {
         get {
-            var versionStr = ""
-            if let version = Bundle(for: FRAuth.self).infoDictionary?["CFBundleShortVersionString"] as? String {
-                versionStr = "[\(version)]"
-            }
-            return "[FRAuth]" + versionStr
+            return "[FRAuth]" + "[\(FRCore.Log.sdkVersion)]"
         }
     }
     

--- a/FRAuth/FRAuth/Log/FRLog.swift
+++ b/FRAuth/FRAuth/Log/FRLog.swift
@@ -2,7 +2,7 @@
 //  FRLog.swift
 //  FRAuth
 //
-//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuthenticator/FRAuthenticator/Log/FRALog.swift
+++ b/FRAuthenticator/FRAuthenticator/Log/FRALog.swift
@@ -23,11 +23,7 @@ public struct FRALog {
     /// Module name of FRLog
     static var ModuleName: String {
         get {
-            var versionStr = ""
-            if let version = Bundle(for: FRAClient.self).infoDictionary?["CFBundleShortVersionString"] as? String {
-                versionStr = "[\(version)]"
-            }
-            return "[FRAuthenticator]" + versionStr
+            return "[FRAuthenticator]" + "[\(FRCore.Log.sdkVersion)]"
         }
     }
     

--- a/FRAuthenticator/FRAuthenticator/Log/FRALog.swift
+++ b/FRAuthenticator/FRAuthenticator/Log/FRALog.swift
@@ -2,7 +2,7 @@
 //  FRALog.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRCore/FRCore/Log/Log.swift
+++ b/FRCore/FRCore/Log/Log.swift
@@ -2,7 +2,7 @@
 //  Log.swift
 //  FRCore
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRCore/FRCore/Log/Log.swift
+++ b/FRCore/FRCore/Log/Log.swift
@@ -128,6 +128,8 @@ public class Log: NSObject {
     
     //  MARK: - Property
     
+    /// Current SDK version. We hard code it here as currently there is no other way to get it dinamically when used with SPM
+    public static let sdkVersion = "3.2.0"
     /// Current LogLevel
     static var logLevel: LogLevel = .none
     /// Current Loggers to handle log entries
@@ -137,11 +139,7 @@ public class Log: NSObject {
     /// Defuault module name of Log
     static var DefaultModuleName: String {
         get {
-            var versionStr = ""
-            if let version = Bundle(for: RestClient.self).infoDictionary?["CFBundleShortVersionString"] as? String {
-                versionStr = "[\(version)]"
-            }
-            return "[FRCore]" + versionStr
+            return "[FRCore]" + "[\(sdkVersion)]"
         }
     }
     

--- a/FRProximity/FRProximity/Log/FRPLog.swift
+++ b/FRProximity/FRProximity/Log/FRPLog.swift
@@ -2,7 +2,7 @@
 //  FRPLog.swift
 //  FRProximity
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRProximity/FRProximity/Log/FRPLog.swift
+++ b/FRProximity/FRProximity/Log/FRPLog.swift
@@ -22,11 +22,7 @@ public struct FRPLog {
     /// Module name of FRLog
     static var ModuleName: String {
         get {
-            var versionStr = ""
-            if let version = Bundle(for: FRProximity.self).infoDictionary?["CFBundleShortVersionString"] as? String {
-                versionStr = "[\(version)]"
-            }
-            return "[FRProximity]" + versionStr
+            return "[FRProximity]" + "[\(FRCore.Log.sdkVersion)]"
         }
     }
     


### PR DESCRIPTION
So the problem we had was that we were reading the SDK bundle version from CFBundleShortVersionString in Info.plist. This was working great with cocoapods as cocoapods creates a project for each module under the main workspace. In case of SPM, we have only one project and it gets the main app's version (which is not what we want).

I have tried a few things, like adding a variable to Package.swift and using it as a value in target's build settings (I followed the way google did in the signin package) and then trying to read it in Info.plist. But that didn't work at all.

I have also just tried to hardcode it in the Info.plist in each module, but then realized that we don't include the Info.plist files in the SPM package (we even explicitly exclude them). This also could have been the reason of my previous step not working at all.

One other version the internet was suggesting, was trying to read Package.resolved file and extract the version from there (even if I managed to do so, it wouldn't work if the package was imported by a branch name and not by a version).

So I have decided to hardcode the version as a static let in FRCore.Log class (in one place only) and use that value in all the bundles where we print the the SDK version. I know this is not ideal and requires an update with every release.