### PR TITLE
Sdks 1775 add new payload attributes in the push notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Apple Sign In enhancements to get user profile info [SDKS-1632]
 #### Added
 - SSL Pinning Support [SDKS-1627]
 - Obtain timestamp from new Push Notification payload [SDKS-1665]
+- Add new payload attributes in the Push Notification [SDKS-1775]
 #### Changed
 - Remove "Accept: application/x-www-form-urlencoded" header from /authorize endpoint for GET requests [SDKS-1729]
 - Fix issue when expired push notification displayed as "Approved" in the notification history list [SDKS-1491]

--- a/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
@@ -33,6 +33,16 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
     var pending: Bool = true
     /// Boolean indicator of whether push notification is approved or not
     var approved: Bool = false
+    /// The JSON String containing the custom attributes added to this notification */
+    public internal(set) var customPayload: String?
+    /// Message that was received with this notification */
+    public internal(set) var message: String?
+    /// The type of push notification **/
+    public internal(set) var pushType: PushType
+    /// The numbers used in the push challenge **/
+    public internal(set) var numbersChallenge: String?
+    ///The context information to this notification. */
+    public internal(set) var contextInfo: String?
     
     
     //  MARK: - Public Properties
@@ -87,6 +97,11 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         case challenge
         case pending
         case approved
+        case customPayload
+        case message
+        case pushType
+        case numbersChallenge
+        case contextInfo
     }
     
     
@@ -122,6 +137,16 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         } else {
             self.timeAdded = Date()
         }
+        
+        self.customPayload = payload["p"] as? String
+        self.message = payload["m"] as? String
+        if let pushTypeString = payload["k"] as? String {
+            self.pushType = PushType(rawValue: pushTypeString) ?? PushType.default
+        } else {
+            self.pushType = PushType.default
+        }
+        self.numbersChallenge = payload["n"] as? String
+        self.contextInfo = payload["x"] as? String
     }
     
     
@@ -134,7 +159,12 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
     /// - Parameter timeAdded: Date when the notification is delivered
     /// - Parameter pending: Boolean indicator of whether or not current PushNotification is still in pending
     /// - Parameter approved: Boolean indicator of whether or not current PushNotification is already approved
-    init?(messageId: String?, challenge: String?, loadBalanceKey: String?, ttl: Double, mechanismUUID: String?, timeAdded: Double, pending: Bool, approved: Bool) {
+    /// - Parameter customPayload: JSON String containing the custom attributes
+    /// - Parameter message: message from  from APNS payload
+    /// - Parameter pushType: the type of push notification
+    /// - Parameter numbersChallenge: numbers used in the push challenge
+    /// - Parameter contextInfo: contextual information, such as location
+    init?(messageId: String?, challenge: String?, loadBalanceKey: String?, ttl: Double, mechanismUUID: String?, timeAdded: Double, pending: Bool, approved: Bool, customPayload: String?, message: String?, pushType: PushType, numbersChallenge: String?, contextInfo: String?) {
         
         guard let messageId = messageId, let challenge = challenge, let mechanismUUID = mechanismUUID else {
             return nil
@@ -148,6 +178,11 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         self.mechanismUUID = mechanismUUID
         self.pending = pending
         self.approved = approved
+        self.customPayload = customPayload
+        self.message = message
+        self.pushType = pushType
+        self.numbersChallenge = numbersChallenge
+        self.contextInfo = contextInfo
     }
     
     
@@ -165,6 +200,11 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         coder.encode(self.timeAdded.timeIntervalSince1970, forKey: "timeAdded")
         coder.encode(self.pending, forKey: "pending")
         coder.encode(self.approved, forKey: "approved")
+        coder.encode(self.customPayload, forKey: "customPayload")
+        coder.encode(self.message, forKey: "message")
+        coder.encode(self.pushType.rawValue, forKey: "pushType")
+        coder.encode(self.numbersChallenge, forKey: "numbersChallenge")
+        coder.encode(self.contextInfo, forKey: "contextInfo")
     }
     
     
@@ -178,8 +218,16 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         let timeAdded = coder.decodeDouble(forKey: "timeAdded") as Double
         let pending = coder.decodeBool(forKey: "pending") as Bool
         let approved = coder.decodeBool(forKey: "approved") as Bool
+        let customPayload = coder.decodeObject(of: NSString.self, forKey: "customPayload") as String?
+        let message = coder.decodeObject(of: NSString.self, forKey: "message") as String?
+        var pushType = PushType.default
+        if let pushTypeString = coder.decodeObject(of: NSString.self, forKey: "pushType") as? String {
+            pushType = PushType(rawValue: pushTypeString) ?? PushType.default
+        }
+        let numbersChallenge = coder.decodeObject(of: NSString.self, forKey: "numbersChallenge") as String?
+        let contextInfo = coder.decodeObject(of: NSString.self, forKey: "contextInfo") as String?
         
-        self.init(messageId: messageId, challenge: challenge, loadBalanceKey: loadBalanceKey, ttl: ttl, mechanismUUID: mechanismUUID, timeAdded: timeAdded, pending: pending, approved: approved)
+        self.init(messageId: messageId, challenge: challenge, loadBalanceKey: loadBalanceKey, ttl: ttl, mechanismUUID: mechanismUUID, timeAdded: timeAdded, pending: pending, approved: approved, customPayload: customPayload, message: message, pushType: pushType, numbersChallenge: numbersChallenge, contextInfo: contextInfo)
     }
     
     
