### PR TITLE
Remove response header from /authorize GET call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## [Unreleased]
 #### Added
 - SSL Pinning Support [SDKS-1627]
+#### Changed
+- Remove "Accept: application/x-www-form-urlencoded" header from /authorize endpoint for GET requests [SDKS-1729]
 
 ## [3.2.0]
 #### Changed

--- a/FRAuth/FRAuth/Config/OAuth2Client.swift
+++ b/FRAuth/FRAuth/Config/OAuth2Client.swift
@@ -2,7 +2,7 @@
 //  OAuth2Client.swift
 //  FRAuth
 //
-//  Copyright (c) 2019-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/Config/OAuth2Client.swift
+++ b/FRAuth/FRAuth/Config/OAuth2Client.swift
@@ -378,7 +378,7 @@ public class OAuth2Client: NSObject, Codable {
         var header: [String: String] = [:]
         header[OpenAM.acceptAPIVersion] = OpenAM.apiResource21 + "," + OpenAM.apiProtocol10
         
-        return Request(url: self.serverConfig.authorizeURL, method: .GET, headers: header, urlParams:parameter, requestType: .urlEncoded, responseType: .urlEncoded, timeoutInterval: self.serverConfig.timeout)
+        return Request(url: self.serverConfig.authorizeURL, method: .GET, headers: header, urlParams:parameter, requestType: .urlEncoded, responseType: nil, timeoutInterval: self.serverConfig.timeout)
     }
     
     

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FRAuth/FRAuthTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FRAuth/FRAuthTests.swift
@@ -530,4 +530,28 @@ class FRAuthTests: FRAuthBaseTest {
         // It should
         XCTAssertNotNil(FRAuth.shared)
     }
+    
+    func testOAuth2ClientAuthorizeCallDoesntContainAcceptHeader() {
+        
+        // Given
+        FRAuth.configPlistFileName = "FRAuthConfig"
+        
+        // Then
+        do {
+            try FRAuth.start()
+        }
+        catch {
+            XCTFail("SDK Initialization failed: \(error.localizedDescription)")
+        }
+        
+        guard let frAuth = FRAuth.shared else {
+            XCTFail("FRAuth shared instance is returned nil")
+            return
+        }
+        XCTAssertNotNil(frAuth.oAuth2Client, "OAuth2Client should not be nil")
+        let request = frAuth.oAuth2Client?.buildAuthorizeRequest(ssoToken: "ssO_Token", pkce: PKCE()).build()
+        XCTAssertNotNil(request, "Request should not be nil")
+        XCTAssertNil(request?.value(forHTTPHeaderField:"Accept"), "Request should not contain Accept header")
+        
+    }
 }

--- a/FRCore/FRCore/Log/Log.swift
+++ b/FRCore/FRCore/Log/Log.swift
@@ -321,7 +321,7 @@ public class Log: NSObject {
         }
         
         var log = "Request | [\(request.method.rawValue)] " + request.url
-        log += "\n\tRequest Type: \(request.requestType.rawValue) | Response Type: \(request.responseType.rawValue) | Timeout Interval: \(request.timeoutInterval)"
+        log += "\n\tRequest Type: \(request.requestType.rawValue) | Response Type: \(request.responseType?.rawValue ?? "not set") | Timeout Interval: \(request.timeoutInterval)"
         
         if request.headers.keys.count > 0 {
             log += "\n\tAdditional Headers: \(request.headers)"

--- a/FRCore/FRCore/Network/Request.swift
+++ b/FRCore/FRCore/Network/Request.swift
@@ -53,7 +53,7 @@ public struct Request {
     /// URL parameters as dictionary
     public let urlParams: [String: String]
     /// Response type as `ContentType`; "Accept" header will be automatically added
-    public let responseType: ContentType
+    public let responseType: ContentType?
     /// Request type as `ContentType`; "Content-type" header will be automatically added
     public let requestType: ContentType
     /// Request timeout interval in second
@@ -73,7 +73,7 @@ public struct Request {
     ///   - requestType: ContentType of request content; enumeration value of `ContentType`
     ///   - responseType: ContentType of expected response content; enumeration value of `ContentType`
     ///   - timeoutInterval: Timeout interval in second for the request
-    public init(url: String, method: HTTPMethod, headers: [String: String] = [:], bodyParams: [String: Any] = [:], urlParams: [String: String] = [:], requestType: ContentType = .json, responseType: ContentType = .json, timeoutInterval: Double = 60) {
+    public init(url: String, method: HTTPMethod, headers: [String: String] = [:], bodyParams: [String: Any] = [:], urlParams: [String: String] = [:], requestType: ContentType = .json, responseType: ContentType? = .json, timeoutInterval: Double = 60) {
         self.url = url
         self.method = method
         self.headers = headers
@@ -123,8 +123,9 @@ public struct Request {
                
         //  Set Content-Type, and Accept headers based on request/response types
         thisRequest.setValue(self.requestType.rawValue, forHTTPHeaderField: "Content-Type")
-        thisRequest.setValue(self.responseType.rawValue, forHTTPHeaderField: "Accept")
-        
+        if let responseType = self.responseType {
+            thisRequest.setValue(responseType.rawValue, forHTTPHeaderField: "Accept")
+        }
         //  Add additional headers
         self.headers.forEach{ thisRequest.setValue($0.value, forHTTPHeaderField: $0.key) }
         //  Build http body content
@@ -162,7 +163,7 @@ public struct Request {
     /// Generates debug description string of `Request` instance
     var debugDescription: String {
         var desc = "Request: \(self.url) | \(self.method.rawValue) \r\n"
-        desc += "   Request Type: \(self.requestType.rawValue) | Response Type: \(self.responseType.rawValue) \r\n"
+        desc += "   Request Type: \(self.requestType.rawValue) | Response Type: \(self.responseType?.rawValue ?? "not set") \r\n"
         if self.urlParams.count > 0 {
             desc += "   URL Parameters: \r\n"
             self.urlParams.forEach{ desc += "       \($0.key): \($0.value) \r\n"}

--- a/FRCore/FRCore/Network/Request.swift
+++ b/FRCore/FRCore/Network/Request.swift
@@ -2,7 +2,7 @@
 //  Request.swift
 //  FRCore
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.


### PR DESCRIPTION
Remove _accept: application/x-www-form-urlencoded_ header from /authorize endpoint for GET requests

I checked Android SDK. They don't send any response header.