### PR TITLE
Added workflow for triggering the e2e tests against IDCloud instance.

### DIFF
--- a/.github/workflows/run-live-tests.yaml
+++ b/.github/workflows/run-live-tests.yaml
@@ -1,0 +1,70 @@
+name: Run Live Tests
+on:
+  workflow_dispatch:
+    inputs:
+      am-url:
+        description: The AM url to run live test cases against
+        type: string
+        required: true
+        default: https://openam-forgerrock-sdksteanant.forgeblocks.com/am
+      realm:
+        description: The AM realm to use
+        type: string
+        required: true
+        default: alpha
+      cookie-name:
+        description: The AM session cookie name
+        type: string
+        required: true
+        default: iPlanetDirectoryPro
+  
+jobs:
+  run-live-tests:
+    runs-on: macos-12
+
+    steps:
+      # Clone the repo
+      - name: Clone the repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      # Replace forgerock_url, forgerock_realm, and forgerock_cookie_name values in config-live-01.json
+      - name: Setup values in config-live-01.json
+        run: |
+          amURL=$(echo ${{ inputs.am-url }} | sed 's/\//\\\//g')
+          echo $amURL
+          sed -i -r "s/\(\"forgerock_url\":\).*/\1 \"$amURL\",/" "FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config-live-01.json"
+          sed -i -r "s/\(\"forgerock_oauth_url\":\).*/\1 \"$amURL\",/" "FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config-live-01.json"
+          sed -i -r "s/\(\"forgerock_cookie_name\":\).*/\1 \"${{ inputs.cookie-name }}\",/" "FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config-live-01.json"
+          sed -i -r "s/\(\"forgerock_realm\":\).*/\1 \"${{ inputs.realm }}\",/" "FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config-live-01.json"
+          sed -i -r "s/\(\"password\":\).*/\1 \"${{ secrets.SDKUSER_PASSWORD }}\",/" "FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config-live-01.json"
+          rm -rf FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config-live-01.json-r
+
+      # Set target Xcode version. For more details and options see: 
+      # https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md
+      - name: Select Xcode
+        run: sudo xcode-select -switch /Applications/Xcode_13.3.1.app && /usr/bin/xcodebuild -version
+
+      # Run all e2e tests
+      - name: Run e2e tests
+        run: xcodebuild test -scheme FRTestHostE2E -workspace SampleApps/FRExample.xcworkspace -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 12,OS=15.4' -derivedDataPath DerivedData -enableCodeCoverage YES -resultBundlePath TestResultsE2E | xcpretty && exit ${PIPESTATUS[0]}
+
+      # Publish test results
+      - name: Publish test results
+        uses: kishikawakatsumi/xcresulttool@v1
+        with:
+          path: TestResultsE2E.xcresult
+          show-passed-tests: true
+        if: success() || failure()
+
+      # Send slack notification with result status
+      - uses: 8398a7/action-slack@v3
+        with:
+          mention: 'stoyan.petrov'
+          if_mention: 'failure,cancelled'
+          fields: repo,author,eventName,message,job,took
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()

