### PR TITLE
Sdks 1491 expired push notification displayed as approved

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - SSL Pinning Support [SDKS-1627]
 #### Changed
 - Remove "Accept: application/x-www-form-urlencoded" header from /authorize endpoint for GET requests [SDKS-1729]
+- Fix issue when expired push notification displayed as "Approved" in the notification history list [SDKS-1491]
 
 ## [3.2.0]
 #### Changed

--- a/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
@@ -237,7 +237,7 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
     
     /// Handles PushNotification authentication process with given decision
     /// - Parameters:
-    ///   - result: Boolean indicator whether or not PushNotification authentication is approved or denied
+    ///   - approved: Boolean indicator whether or not PushNotification authentication is approved or denied
     ///   - onSuccess: successful completion callback
     ///   - onError: failure error callback
     func handleNotification(approved: Bool, onSuccess: @escaping SuccessCallback, onError: @escaping ErrorCallback) {

--- a/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
@@ -248,12 +248,7 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         }
         
         if let mechanism = FRAClient.storage.getMechanismForUUID(uuid: self.mechanismUUID) as? PushMechanism {
-            if FRAClient.storage.setNotification(notification: self) {
-                FRALog.v("New PushNotification object is stored into StorageClient")
-            }
-            else {
-                FRALog.e("Failed to save PushNotification object into StorageClient")
-            }
+            
             
             do {
                 let request = try buildPushAuthenticationRequest(approved: approved, mechanism: mechanism)
@@ -263,6 +258,12 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
                         self.approved = approved
                         self.pending = false
                         Log.i("PushNotification authentication was successful")
+                        if FRAClient.storage.setNotification(notification: self) {
+                            FRALog.v("New PushNotification object is stored into StorageClient")
+                        }
+                        else {
+                            FRALog.e("Failed to save PushNotification object into StorageClient")
+                        }
                         onSuccess()
                         break
                     case .failure(let error):

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Push/PushNotificationAuthenticationTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Push/PushNotificationAuthenticationTests.swift
@@ -2,7 +2,7 @@
 //  PushNotificationAuthenticationTests.swift
 //  FRAuthenticatorTests
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -119,7 +119,7 @@ class PushNotificationAuthenticationTests: FRABaseTests {
             
             let notification = try PushNotification(messageId: notificationMessageId, payload: notificationPayload)
 
-            let request = try notification.buildPushAuthenticationRequest(result: true, mechanism: mechanism)
+            let request = try notification.buildPushAuthenticationRequest(approved: true, mechanism: mechanism)
             
             let bodyPayload = request.bodyParams
             let messageId = bodyPayload["messageId"] as? String
@@ -171,7 +171,7 @@ class PushNotificationAuthenticationTests: FRABaseTests {
             
             let notification = try PushNotification(messageId: notificationMessageId, payload: notificationPayload)
 
-            let request = try notification.buildPushAuthenticationRequest(result: false, mechanism: mechanism)
+            let request = try notification.buildPushAuthenticationRequest(approved: false, mechanism: mechanism)
             
             let bodyPayload = request.bodyParams
             let messageId = bodyPayload["messageId"] as? String


### PR DESCRIPTION
Fix the bug when expired notification would show up as approved
Move saving notification to the storage to the request success block (similar to Android) - this also fixed the failing tests after the first commit