@@ -197,6 +245,11 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         try container.encode(self.pending, forKey: .pending)
         try container.encode(self.approved, forKey: .approved)
         try container.encode(self.identifier, forKey: .identifier)
+        try container.encode(self.customPayload, forKey: .customPayload)
+        try container.encode(self.message, forKey: .message)
+        try container.encode(self.pushType, forKey: .pushType)
+        try container.encode(self.numbersChallenge, forKey: .numbersChallenge)
+        try container.encode(self.contextInfo, forKey: .contextInfo)
     }
 
     
@@ -212,8 +265,13 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         let approved = try values.decode(Bool.self, forKey: .approved)
         let milliseconds = try values.decode(Double.self, forKey: .timeAdded)
         let timeAdded = milliseconds / 1000
+        let customPayload = try values.decode(String.self, forKey: .customPayload)
+        let message = try values.decode(String.self, forKey: .message)
+        let pushType = try values.decode(PushType.self, forKey: .pushType)
+        let numbersChallenge = try values.decode(String.self, forKey: .numbersChallenge)
+        let contextInfo = try values.decode(String.self, forKey: .contextInfo)
 
-        self.init(messageId: messageId, challenge: challenge, loadBalanceKey: loadBalanceKey, ttl: ttl, mechanismUUID: mechanismUUID, timeAdded: timeAdded, pending: pending, approved: approved)!
+        self.init(messageId: messageId, challenge: challenge, loadBalanceKey: loadBalanceKey, ttl: ttl, mechanismUUID: mechanismUUID, timeAdded: timeAdded, pending: pending, approved: approved, customPayload: customPayload, message: message, pushType: pushType, numbersChallenge: numbersChallenge, contextInfo: contextInfo)!
     }
     
     
@@ -330,4 +388,10 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
             return nil
         }
     }
+}
+                  
+public enum PushType: String, Codable {
+    case `default`
+    case challenge
+    case biometric
 }

