### PR TITLE
SDKS-2083-Restarting the SDK with the same configuration logs out the current user

### DIFF
--- a/FRAuth/FRAuth/Config/FROptions.swift
+++ b/FRAuth/FRAuth/Config/FROptions.swift
@@ -202,7 +202,8 @@ public class FROptions: NSObject, Codable {
                 lhs.cookieName == rhs.cookieName &&
                 lhs.oauthClientId == rhs.oauthClientId &&
                 lhs.oauthScope == rhs.oauthScope &&
-                lhs.oauthRedirectUri == rhs.oauthRedirectUri)
+                lhs.oauthRedirectUri == rhs.oauthRedirectUri &&
+                lhs.keychainAccessGroup == rhs.keychainAccessGroup)
     }
 }
 

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FROptions/FROptionsTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FROptions/FROptionsTests.swift
@@ -152,8 +152,9 @@ class FROptionsTests: FRAuthBaseTest {
             let updatedOptions = FROptions(url: "https://sdkapp.example.com/", realm: "alpha", enableCookie: false, cookieName: "CookieName", timeout: "35", authenticateEndpoint: "json/authenticate", authorizeEndpoint: "json/authorize", tokenEndpoint: "json/accessToken", revokeEndpoint: "json/revoke", userinfoEndpoint: "json/userinfo", sessionEndpoint: "json/session", authServiceName: "LoginTest", registrationServiceName: "RegisterTest", oauthThreshold: "62", oauthClientId: "iOSClient", oauthRedirectUri: "frauth://com.forgerock.ios", oauthScope: "openid email address", keychainAccessGroup: "com.bitbar.*", sslPinningPublicKeyHashes: ["hash1", "hash2"])
             
             self.dictionaryMatches(options: updatedOptions)
+            XCTAssertFalse(options == updatedOptions)
             try FRAuth.start(options: updatedOptions)
-    
+            
             XCTAssertNotNil(frAuth)
             self.dictionaryMatches(options: frAuth!.options!)
             self.frAuthInternalValuesCheck(updatedOptions: updatedOptions)
@@ -200,11 +201,30 @@ class FROptionsTests: FRAuthBaseTest {
                                 oauthRedirectUri: "frauth://com.forgerock.ios.frexample",
                                 oauthScope: "openid profile email address")
         
+        let optionsF = FROptions(url: "https://openam-forgerock-sdks/am",
+                                realm: "alpha",
+                                authServiceName: "Login",
+                                registrationServiceName: "Register",
+                                oauthClientId: "jsClient",
+                                oauthRedirectUri: "frauth://com.forgerock.ios.frexample",
+                                oauthScope: "openid profile email address",
+                                keychainAccessGroup: "com.bitbar.*")
+        
+        let optionsG = FROptions(url: "https://openam-forgerock-sdks/am",
+                                realm: "alpha",
+                                authServiceName: "Login",
+                                registrationServiceName: "Register",
+                                oauthClientId: "jsClient",
+                                oauthRedirectUri: "frauth://com.forgerock.ios.frexample",
+                                oauthScope: "openid profile email address",
+                                keychainAccessGroup: "com.bitbar.example")
+        
         XCTAssertTrue(optionsA == optionsB)
         XCTAssertFalse(optionsA == optionsC)
         XCTAssertFalse(optionsB == optionsC)
         XCTAssertFalse(optionsA == optionsD)
         XCTAssertFalse(optionsA == optionsE)
+        XCTAssertFalse(optionsF == optionsG)
     }
     
     func testInitWithConfig() {


### PR DESCRIPTION
Added the kychainAccessGroup in the comparison for equality of FROptions and fixed an issue with the SDK revoking tokens when the same configuration is started within an app session

# JIRA Ticket

Please, link jira ticket here.

# Description

Briefly describe the change and any information that would help speedup the review and testing process.

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] Example code snippets have been added.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).