### PR TITLE
 Issues with registering TOTP accounts with invalid period

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - SSL Pinning Support [SDKS-1627]
 #### Changed
 - Remove "Accept: application/x-www-form-urlencoded" header from /authorize endpoint for GET requests [SDKS-1729]
+- Fix Issues with registering TOTP accounts with invalid period [SDKS-1405]
 
 ## [3.2.0]
 #### Changed

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/OathQRCodeParser.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/OathQRCodeParser.swift
@@ -93,9 +93,16 @@ struct OathQRCodeParser {
                     digitsValue = intVal
                 }
                 if item.name == "period" {
-                    if let strVal = item.value, let intVal = Int(strVal) {
-                        self.period = intVal
-                    }
+                    if let strVal = item.value {
+                        if let intVal = Int(strVal) {
+                            if intVal <= 0 {
+                                throw MechanismError.invalidInformation("refresh period was not a positive number")
+                            }
+                            self.period = intVal
+                        } else {
+                            throw MechanismError.invalidInformation("refresh period was not a number: \(strVal)")
+                        }
+                    } 
                 }
                 if item.name == "image", let imgUrl = item.value {
                     if let imgUrlDecodedData = imgUrl.decodeURL() {

--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/OathQRCodeParser.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/OathQRCodeParser.swift
@@ -2,7 +2,7 @@
 //  QRCodeParser.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Util/OathQRCodeParserTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Util/OathQRCodeParserTests.swift
@@ -2,7 +2,7 @@
 //  OathQRCodeParserTests.swift
 //  FRAuthenticatorTests
 //
-//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Util/OathQRCodeParserTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Util/OathQRCodeParserTests.swift
@@ -320,4 +320,51 @@ class OathQRCodeParserTests: FRABaseTests {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")
         }
     }
+    
+    func test_18_invalid_period() {
+        let qrCode = URL(string: "otpauth://totp/ForgeRock:demo?secret=T7SIIEPTZJQQDSCB&issuer=ForgeRock&digits=6&period=invalid")!
+        
+        do {
+            let _ = try OathQRCodeParser(url: qrCode)
+            XCTFail("Parsing success while expecting failure for invalid period")
+        }
+        catch MechanismError.invalidInformation {
+            
+        }
+        catch {
+            XCTFail("Failed to parse with unexpected error: \(error.localizedDescription)")
+        }
+    }
+    
+  
+    
+    func test_18_negative_period() {
+        let qrCode = URL(string: "otpauth://totp/ForgeRock:demo?secret=T7SIIEPTZJQQDSCB&issuer=ForgeRock&digits=6&period=-10")!
+        
+        do {
+            let _ = try OathQRCodeParser(url: qrCode)
+            XCTFail("Parsing success while expecting failure for negative period")
+        }
+        catch MechanismError.invalidInformation {
+            
+        }
+        catch {
+            XCTFail("Failed to parse with unexpected error: \(error.localizedDescription)")
+        }
+    }
+    
+    func test_19_zero_period() {
+        let qrCode = URL(string: "otpauth://totp/ForgeRock:demo?secret=T7SIIEPTZJQQDSCB&issuer=ForgeRock&digits=6&period=0")!
+        
+        do {
+            let _ = try OathQRCodeParser(url: qrCode)
+            XCTFail("Parsing success while expecting failure for zero period")
+        }
+        catch MechanismError.invalidInformation {
+            
+        }
+        catch {
+            XCTFail("Failed to parse with unexpected error: \(error.localizedDescription)")
+        }
+    }
 }


### PR DESCRIPTION
Add error checking for invalid and negative refresh periods in OathQRCodeParser. 
Add tests