### PR TITLE
Sdks-1708_inject cookie to header instead of query param

### DIFF
--- a/FRAuth/FRAuth/Config/OAuth2Client.swift
+++ b/FRAuth/FRAuth/Config/OAuth2Client.swift
@@ -362,7 +362,6 @@ public class OAuth2Client: NSObject, Codable {
         //  Construct parameter for the request
         var parameter: [String: String] = [:]
         parameter[OAuth2.responseType] = OAuth2.code
-        parameter[self.serverConfig.cookieName] = ssoToken
         parameter[OAuth2.clientId] = self.clientId
         parameter[OAuth2.scope] = self.scope
         parameter[OAuth2.redirecUri] = self.redirectUri.absoluteString
@@ -377,6 +376,7 @@ public class OAuth2Client: NSObject, Codable {
         
         var header: [String: String] = [:]
         header[OpenAM.acceptAPIVersion] = OpenAM.apiResource21 + "," + OpenAM.apiProtocol10
+        header[self.serverConfig.cookieName] = ssoToken
         
         return Request(url: self.serverConfig.authorizeURL, method: .GET, headers: header, urlParams:parameter, requestType: .urlEncoded, responseType: .urlEncoded, timeoutInterval: self.serverConfig.timeout)
     }

--- a/FRAuth/FRAuth/Config/OAuth2Client.swift
+++ b/FRAuth/FRAuth/Config/OAuth2Client.swift
@@ -2,7 +2,7 @@
 //  OAuth2Client.swift
 //  FRAuth
 //
-//  Copyright (c) 2019-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.


### PR DESCRIPTION
Fix in OAuth2Client class to pass the cookie(sso token) as a header field, not a query param