--- a/FRTestHost/FRTestHost.xcodeproj/xcshareddata/xcschemes/FRTestHostE2E.xcscheme
+++ b/FRTestHost/FRTestHost.xcodeproj/xcshareddata/xcschemes/FRTestHostE2E.xcscheme
@@ -1,0 +1,319 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1150"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D5A7A1E4248CD88C00E30CFE"
+               BuildableName = "FRTestHost.app"
+               BlueprintName = "FRTestHost"
+               ReferencedContainer = "container:FRTestHost.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D554630022A6DF720096C7A4"
+               BuildableName = "FRAuthTests.xctest"
+               BlueprintName = "FRAuthTests"
+               ReferencedContainer = "container:../FRAuth/FRAuth.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D55462F722A6DF720096C7A4"
+            BuildableName = "FRAuth.framework"
+            BlueprintName = "FRAuth"
+            ReferencedContainer = "container:../FRAuth/FRAuth.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "D554630022A6DF720096C7A4"
+               BuildableName = "FRAuthTests.xctest"
+               BlueprintName = "FRAuthTests"
+               ReferencedContainer = "container:../FRAuth/FRAuth.xcodeproj">
+            </BuildableReference>
+            <SkippedTests>
+               <Test
+                  Identifier = "AbstractValidatedCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "AccessTokenTests">
+               </Test>
+               <Test
+                  Identifier = "AppleSignInHandlerTests">
+               </Test>
+               <Test
+                  Identifier = "AtomicDictionaryTests">
+               </Test>
+               <Test
+                  Identifier = "AuthApiErrorTests">
+               </Test>
+               <Test
+                  Identifier = "AuthErrorTests">
+               </Test>
+               <Test
+                  Identifier = "AuthServiceTests">
+               </Test>
+               <Test
+                  Identifier = "AuthorizationPolicyTests">
+               </Test>
+               <Test
+                  Identifier = "BooleanAttributeInputCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "BrowserBuilderTests">
+               </Test>
+               <Test
+                  Identifier = "BrowserErrorTests">
+               </Test>
+               <Test
+                  Identifier = "CallbackBaseTest">
+               </Test>
+               <Test
+                  Identifier = "CallbackConstantsTests">
+               </Test>
+               <Test
+                  Identifier = "ChoiceCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "ConfigErrorTests">
+               </Test>
+               <Test
+                  Identifier = "ConfirmationCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "CookieTests">
+               </Test>
+               <Test
+                  Identifier = "CookieValidationTests">
+               </Test>
+               <Test
+                  Identifier = "CustomCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "DeviceProfileCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "FRAuthBaseTest">
+               </Test>
+               <Test
+                  Identifier = "FRAuthTests">
+               </Test>
+               <Test
+                  Identifier = "FRBaseTestCase">
+               </Test>
+               <Test
+                  Identifier = "FRDeviceCollectorTests">
+               </Test>
+               <Test
+                  Identifier = "FRDeviceIdentifierTests">
+               </Test>
+               <Test
+                  Identifier = "FRDeviceTests">
+               </Test>
+               <Test
+                  Identifier = "FROptionsTests">
+               </Test>
+               <Test
+                  Identifier = "FRRequestInterceptorTests">
+               </Test>
+               <Test
+                  Identifier = "FRSessionTests">
+               </Test>
+               <Test
+                  Identifier = "FRURLProtocolTests">
+               </Test>
+               <Test
+                  Identifier = "FRUserTests">
+               </Test>
+               <Test
+                  Identifier = "FailedPolicyTests">
+               </Test>
+               <Test
+                  Identifier = "IdPCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "IdPClientTests">
+               </Test>
+               <Test
+                  Identifier = "IdPHandlerTests">
+               </Test>
+               <Test
+                  Identifier = "IdPValueTests">
+               </Test>
+               <Test
+                  Identifier = "JailbreakDetectorTests">
+               </Test>
+               <Test
+                  Identifier = "KbaCreateCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "KeychainManagerTests">
+               </Test>
+               <Test
+                  Identifier = "MetadataCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "MultipleValuesCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "NameCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "NetworkReachabilityMonitorTests">
+               </Test>
+               <Test
+                  Identifier = "NodeFlowTests">
+               </Test>
+               <Test
+                  Identifier = "NodeTests">
+               </Test>
+               <Test
+                  Identifier = "NumberAttributeInputCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "OAuth2ErrorTests">
+               </Test>
+               <Test
+                  Identifier = "PKCETests">
+               </Test>
+               <Test
+                  Identifier = "PasswordCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "PolicyAdviceTests">
+               </Test>
+               <Test
+                  Identifier = "PollingWaitCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "ReCaptchaCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "SSLPinningTests">
+               </Test>
+               <Test
+                  Identifier = "SelectIdPCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "ServerConfigTests">
+               </Test>
+               <Test
+                  Identifier = "SessionManagerTests">
+               </Test>
+               <Test
+                  Identifier = "SocialLoginErrorTests">
+               </Test>
+               <Test
+                  Identifier = "TermsAndConditionsCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "TextOutputCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "TokenErrorTests">
+               </Test>
+               <Test
+                  Identifier = "TokenManagementPolicyTests">
+               </Test>
+               <Test
+                  Identifier = "TokenTests">
+               </Test>
+               <Test
+                  Identifier = "WebAuthnAuthenticationCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "WebAuthnAuthenticationTests">
+               </Test>
+               <Test
+                  Identifier = "WebAuthnCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "WebAuthnRegistrationCallbackTests">
+               </Test>
+               <Test
+                  Identifier = "WebAuthnRegistrationTests">
+               </Test>
+               <Test
+                  Identifier = "WebAuthnSharedUtils">
+               </Test>
+            </SkippedTests>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D5A7A1E4248CD88C00E30CFE"
+            BuildableName = "FRTestHost.app"
+            BlueprintName = "FRTestHost"
+            ReferencedContainer = "container:FRTestHost.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "D5A7A1E4248CD88C00E30CFE"
+            BuildableName = "FRTestHost.app"
+            BlueprintName = "FRTestHost"
+            ReferencedContainer = "container:FRTestHost.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config-live-01.json
+++ b/FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config-live-01.json
@@ -1,1 +1,52 @@
-
+{
+    "username": "sdkuser",
+    "password": "*******",
+    "kba": {
+        "What's your favorite color?": "White",
+        "Who was your first employer?": "ForgeRock"
+    },
+    "user-email": "sdkuser@example.com",
+    "user-first-name": "Sdk",
+    "user-last-name": "User",
+    "user-info": {
+            "given_name": "Sdk",
+            "family_name": "User",
+            "middle_name": "",
+            "name": "Sdk User",
+            "address": {
+                "formatted": "This should be formatted address",
+                "street_address": "201 Mission St",
+                "locality": "San Francisco",
+                "region": "CA",
+                "postal_code": "94105",
+                "country": "US"
+            },
+            "email": "sdkuser@example.com",
+            "sub": "sdkuser",
+            "nickname": "",
+            "preferred_username": "",
+            "profile": "",
+            "picture": "",
+            "website": "",
+            "email_verified": true,
+            "gender": "male",
+            "birthdate": "2019-01-01",
+            "zoneinfo": "zone",
+            "locale": "US",
+            "phone_number": "7788888888",
+            "phone_number_verified": true
+    },
+    "forgerock_oauth_client_id": "iosclient",
+    "forgerock_oauth_redirect_uri": "http://localhost:8081",
+    "forgerock_oauth_scope": "openid profile email address",
+    "forgerock_oauth_url": "https://openam-forgerrock-sdksteanant.forgeblocks.com/am",
+    "forgerock_oauth_threshold": 60,
+    "forgerock_url": "https://openam-forgerrock-sdksteanant.forgeblocks.com/am",
+    "forgerock_cookie_name": "43d72fc37bdde8c",
+    "forgerock_realm": "alpha",
+    "forgerock_timeout": 60,
+    "forgerock_auth_service_name": "Login",
+    "forgerock_registration_service_name": "Registration",
+    "forgerock_keychain_access_group": "com.bitbar.*",
+    "forgerock_enable_cookie": true
+}


### PR DESCRIPTION
# JIRA Ticket

[SDKS-1789](https://bugster.forgerock.org/jira/browse/SDKS-1789) "Automate Cloud Upgrade Testing"

# Description

This PR adds workflow for triggering the e2e test cases against live IDCloud environment. The workflow is called "Run Live Tests". A new `FRTestHostE2E.xcscheme` scheme has been added to the project to filter the "live" test cases only.
The e2e tests now can be triggered either manually from the "Actions" menu in the repo, or via an HTTP request. 
Triggering the workflow via HTTP request requires a [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) (PAT) passed as a Bearer token in the Authorization header. For more details read the [workflow-dispatch-event](https://docs.github.com/en/rest/actions/workflows#create-a-workflow-dispatch-event) docs.