--- a/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
@@ -381,9 +381,11 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
     func buildPushAuthenticationRequest(challengeResponse: String? = nil, approved: Bool, mechanism: PushMechanism) throws -> Request {
         var payload: [String: CodableValue] = [:]
         payload[FRAConstants.response] = try CodableValue(Crypto.generatePushChallengeResponse(challenge: self.challenge, secret: mechanism.secret))
-        if self.pushType == .default && !approved {
+        if !approved {
             payload["deny"] = CodableValue(true)
-        } else if self.pushType == .challenge {
+        }
+        
+        if self.pushType == .challenge {
             payload["challengeResponse"] = CodableValue(challengeResponse)
         }
         

--- a/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
@@ -275,11 +275,11 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         let approved = try values.decode(Bool.self, forKey: .approved)
         let milliseconds = try values.decode(Double.self, forKey: .timeAdded)
         let timeAdded = milliseconds / 1000
-        let customPayload = try values.decode(String.self, forKey: .customPayload)
-        let message = try values.decode(String.self, forKey: .message)
-        let pushType = try values.decode(PushType.self, forKey: .pushType)
-        let numbersChallenge = try values.decode(String.self, forKey: .numbersChallenge)
-        let contextInfo = try values.decode(String.self, forKey: .contextInfo)
+        let customPayload = try? values.decode(String.self, forKey: .customPayload)
+        let message = try? values.decode(String.self, forKey: .message)
+        let pushType = (try? values.decode(PushType.self, forKey: .pushType)) ?? .default
+        let numbersChallenge = try? values.decode(String.self, forKey: .numbersChallenge)
+        let contextInfo = try? values.decode(String.self, forKey: .contextInfo)
 
         self.init(messageId: messageId, challenge: challenge, loadBalanceKey: loadBalanceKey, ttl: ttl, mechanismUUID: mechanismUUID, timeAdded: timeAdded, pending: pending, approved: approved, customPayload: customPayload, message: message, pushType: pushType, numbersChallenge: numbersChallenge, contextInfo: contextInfo)!
     }

--- a/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Notification/PushNotification.swift
@@ -82,6 +82,14 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         }
     }
     
+    ///numbers used for push challenge as int array
+    public var numbersChallengeArray: [Int]? {
+        guard numbersChallenge != nil else {
+            return nil
+        }
+        return numbersChallenge!.components(separatedBy: ",").compactMap { Int($0) }
+    }
+    
     
     // MARK: - Coding Keys
     
@@ -145,7 +153,9 @@ public class PushNotification: NSObject, NSSecureCoding, Codable {
         } else {
             self.pushType = PushType.default
         }
