### PR TITLE
SDKS-1665 - Obtain timestamp from new Push Notification payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Apple Sign In enhancements to get user profile info [SDKS-1632]
 ## [Unreleased]
 #### Added
 - SSL Pinning Support [SDKS-1627]
+- Obtain timestamp from new Push Notification payload [SDKS-1665]
 #### Changed
 - Remove "Accept: application/x-www-form-urlencoded" header from /authorize endpoint for GET requests [SDKS-1729]
 - Fix issue when expired push notification displayed as "Approved" in the notification history list [SDKS-1491]

--- a/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
@@ -117,7 +117,11 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         self.ttl = ttlDouble
         self.mechanismUUID = mechanismUUID
         
-        self.timeAdded = Date()
+        if let intervalString = payload["i"] as? String, let interval = Int64(intervalString) {
+            self.timeAdded = Date(milliseconds: interval)
+        } else {
+            self.timeAdded = Date()
+        }
     }
     
     


### PR DESCRIPTION
Set _timeAdded_ from the new payload if available. Update and add unit tests

Please note that in iOS PushNotification doesn't have _timeExpired_ property. It has _isExpired_ property that is calculated based on _timeAdded_ and _ttl_

