### PR TITLE
SDKS-1826 Remove the example item from forgerock_ssl_pinning_public_key_hashes 

### DIFF
--- a/SampleApps/FRExample/FRExample/Configs/FRAuthConfig.plist
+++ b/SampleApps/FRExample/FRExample/Configs/FRAuthConfig.plist
@@ -3,9 +3,7 @@
 <plist version="1.0">
 <dict>
 	<key>forgerock_ssl_pinning_public_key_hashes</key>
-	<array>
-		<string>[Cert key hash]</string>
-	</array>
+	<array/>
 	<key>forgerock_cookie_name</key>
 	<string>iPlanetDirectoryPro</string>
 	<key>forgerock_enable_cookie</key>


### PR DESCRIPTION
Remove the example item from forgerock_ssl_pinning_public_key_hashes  array in the sample app's plist