-        self.numbersChallenge = payload["n"] as? String
+        if self.pushType == .challenge {
+            self.numbersChallenge = payload["n"] as? String
+        }
         self.contextInfo = payload["x"] as? String
     }
     

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/NotificationTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Model/NotificationTests.swift
@@ -14,12 +14,33 @@ import XCTest
 class NotificationTests: FRABaseTests {
 
     var payload: [String: String] = ["c": "j4i8MSuGOcqfslLpRMsYWUMkfsZnsgTCcgNZ+WN3MEE=", "l": "YW1sYmNvb2tpZT0wMQ", "t": "120", "u": "026BE51C-3B14-456D-A0DF-DD460BB8B100", "i": "1629261902660"]
+    var newPayload: [String: String] = [
+        "c": "j4i8MSuGOcqfslLpRMsYWUMkfsZnsgTCcgNZ+WN3MEE=",
+        "l": "YW1sYmNvb2tpZT0wMQ",
+        "t": "120",
+        "u": "026BE51C-3B14-456D-A0DF-DD460BB8B100",
+        "i": "1629261902660",
+        "p": "{\"ipAddress\": \"9.9.9.9\"}",
+        "x": "{\"location\":{\"latitude\":49.2208569,\"longitude\":-123.1174431},\"userAgent\":\"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36\",\"platform\":\"MacIntel\"}",
+        "m": "Login attempt at ForgeRock",
+        "k": "challenge",
+        "n": "34,56,82"]
     let messageId = "AUTHENTICATE:e84233f8-9ecf-4456-91ad-2649c4103bc01569980570407"
     let c: String = "j4i8MSuGOcqfslLpRMsYWUMkfsZnsgTCcgNZ+WN3MEE="
     let l: String = "YW1sYmNvb2tpZT0wMQ"
     let t: Double = 120
     let u: String = "026BE51C-3B14-456D-A0DF-DD460BB8B100"
     let i: Int64 = 1629261902660
+    let p: String =  """
+    {"ipAddress": "9.9.9.9"}
+    """
+    let x: String =  """
+{"location":{"latitude":49.2208569,"longitude":-123.1174431},"userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/100.0.4896.127 Safari/537.36","platform":"MacIntel"}
+"""
+    let m: String = "Login attempt at ForgeRock"
+    let k: String = "challenge"
+    let n: String = "34,56,82"
+    let numbersChallengeArray: [Int] = [34,56,82]
     
     func test_01_notification_init_success() {
         do {
@@ -30,6 +51,33 @@ class NotificationTests: FRABaseTests {
             XCTAssertEqual(notification.ttl, t)
             XCTAssertEqual(notification.mechanismUUID, u)
             XCTAssertEqual(notification.timeAdded, Date(milliseconds: i))
+            XCTAssertNil(notification.customPayload)
+            XCTAssertNil(notification.message)
+            XCTAssertEqual(notification.pushType, PushType.default)
+            XCTAssertNil(notification.numbersChallenge)
+            XCTAssertNil(notification.contextInfo)
+        }
+        catch {
+            XCTFail("Failed with unexpected error: \(error.localizedDescription)")
+        }
+    }
+    
+    
+    func test_01_1_notification_new_payload_init_success() {
+        do {
+            let notification = try PushNotification(messageId: messageId, payload: newPayload)
+            XCTAssertNotNil(notification)
+            XCTAssertEqual(notification.challenge, c)
+            XCTAssertEqual(notification.loadBalanceKey, "amlbcookie=01")
+            XCTAssertEqual(notification.ttl, t)
+            XCTAssertEqual(notification.mechanismUUID, u)
+            XCTAssertEqual(notification.timeAdded, Date(milliseconds: i))
+            XCTAssertEqual(notification.customPayload, p)
+            XCTAssertEqual(notification.message, m)
+            XCTAssertEqual(notification.pushType, PushType(rawValue: k))
+            XCTAssertEqual(notification.numbersChallenge, n)
+            XCTAssertEqual(notification.contextInfo, x)
+            
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")
@@ -238,6 +286,52 @@ class NotificationTests: FRABaseTests {
     }
     
     
+    func test_10_1_notification_archive_obj_with_new_payload() {
+        do {
+            let notification = try PushNotification(messageId: messageId, payload: newPayload)
+            XCTAssertNotNil(notification)
+
+            if #available(iOS 11.0, *) {
+                if let notificationData = try? NSKeyedArchiver.archivedData(withRootObject: notification, requiringSecureCoding: true) {
+                    let notificationFromData = NSKeyedUnarchiver.unarchiveObject(with: notificationData) as? PushNotification
+                    XCTAssertEqual(notification.messageId, notificationFromData?.messageId)
+                    XCTAssertEqual(notification.challenge, notificationFromData?.challenge)
+                    XCTAssertEqual(notification.loadBalanceKey, notificationFromData?.loadBalanceKey)
+                    XCTAssertEqual(notification.ttl, notificationFromData?.ttl)
+                    XCTAssertEqual(notification.mechanismUUID, notificationFromData?.mechanismUUID)
+                    XCTAssertEqual(notification.timeAdded.timeIntervalSince1970, notificationFromData?.timeAdded.timeIntervalSince1970)
+                    XCTAssertEqual(notification.customPayload, notificationFromData?.customPayload)
+                    XCTAssertEqual(notification.message, notificationFromData?.message)
+                    XCTAssertEqual(notification.pushType, notificationFromData?.pushType)
+                    XCTAssertEqual(notification.numbersChallenge, notificationFromData?.numbersChallenge)
+                    XCTAssertEqual(notification.contextInfo, notificationFromData?.contextInfo)
+                }
+                else {
+                    XCTFail("Failed to serialize PushNotification object with Secure Coding")
+                }
+            } else {
+                let notificationData = NSKeyedArchiver.archivedData(withRootObject: notification)
+                let notificationFromData = NSKeyedUnarchiver.unarchiveObject(with: notificationData) as? PushNotification
+                
+                XCTAssertEqual(notification.messageId, notificationFromData?.messageId)
+                XCTAssertEqual(notification.challenge, notificationFromData?.challenge)
+                XCTAssertEqual(notification.loadBalanceKey, notificationFromData?.loadBalanceKey)
+                XCTAssertEqual(notification.ttl, notificationFromData?.ttl)
+                XCTAssertEqual(notification.mechanismUUID, notificationFromData?.mechanismUUID)
+                XCTAssertEqual(notification.timeAdded.timeIntervalSince1970, notificationFromData?.timeAdded.timeIntervalSince1970)
+                XCTAssertEqual(notification.customPayload, notificationFromData?.customPayload)
+                XCTAssertEqual(notification.message, notificationFromData?.message)
+                XCTAssertEqual(notification.pushType, notificationFromData?.pushType)
+                XCTAssertEqual(notification.numbersChallenge, notificationFromData?.numbersChallenge)
+                XCTAssertEqual(notification.contextInfo, notificationFromData?.contextInfo)
+            }
+        }
+        catch {
+            XCTFail("Failed with unexpected error: \(error.localizedDescription)")
+        }
+    }
+    
+    
     func test_11_codable_serialization() {
         do {
             let notification = try PushNotification(messageId: messageId, payload: payload)
@@ -262,6 +356,36 @@ class NotificationTests: FRABaseTests {
         }
     }
     
+    
+    func test_11_1_codable_serialization_with_new_payload() {
+        do {
+            let notification = try PushNotification(messageId: messageId, payload: newPayload)
+            XCTAssertNotNil(notification)
+            
+            //  Encode
+            let encodedData = try JSONEncoder().encode(notification)
+            
+            //  Decode
+            let decodedNotification = try JSONDecoder().decode(PushNotification.self, from: encodedData)
+            
+            //  Then
+            XCTAssertEqual(notification.messageId, decodedNotification.messageId)
+            XCTAssertEqual(notification.challenge, decodedNotification.challenge)
+            XCTAssertEqual(notification.loadBalanceKey, decodedNotification.loadBalanceKey)
+            XCTAssertEqual(notification.ttl, decodedNotification.ttl)
+            XCTAssertEqual(notification.mechanismUUID, decodedNotification.mechanismUUID)
+            XCTAssertEqual(notification.timeAdded.millisecondsSince1970, decodedNotification.timeAdded.millisecondsSince1970)
+            XCTAssertEqual(notification.customPayload, decodedNotification.customPayload)
+            XCTAssertEqual(notification.message, decodedNotification.message)
+            XCTAssertEqual(notification.pushType, decodedNotification.pushType)
+            XCTAssertEqual(notification.numbersChallenge, decodedNotification.numbersChallenge)
+            XCTAssertEqual(notification.contextInfo, decodedNotification.contextInfo)
+        }
+        catch {
+            XCTFail("Failed with unexpected error: \(error.localizedDescription)")
+        }
+    }
+
     
     func test_12_json_string_serialization() {
         do {
@@ -294,6 +418,42 @@ class NotificationTests: FRABaseTests {
     }
     
     
+    func test_12_1_json_string_serialization_with_new_payload() {
+        do {
+            let notification = try PushNotification(messageId: messageId, payload: newPayload)
+            XCTAssertNotNil(notification)
+            
+            guard let jsonString = notification.toJson() else {
+                XCTFail("Failed to serialize the object into JSON String value")
+                return
+            }
+            
+            //  Covert jsonString to Dictionary
+            let jsonDictionary = FRJSONEncoder.jsonStringToDictionary(jsonString: jsonString)
+            
+            //  Then
+            XCTAssertEqual(notification.identifier, jsonDictionary?["id"] as! String)
+            XCTAssertEqual(notification.messageId, jsonDictionary?["messageId"] as! String)
+            XCTAssertEqual(notification.challenge, jsonDictionary?["challenge"] as! String)
+            XCTAssertEqual(notification.loadBalanceKey, jsonDictionary?["amlbCookie"] as? String)
+            XCTAssertEqual(notification.ttl, jsonDictionary?["ttl"] as! Double)
+            XCTAssertEqual(notification.mechanismUUID, jsonDictionary?["mechanismUID"] as! String)
+            XCTAssertEqual(notification.approved, jsonDictionary?["approved"] as! Bool)
+            XCTAssertEqual(notification.pending, jsonDictionary?["pending"] as! Bool)
+            XCTAssertEqual(notification.timeAdded.millisecondsSince1970, jsonDictionary?["timeAdded"] as! Int64)
+            XCTAssertEqual(notification.timeAdded.millisecondsSince1970 + Int64(notification.ttl * 1000), jsonDictionary?["timeExpired"] as! Int64)
+            XCTAssertEqual(notification.customPayload, jsonDictionary?["customPayload"] as? String)
+            XCTAssertEqual(notification.message, jsonDictionary?["message"] as? String)
+            XCTAssertEqual(notification.pushType, PushType(rawValue:  jsonDictionary?["pushType"] as! String))
+            XCTAssertEqual(notification.numbersChallenge, jsonDictionary?["numbersChallenge"] as? String)
+            XCTAssertEqual(notification.contextInfo, jsonDictionary?["contextInfo"] as? String)
+        }
+        catch {
+            XCTFail("Failed with unexpected error: \(error.localizedDescription)")
+        }
+    }
+    
+    
     func test13_notification_init_missing_interval() {
         do {
             payload.removeValue(forKey: "i")
@@ -317,6 +477,41 @@ class NotificationTests: FRABaseTests {
             XCTAssertNotEqual(notification.timeAdded, Date(milliseconds: i))
             XCTAssertNotNil(notification.timeAdded)
             XCTAssertGreaterThan(notification.timeAdded, Date() - 10)
+        }
+        catch {
+            XCTFail("Failed with unexpected error: \(error.localizedDescription)")
+        }
+    }
+    
+    func test_15_notification_numbers_challenge_array() {
+        do {
+            let notification = try PushNotification(messageId: messageId, payload: newPayload)
+            XCTAssertNotNil(notification)
+            XCTAssertEqual(notification.numbersChallengeArray, numbersChallengeArray)
+        }
+        catch {
+            XCTFail("Failed with unexpected error: \(error.localizedDescription)")
+        }
+    }
+    
+    func test_16_init_with_no_pushtype() {
+        do {
+            newPayload.removeValue(forKey: "k")
+            let notification = try PushNotification(messageId: messageId, payload: newPayload)
+            XCTAssertNotNil(notification)
+            XCTAssertEqual(notification.pushType, PushType.default)
+        }
+        catch {
+            XCTFail("Failed with unexpected error: \(error.localizedDescription)")
+        }
+    }
+    
+    func test_17_init_with_invalid_pushtype() {
+        do {
+            newPayload["k"] = "invalid"
+            let notification = try PushNotification(messageId: messageId, payload: newPayload)
+            XCTAssertNotNil(notification)
+            XCTAssertEqual(notification.pushType, PushType.default)
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")


### PR DESCRIPTION
Unit Tests implemented too. Please rereview 

[Add new properties to PushNotification, handle init, encoding/decoding](https://github.com/ForgeRock/forgerock-ios-sdk/commit/d53bb594aa4cad626603877b96486e1ebacc3d71)
[Add numbersChallengeArray that returns int array](https://github.com/ForgeRock/forgerock-ios-sdk/commit/412bc7121a857f2275593669fe740cf1fba36e84)
[Add new accept with challengeResponse method. Modify push handling notification to consider challenge type](https://github.com/ForgeRock/forgerock-ios-sdk/commit/aabc4dd1fc1b8bb006f58d4f57891f15d51aa82c) 
[Update changelog. Remove the check for pushtype if push is denied](https://github.com/ForgeRock/forgerock-ios-sdk/pull/131/commits/6c8548943614dea6c947a9655e60d5618cec39f3)
[Make decoding of newaly added properties optional for backwards compatibility](https://github.com/ForgeRock/forgerock-ios-sdk/pull/131/commits/1b25416b8ff07f8e9a1ba129c8437e167b5b8051) 
[Add unit tests for PushNotification changes. Test the new attributes of the payload](https://github.com/ForgeRock/forgerock-ios-sdk/pull/131/commits/665a8d37be55decc7054d505c943c18d6e6aed74) 
