### PR TITLE
SDKS-1408 Discrepancies between Android and iOS behavior upon registering OATH account (Issuer param)

### DIFF
--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/OathQRCodeParser.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/OATH/OathQRCodeParser.swift
@@ -118,7 +118,7 @@ struct OathQRCodeParser {
                 if item.name == "b" {
                     self.backgroundColor = item.value
                 }
-                if item.name == "issuer", let strVal = item.value, self.issuer.count == 0 {
+                if item.name == "issuer", let strVal = item.value {
                     self.issuer = strVal
                 }
             }

--- a/FRAuthenticator/FRAuthenticatorTests/E2ETests/AuthenticatorManager/AuthenticatorManagerTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/E2ETests/AuthenticatorManager/AuthenticatorManagerTests.swift
@@ -2,7 +2,7 @@
 //  AuthenticatorManager.swift
 //  FRAuthenticatorTests
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -272,7 +272,7 @@ class AuthenticatorManagerTests: FRABaseTests {
         do {
             let mechanism = try authenticatorManager.storeOathQRCode(uri: qrCode)
             XCTAssertNotNil(mechanism)
-            let accountFromStorage = authenticatorManager.getAccount(identifier: "Forgerock-demo")
+            let accountFromStorage = authenticatorManager.getAccount(identifier: "ForgeRock-demo")
             XCTAssertNotNil(accountFromStorage)
             XCTAssertNotNil(accountFromStorage?.mechanisms)
             XCTAssertEqual(accountFromStorage?.mechanisms.count, 1)
@@ -315,7 +315,7 @@ class AuthenticatorManagerTests: FRABaseTests {
         do {
             let mechanism = try authenticatorManager.storeOathQRCode(uri: qrCode)
             XCTAssertNotNil(mechanism)
-            let accountFromStorage = authenticatorManager.getAccount(identifier: "Forgerock-demo")
+            let accountFromStorage = authenticatorManager.getAccount(identifier: "ForgeRock-demo")
             XCTAssertNotNil(accountFromStorage)
             XCTAssertNotNil(accountFromStorage?.mechanisms)
             XCTAssertEqual(accountFromStorage?.mechanisms.count, 1)
@@ -325,7 +325,7 @@ class AuthenticatorManagerTests: FRABaseTests {
             XCTFail("AuthenticatorManager.storeOathQRCode with duplicated Mechanism was expected to fail; but somehow passed")
         }
         catch MechanismError.alreadyExists(let message) {
-            XCTAssertEqual(message, "Forgerock-demo-totp")
+            XCTAssertEqual(message, "ForgeRock-demo-totp")
         }
         catch {
             XCTFail("AuthenticatorManager.storeOathQRCode with TOTP QR Code failed with unexpected reason")

--- a/FRAuthenticator/FRAuthenticatorTests/E2ETests/FRAClient/FRAClientTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/E2ETests/FRAClient/FRAClientTests.swift
@@ -2,7 +2,7 @@
 //  FRAClientTests.swift
 //  FRAuthenticatorTests
 //
-//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -51,7 +51,7 @@ class FRAClientTests: FRABaseTests {
         self.shouldCleanup = false
         
         // Given
-        let hotp = URL(string: "otpauth://hotp/Forgerock:demo?secret=IJQWIZ3FOIQUEYLE&issuer=Forgerock&counter=4&algorithm=SHA256")!
+        let hotp = URL(string: "otpauth://hotp/Forgerock:demo?secret=IJQWIZ3FOIQUEYLE&issuer=ForgeRock&counter=4&algorithm=SHA256")!
         let totp = URL(string: "otpauth://totp/Forgerock:demo?secret=T7SIIEPTZJQQDSCB&issuer=ForgeRock&digits=6&period=30")!
         
         do {
@@ -69,8 +69,8 @@ class FRAClientTests: FRABaseTests {
             waitForExpectations(timeout: 60, handler: nil)
             
             XCTAssertEqual(FRAClient.shared?.getAllAccounts().count, 1)
-            XCTAssertNotNil(FRAClient.shared?.getAccount(identifier: "Forgerock-demo"))
-            XCTAssertEqual(FRAClient.shared?.getAccount(identifier: "Forgerock-demo")?.mechanisms.count, 1)
+            XCTAssertNotNil(FRAClient.shared?.getAccount(identifier: "ForgeRock-demo"))
+            XCTAssertEqual(FRAClient.shared?.getAccount(identifier: "ForgeRock-demo")?.mechanisms.count, 1)
             
             //  Store second Mechanism under same Account
             ex = self.expectation(description: "FRAClient.createMechanismFromUri")
@@ -83,8 +83,8 @@ class FRAClientTests: FRABaseTests {
             waitForExpectations(timeout: 60, handler: nil)
             
             XCTAssertEqual(FRAClient.shared?.getAllAccounts().count, 1)
-            XCTAssertNotNil(FRAClient.shared?.getAccount(identifier: "Forgerock-demo"))
-            XCTAssertEqual(FRAClient.shared?.getAccount(identifier: "Forgerock-demo")?.mechanisms.count, 2)
+            XCTAssertNotNil(FRAClient.shared?.getAccount(identifier: "ForgeRock-demo"))
+            XCTAssertEqual(FRAClient.shared?.getAccount(identifier: "ForgeRock-demo")?.mechanisms.count, 2)
             
             
             //  Store same TOTPMechanism under same Account
@@ -96,7 +96,7 @@ class FRAClientTests: FRABaseTests {
             }, onError: { (error) in
                 switch error {
                 case MechanismError.alreadyExists(let message):
-                    XCTAssertEqual(message, "Forgerock-demo-totp")
+                    XCTAssertEqual(message, "ForgeRock-demo-totp")
                     break
                 default:
                     XCTFail("FRAClient.createMechanismFromUri failed with unexpected reason: \(error.localizedDescription)")
@@ -108,7 +108,7 @@ class FRAClientTests: FRABaseTests {
             
             
             //  Store same HOTPMechanism under same Account
-            let hotp2 = URL(string: "otpauth://hotp/Forgerock:demo?secret=T7SIIEPTZJQQDSCB&issuer=Forgerock&counter=4&algorithm=SHA256")!
+            let hotp2 = URL(string: "otpauth://hotp/Forgerock:demo?secret=T7SIIEPTZJQQDSCB&issuer=ForgeRock&counter=4&algorithm=SHA256")!
             ex = self.expectation(description: "FRAClient.createMechanismFromUri")
             FRAClient.shared?.createMechanismFromUri(uri: hotp2, onSuccess: { (mechanism) in
                 XCTFail("FRAClient.createMechanismFromUri was expected to fail for duplication; but somehow passed")
@@ -116,7 +116,7 @@ class FRAClientTests: FRABaseTests {
             }, onError: { (error) in
                 switch error {
                 case MechanismError.alreadyExists(let message):
-                    XCTAssertEqual(message, "Forgerock-demo-hotp")
+                    XCTAssertEqual(message, "ForgeRock-demo-hotp")
                     break
                 default:
                     XCTFail("FRAClient.createMechanismFromUri failed with unexpected reason: \(error.localizedDescription)")
@@ -127,12 +127,12 @@ class FRAClientTests: FRABaseTests {
             waitForExpectations(timeout: 60, handler: nil)
             
             XCTAssertEqual(FRAClient.shared?.getAllAccounts().count, 1)
-            XCTAssertNotNil(FRAClient.shared?.getAccount(identifier: "Forgerock-demo"))
-            XCTAssertEqual(FRAClient.shared?.getAccount(identifier: "Forgerock-demo")?.mechanisms.count, 2)
+            XCTAssertNotNil(FRAClient.shared?.getAccount(identifier: "ForgeRock-demo"))
+            XCTAssertEqual(FRAClient.shared?.getAccount(identifier: "ForgeRock-demo")?.mechanisms.count, 2)
             
             
             //  Store another Mechanism under different Account
-            let diff = URL(string: "otpauth://totp/ForgeRockSandbox:demo?secret=T7SIIEPTZJQQDSCB&issuer=ForgeRock&digits=6&period=30")!
+            let diff = URL(string: "otpauth://totp/ForgeRock:demo?secret=T7SIIEPTZJQQDSCB&issuer=ForgeRockSandbox&digits=6&period=30")!
             ex = self.expectation(description: "FRAClient.createMechanismFromUri")
             FRAClient.shared?.createMechanismFromUri(uri: diff, onSuccess: { (mechanism) in
                 ex.fulfill()
@@ -143,8 +143,8 @@ class FRAClientTests: FRABaseTests {
             waitForExpectations(timeout: 60, handler: nil)
                         
             XCTAssertEqual(FRAClient.shared?.getAllAccounts().count, 2)
-            XCTAssertNotNil(FRAClient.shared?.getAccount(identifier: "Forgerock-demo"))
-            XCTAssertEqual(FRAClient.shared?.getAccount(identifier: "Forgerock-demo")?.mechanisms.count, 2)
+            XCTAssertNotNil(FRAClient.shared?.getAccount(identifier: "ForgeRock-demo"))
+            XCTAssertEqual(FRAClient.shared?.getAccount(identifier: "ForgeRock-demo")?.mechanisms.count, 2)
             XCTAssertNotNil(FRAClient.shared?.getAccount(identifier: "ForgeRockSandbox-demo"))
             XCTAssertEqual(FRAClient.shared?.getAccount(identifier: "ForgeRockSandbox-demo")?.mechanisms.count, 1)
         }
@@ -164,8 +164,8 @@ class FRAClientTests: FRABaseTests {
         
         //  Make sure all results were persisted from previous test
         XCTAssertEqual(fraClient.getAllAccounts().count, 2)
-        XCTAssertNotNil(fraClient.getAccount(identifier: "Forgerock-demo"))
-        XCTAssertEqual(fraClient.getAccount(identifier: "Forgerock-demo")?.mechanisms.count, 2)
+        XCTAssertNotNil(fraClient.getAccount(identifier: "ForgeRock-demo"))
+        XCTAssertEqual(fraClient.getAccount(identifier: "ForgeRock-demo")?.mechanisms.count, 2)
         XCTAssertNotNil(fraClient.getAccount(identifier: "ForgeRockSandbox-demo"))
         XCTAssertEqual(fraClient.getAccount(identifier: "ForgeRockSandbox-demo")?.mechanisms.count, 1)
         
@@ -177,20 +177,20 @@ class FRAClientTests: FRABaseTests {
         XCTAssertTrue(fraClient.removeAccount(account: account1))
         //  Then
         XCTAssertEqual(fraClient.getAllAccounts().count, 1)
-        XCTAssertNotNil(fraClient.getAccount(identifier: "Forgerock-demo"))
-        XCTAssertEqual(fraClient.getAccount(identifier: "Forgerock-demo")?.mechanisms.count, 2)
+        XCTAssertNotNil(fraClient.getAccount(identifier: "ForgeRock-demo"))
+        XCTAssertEqual(fraClient.getAccount(identifier: "ForgeRock-demo")?.mechanisms.count, 2)
         XCTAssertNil(fraClient.getAccount(identifier: "ForgeRockSandbox-demo"))
         XCTAssertEqual(storageClient.defaultStorageClient.accountStorage.allItems()?.count, 1)
         XCTAssertEqual(storageClient.defaultStorageClient.mechanismStorage.allItems()?.count, 2)
         
         //  When
-        guard let account2 = fraClient.getAccount(identifier: "Forgerock-demo") else {
+        guard let account2 = fraClient.getAccount(identifier: "ForgeRock-demo") else {
             XCTFail("Failed to retrieve already stored Account object")
             return
         }
         XCTAssertTrue(fraClient.removeAccount(account: account2))
         XCTAssertNil(fraClient.getAccount(identifier: "ForgeRockSandbox-demo"))
-        XCTAssertNil(fraClient.getAccount(identifier: "Forgerock-demo"))
+        XCTAssertNil(fraClient.getAccount(identifier: "ForgeRock-demo"))
         XCTAssertEqual(storageClient.defaultStorageClient.accountStorage.allItems()?.count, 0)
         XCTAssertEqual(storageClient.defaultStorageClient.mechanismStorage.allItems()?.count, 0)
     }

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Util/OathQRCodeParserTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Util/OathQRCodeParserTests.swift
@@ -367,4 +367,18 @@ class OathQRCodeParserTests: FRABaseTests {
             XCTFail("Failed to parse with unexpected error: \(error.localizedDescription)")
         }
     }
+    
+    func test_20_totp_identity_with_issuer() {
+        let qrCode = URL(string: "otpauth://totp/ForgeRock:demo?period=30&b=032b75&digits=6&secret=X6KUBOXCEZXMBR6IWB5MES5BPQ======&issuer=ACME")!
+        
+        do {
+            let parser = try OathQRCodeParser(url: qrCode)
+            XCTAssertEqual(parser.issuer, "ACME")
+            XCTAssertEqual(parser.label, "demo")
+        }
+        catch {
+            XCTFail("Failed with unexpected error: \(error.localizedDescription)")
+        }
+    }
+    
 }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-1408](https://bugster.forgerock.org/jira/browse/SDKS-1408) Discrepancies between Android and iOS behavior upon registering OATH account (Issuer param)

# Description

While registering a new mechanism,  if "issuer" is provided as query parameter of the URI and isn't empty, it should replace the issuer in the path.

# Definition of Done Checklist:

- [x] Acceptance criteria is met.
- [x] All tasks listed in the user story have been completed.
- [x] Coded to standards.
- [x] Ensure backward compatibility.
- [x] API reference docs is updated.
- [x] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] contains example code snippets.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).