### PR TITLE
- - - DO NOT MERGE - - - SKDKs-1934_SPIKE_IOS16_PASSKEYS - - - DO NOT MERGE - - -

### DIFF
--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		EC0BA2FA2863325B00F8326E /* FROptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0BA2F92863325B00F8326E /* FROptionsTests.swift */; };
 		EC7EA0F427D10FA70003F878 /* AppleSignInUserStructs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7EA0F327D10FA70003F878 /* AppleSignInUserStructs.swift */; };
 		EC8BCAFF273C3EC100C3B2D8 /* FRHTTPCookie.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8BCAFD273C3EC100C3B2D8 /* FRHTTPCookie.swift */; };
+		ECBB7F1428E31CD50082EA59 /* WebAuthnManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBB7F1328E31CD50082EA59 /* WebAuthnManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -612,6 +613,7 @@
 		EC0BA2F92863325B00F8326E /* FROptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FROptionsTests.swift; sourceTree = "<group>"; };
 		EC7EA0F327D10FA70003F878 /* AppleSignInUserStructs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInUserStructs.swift; sourceTree = "<group>"; };
 		EC8BCAFD273C3EC100C3B2D8 /* FRHTTPCookie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRHTTPCookie.swift; sourceTree = "<group>"; };
+		ECBB7F1328E31CD50082EA59 /* WebAuthnManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WebAuthnManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -813,6 +815,7 @@
 		D53A801C262789BD0093B1CA /* WebAuthn */ = {
 			isa = PBXGroup;
 			children = (
+				ECBB7F1128E31CC70082EA59 /* iOS16 */,
 				D53A801D262789BD0093B1CA /* Format */,
 				D53A8024262789BD0093B1CA /* WAKLogger.swift */,
 				D53A8025262789BD0093B1CA /* Authenticator */,
@@ -1540,6 +1543,14 @@
 			path = FROptions;
 			sourceTree = "<group>";
 		};
+		ECBB7F1128E31CC70082EA59 /* iOS16 */ = {
+			isa = PBXGroup;
+			children = (
+				ECBB7F1328E31CD50082EA59 /* WebAuthnManager.swift */,
+			);
+			path = iOS16;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
@@ -1786,6 +1797,7 @@
 				D53A8039262789BD0093B1CA /* COSE.swift in Sources */,
 				D5B2061025FFDDD200DABB9B /* IdPClient.swift in Sources */,
 				D5B2A38023FCA9A600764370 /* DeviceProfileCallback.swift in Sources */,
+				ECBB7F1428E31CD50082EA59 /* WebAuthnManager.swift in Sources */,
 				D586CF8D23358EE0007A2194 /* NetworkReachabilityMonitor.swift in Sources */,
 				D5B2061C260004E500DABB9B /* AppleSignInHandler.swift in Sources */,
 				D53A805C262789FC0093B1CA /* WebAuthnError.swift in Sources */,

--- a/FRAuth/FRAuth/Callbacks/WebAuthnAuthenticationCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/WebAuthnAuthenticationCallback.swift
@@ -10,7 +10,7 @@
 
 
 import Foundation
-
+import UIKit
 /**
  WebAuthnAuthenticationCallback is a representation of AM's WebAuthn Authentication Node to generate WebAuthn assertion based on given credentials, and optionally set the WebAuthn outcome value in `Node`'s designated `HiddenValueCallback`
  */
@@ -40,7 +40,9 @@ open class WebAuthnAuthenticationCallback: WebAuthnCallback {
     var webAuthnClient: WebAuthnClient?
     /// Boolean indicator whether or not Callback response is AM 7.1.0 or above
     var isNewJSONFormat: Bool = false
-    
+    var successCallback: StringCompletionCallback?
+    var errorCallback: ErrorCallback?
+    var webAuthnManager: Any?
     
     //  MARK: - Lifecycle
     
@@ -86,7 +88,7 @@ open class WebAuthnAuthenticationCallback: WebAuthnCallback {
             throw AuthError.invalidCallbackResponse("Missing userVerification")
         }
         self.userVerification = userVerification
-                
+        
         //  If AM 7.1.0 or above
         if self.isNewJSONFormat {
             //  Relying Party Identifier
@@ -171,92 +173,102 @@ open class WebAuthnAuthenticationCallback: WebAuthnCallback {
     ///   - node: Optional `Node` object to set WebAuthn value to the designated `HiddenValueCallback`
     ///   - onSuccess: Completion callback for successful WebAuthn assertion outcome; note that the outcome will automatically be set to the designated `HiddenValueCallback`
     ///   - onError: Error callback to notify any error thrown while generating WebAuthn assertion
-    public func authenticate(node: Node? = nil, onSuccess: @escaping StringCompletionCallback, onError: @escaping ErrorCallback) {
-        
-        if self.isNewJSONFormat {
-            FRLog.i("Performing WebAuthn authentication for AM 7.1.0 or above", subModule: WebAuthn.module)
-        }
-        else {
-            FRLog.i("Performing WebAuthn authentication for AM 7.0.0 or below", subModule: WebAuthn.module)
-        }
-        
-        //  Platform Authenticator
-        let platformAuthenticator = PlatformAuthenticator(authenticationDelegate: self)
-        //  For AM 7.0.0, origin only supports https scheme; to be updated for AM 7.1.0
-        var origin = CBConstants.originScheme + (Bundle.main.bundleIdentifier ?? CBConstants.defaultOrigin)
-        //  For AM 7.1.0 or above, origin should follow origin format according to FIDO AppId and Facet specification
-        if self.isNewJSONFormat {
-            origin = CBConstants.originPrefix + (Bundle.main.bundleIdentifier ?? CBConstants.defaultOrigin)
-        }
-        
-        let webAuthnClient = WebAuthnClient(origin: origin, authenticator: platformAuthenticator)
-        self.webAuthnClient = webAuthnClient
-        
-        //  PublicKey credential request options
-        var options = PublicKeyCredentialRequestOptions()
-        
-        //  Default userVerification option set to preferred
-        options.userVerification = self.userVerification.convert()
-        
-        //  Challenge
-        options.challenge = Bytes.fromString(self.challenge.urlSafeEncoding())
-        //  Relying Party
-        options.rpId = self.relyingPartyId
-        //  Timeout
-        options.timeout = UInt64(self.timeout/1000)
-        
-        //  Allowed credentials
-        for allowCred in allowCredentials {
-            options.addAllowCredential(credentialId: allowCred, transports: [.internal_])
-        }
-
-        webAuthnClient.get(options, onSuccess: { (assertion) in
-        
-            var result = "\(assertion.response.clientDataJSON)"
-            
-            let authInt8Arr = assertion.response.authenticatorData.map { Int8(bitPattern: $0) }
-            let sigInt8Arr = assertion.response.signature.map { Int8(bitPattern: $0) }
-            
-            let authenticatorData = self.convertInt8ArrToStr(authInt8Arr)
-            result = result + "::\(authenticatorData)"
-            let signatureData = self.convertInt8ArrToStr(sigInt8Arr)
-            result = result + "::\(signatureData)"
-            result = result + "::\(assertion.id)"
-            if let userHandle = assertion.response.userHandle {
-                let encoded = Base64.encodeBase64(userHandle)
-                if let decoded = encoded.base64Decoded() {
-                    result = result + "::\(decoded)"
-                }
-            }
-            
-            //  Expected AM result for successful assertion
-            //  {clientDataJSON as String}::{Int8 array of authenticatorData}::{Int8 array of signature}::{assertion identifier}::{user handle}
-            
-            //  If Node is given, set WebAuthn outcome to designated HiddenValueCallback
-            if let node = node {
-                FRLog.i("Found optional 'Node' instance, setting WebAuthn outcome to designated HiddenValueCallback", subModule: WebAuthn.module)
-                self.setWebAuthnOutcome(node: node, outcome: result)
-            }
-            onSuccess(result)
-            
-        }) { (error) in
-        
-            /// Converts internal WAKError into WebAuthnError
-            if let webAuthnError = error as? WAKError {
-                //  Converts the error to public facing error
-                let publicError = webAuthnError.convert()
-                if let node = node {
-                    FRLog.i("Found optional 'Node' instance, setting WebAuthn error outcome to designated HiddenValueCallback", subModule: WebAuthn.module)
-                    //  Converts WebAuthnError to proper WebAuthn error outcome that can be understood by AM
-                    self.setWebAuthnOutcome(node: node, outcome: publicError.convertToWebAuthnOutcome())
-                }
-                onError(publicError)
+    public func authenticate(node: Node? = nil, window: UIWindow? = nil, preferImmediatelyAvailableCredentials: Bool = false, onSuccess: @escaping StringCompletionCallback, onError: @escaping ErrorCallback) {
+        if #available(iOS 16.0, *) {
+            self.successCallback = onSuccess
+            self.errorCallback = onError
+            guard let window = window, let data = Data(base64Encoded: self.challenge, options: .ignoreUnknownCharacters), let node = node else { fatalError("The view was not in the app's view hierarchy!") }
+            self.webAuthnManager = WebAuthnManager(domain: self.relyingPartyId, authenticationAnchor: window, node: node)
+            guard let webAuthnManager = self.webAuthnManager as? WebAuthnManager else { return }
+            webAuthnManager.delegate = self
+            webAuthnManager.signInWith(preferImmediatelyAvailableCredentials: false, challenge: data, allowedCredentialsArray: self.allowCredentials)
+        } else {
+            if self.isNewJSONFormat {
+                FRLog.i("Performing WebAuthn authentication for AM 7.1.0 or above", subModule: WebAuthn.module)
             }
             else {
-                onError(error)
+                FRLog.i("Performing WebAuthn authentication for AM 7.0.0 or below", subModule: WebAuthn.module)
+            }
+            
+            //  Platform Authenticator
+            let platformAuthenticator = PlatformAuthenticator(authenticationDelegate: self)
+            //  For AM 7.0.0, origin only supports https scheme; to be updated for AM 7.1.0
+            var origin = CBConstants.originScheme + (Bundle.main.bundleIdentifier ?? CBConstants.defaultOrigin)
+            //  For AM 7.1.0 or above, origin should follow origin format according to FIDO AppId and Facet specification
+            if self.isNewJSONFormat {
+                origin = CBConstants.originPrefix + (Bundle.main.bundleIdentifier ?? CBConstants.defaultOrigin)
+            }
+            
+            let webAuthnClient = WebAuthnClient(origin: origin, authenticator: platformAuthenticator)
+            self.webAuthnClient = webAuthnClient
+            
+            //  PublicKey credential request options
+            var options = PublicKeyCredentialRequestOptions()
+            
+            //  Default userVerification option set to preferred
+            options.userVerification = self.userVerification.convert()
+            
+            //  Challenge
+            options.challenge = Bytes.fromString(self.challenge.urlSafeEncoding())
+            //  Relying Party
+            options.rpId = self.relyingPartyId
+            //  Timeout
+            options.timeout = UInt64(self.timeout/1000)
+            
+            //  Allowed credentials
+            for allowCred in allowCredentials {
+                options.addAllowCredential(credentialId: allowCred, transports: [.internal_])
+            }
+            
+            webAuthnClient.get(options, onSuccess: { (assertion) in
+                
+                var result = "\(assertion.response.clientDataJSON)"
+                
+                let authInt8Arr = assertion.response.authenticatorData.map { Int8(bitPattern: $0) }
+                let sigInt8Arr = assertion.response.signature.map { Int8(bitPattern: $0) }
+                
+                let authenticatorData = self.convertInt8ArrToStr(authInt8Arr)
+                result = result + "::\(authenticatorData)"
+                let signatureData = self.convertInt8ArrToStr(sigInt8Arr)
+                result = result + "::\(signatureData)"
+                result = result + "::\(assertion.id)"
+                if let userHandle = assertion.response.userHandle {
+                    let encoded = Base64.encodeBase64(userHandle)
+                    if let decoded = encoded.base64Decoded() {
+                        result = result + "::\(decoded)"
+                    }
+                }
+                
+                //  Expected AM result for successful assertion
+                //  {clientDataJSON as String}::{Int8 array of authenticatorData}::{Int8 array of signature}::{assertion identifier}::{user handle}
+                
+                //  If Node is given, set WebAuthn outcome to designated HiddenValueCallback
+                if let node = node {
+                    FRLog.i("Found optional 'Node' instance, setting WebAuthn outcome to designated HiddenValueCallback", subModule: WebAuthn.module)
+                    self.setWebAuthnOutcome(node: node, outcome: result)
+                }
+                onSuccess(result)
+                
+            }) { (error) in
+                
+                /// Converts internal WAKError into WebAuthnError
+                if let webAuthnError = error as? WAKError {
+                    //  Converts the error to public facing error
+                    let publicError = webAuthnError.convert()
+                    if let node = node {
+                        FRLog.i("Found optional 'Node' instance, setting WebAuthn error outcome to designated HiddenValueCallback", subModule: WebAuthn.module)
+                        //  Converts WebAuthnError to proper WebAuthn error outcome that can be understood by AM
+                        self.setWebAuthnOutcome(node: node, outcome: publicError.convertToWebAuthnOutcome())
+                    }
+                    onError(publicError)
+                }
+                else {
+                    onError(error)
+                }
             }
         }
     }
+    
 }
 
 extension WebAuthnAuthenticationCallback: PlatformAuthenticatorAuthenticationDelegate {
@@ -268,5 +280,20 @@ extension WebAuthnAuthenticationCallback: PlatformAuthenticatorAuthenticationDel
         else {
             FRLog.e("Missing PlatformAuthenticatorAuthenticationDelegate", subModule: WebAuthn.module)
         }
+    }
+}
+
+extension WebAuthnAuthenticationCallback: WebAuthnManagerDelegate {
+    // MARK: - WebAuthnManagerDelegate
+    public func didFinishAuthorization() {
+        self.successCallback?("Success")
+    }
+    
+    public func didCompleteWithError(_ error: Error) {
+        self.errorCallback?(error)
+    }
+    
+    public func didCancelModalSheet() {
+        self.successCallback?("Cancel")
     }
 }

--- a/FRAuth/FRAuth/Callbacks/WebAuthnRegistrationCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/WebAuthnRegistrationCallback.swift
@@ -10,7 +10,7 @@
 
 
 import Foundation
-
+import UIKit
 /**
  WebAuthnRegistrationCallback is a representation of AM's WebAuthn Registration Node to generate WebAuthn attestation based on given credentials, and optionally set the WebAuthn outcome value in `Node`'s designated `HiddenValueCallback`
  */
@@ -57,6 +57,10 @@ open class WebAuthnRegistrationCallback: WebAuthnCallback {
     /// Boolean indicator whether or not Callback response is AM 7.1.0 or above
     var isNewJSONFormat: Bool = false
     var pubCredAlg: [COSEAlgorithmIdentifier] = []
+    
+    var successCallback: StringCompletionCallback?
+    var errorCallback: ErrorCallback?
+    var webAuthnManager: Any?
     
     //  MARK: - Lifecycle
     
@@ -283,96 +287,107 @@ open class WebAuthnRegistrationCallback: WebAuthnCallback {
     ///   - node: Optional `Node` object to set WebAuthn value to the designated `HiddenValueCallback`
     ///   - onSuccess: Completion callback for successful WebAuthn assertion outcome; note that the outcome will automatically be set to the designated `HiddenValueCallback`
     ///   - onError: Error callback to notify any error thrown while generating WebAuthn assertion
-    public func register(node: Node? = nil, onSuccess: @escaping StringCompletionCallback, onError: @escaping ErrorCallback) {
-        
-        if self.isNewJSONFormat {
-            FRLog.i("Performing WebAuthn registration for AM 7.1.0 or above", subModule: WebAuthn.module)
-        }
-        else {
-            FRLog.i("Performing WebAuthn registration for AM 7.0.0 or below", subModule: WebAuthn.module)
-        }
-        
-        //  Platform Authenticator
-        let platformAuthenticator = PlatformAuthenticator(registrationDelegate: self)
-        //  For AM 7.0.0, origin only supports https scheme; to be updated for AM 7.1.0
-        var origin = CBConstants.originScheme + (Bundle.main.bundleIdentifier ?? CBConstants.defaultOrigin)
-        //  For AM 7.1.0 or above, origin should follow origin format according to FIDO AppId and Facet specification
-        if self.isNewJSONFormat {
-            origin = CBConstants.originPrefix + (Bundle.main.bundleIdentifier ?? CBConstants.defaultOrigin)
-        }
-        let webAuthnClient = WebAuthnClient(origin: origin, authenticator: platformAuthenticator)
-        self.webAuthnClient = webAuthnClient
-        
-        //  Default UserVerification set to preferred
-        let userVerification = self.userVerification.convert()
-        
-        //  PublicKey credential creation options
-        var options = PublicKeyCredentialCreationOptions()
-        //  Challenge
-        options.challenge = Bytes.fromString(self.challenge.urlSafeEncoding())
-        //  User
-        options.user.id = Bytes.fromString(self.userId)
-        options.user.name = self.userName
-        options.user.displayName = self.displayName
-        //  Relying Party
-        options.rp.id = self.relyingPartyId
-        options.rp.name = self.relyingPartyName
-        //  Timeout
-        options.timeout = UInt64(self.timeout/1000)
-        
-        //  Default attestation to none
-        options.attestation = self.attestationPreference.convert()
-        
-        //  PublicKey credential parameters
-        for alg in self.pubCredAlg {
-            options.addPubKeyCredParam(alg: alg)
-        }
-        
-        //  Exclude credentials with PublicKeyCredentialDescriptor
-        for excludedCred in self.excludeCredentials {
-            //  Do not define transport due to a bug in ClientCreateOperation.swift#241 as per https://www.w3.org/TR/webauthn/#op-make-cred 6.3.2.3
-            //  As long as the given credentials is known to Authenticator, the client should trigger the authorization gesture regardless of the transport
-            let excludeCredentialDescriptor = PublicKeyCredentialDescriptor(id: excludedCred, transports: [])
-            options.excludeCredentials.append(excludeCredentialDescriptor)
-        }
-        
-        //  Authenticator selection
-        options.authenticatorSelection = AuthenticatorSelectionCriteria(requireResidentKey: self.requireResidentKey, userVerification: userVerification)
-
-        //  Perfrom credential create operation through WebAuthnClient
-        webAuthnClient.create(options, onSuccess: { (credential) in
-        
-            let int8Arr = credential.response.attestationObject.map { Int8(bitPattern: $0) }
-            let attObj = self.convertInt8ArrToStr(int8Arr)
-            //  Expected AM result for successful attestation
-            //  {clientDataJSON as String}::{attestation object in Int8 array}::{hashed credential identifier}
-            let result = "\(credential.response.clientDataJSON)::\(attObj)::\(credential.id)"
+    public func register(node: Node? = nil, window: UIWindow? = nil, onSuccess: @escaping StringCompletionCallback, onError: @escaping ErrorCallback) {
+        if #available(iOS 16.0, *) {
+            self.successCallback = onSuccess
+            self.errorCallback = onError
             
-            //  If Node is given, set WebAuthn outcome to designated HiddenValueCallback
-            if let node = node {
-                FRLog.i("Found optional 'Node' instance, setting WebAuthn outcome to designated HiddenValueCallback", subModule: WebAuthn.module)
-                self.setWebAuthnOutcome(node: node, outcome: result)
-            }
-            onSuccess(result)
-            
-        }) { (error) in
-        
-            /// Converts internal WAKError into WebAuthnError
-            if let webAuthnError = error as? WAKError {
-                //  Converts the error to public facing error
-                let publicError = webAuthnError.convert()
-                if let node = node {
-                    FRLog.i("Found optional 'Node' instance, setting WebAuthn error outcome to designated HiddenValueCallback", subModule: WebAuthn.module)
-                    //  Converts WebAuthnError to proper WebAuthn error outcome that can be understood by AM
-                    self.setWebAuthnOutcome(node: node, outcome: publicError.convertToWebAuthnOutcome())
-                }
-                onError(publicError)
+            guard let window = window, let data = Data(base64Encoded: self.challenge, options: .ignoreUnknownCharacters), let node = node else { fatalError("The view was not in the app's view hierarchy!") }
+            self.webAuthnManager = WebAuthnManager(domain: self.relyingPartyId, authenticationAnchor: window, node: node)
+            guard let webAuthnManager = self.webAuthnManager as? WebAuthnManager else { return }
+            webAuthnManager.delegate = self
+            webAuthnManager.signUpWith(userName: self.displayName, challenge: data, userID: self.userId)
+        } else {
+            if self.isNewJSONFormat {
+                FRLog.i("Performing WebAuthn registration for AM 7.1.0 or above", subModule: WebAuthn.module)
             }
             else {
-                onError(error)
+                FRLog.i("Performing WebAuthn registration for AM 7.0.0 or below", subModule: WebAuthn.module)
+            }
+            
+            //  Platform Authenticator
+            let platformAuthenticator = PlatformAuthenticator(registrationDelegate: self)
+            //  For AM 7.0.0, origin only supports https scheme; to be updated for AM 7.1.0
+            var origin = CBConstants.originScheme + (Bundle.main.bundleIdentifier ?? CBConstants.defaultOrigin)
+            //  For AM 7.1.0 or above, origin should follow origin format according to FIDO AppId and Facet specification
+            if self.isNewJSONFormat {
+                origin = CBConstants.originPrefix + (Bundle.main.bundleIdentifier ?? CBConstants.defaultOrigin)
+            }
+            let webAuthnClient = WebAuthnClient(origin: origin, authenticator: platformAuthenticator)
+            self.webAuthnClient = webAuthnClient
+            
+            //  Default UserVerification set to preferred
+            let userVerification = self.userVerification.convert()
+            
+            //  PublicKey credential creation options
+            var options = PublicKeyCredentialCreationOptions()
+            //  Challenge
+            options.challenge = Bytes.fromString(self.challenge.urlSafeEncoding())
+            //  User
+            options.user.id = Bytes.fromString(self.userId)
+            options.user.name = self.userName
+            options.user.displayName = self.displayName
+            //  Relying Party
+            options.rp.id = self.relyingPartyId
+            options.rp.name = self.relyingPartyName
+            //  Timeout
+            options.timeout = UInt64(self.timeout/1000)
+            
+            //  Default attestation to none
+            options.attestation = self.attestationPreference.convert()
+            
+            //  PublicKey credential parameters
+            for alg in self.pubCredAlg {
+                options.addPubKeyCredParam(alg: alg)
+            }
+            
+            //  Exclude credentials with PublicKeyCredentialDescriptor
+            for excludedCred in self.excludeCredentials {
+                //  Do not define transport due to a bug in ClientCreateOperation.swift#241 as per https://www.w3.org/TR/webauthn/#op-make-cred 6.3.2.3
+                //  As long as the given credentials is known to Authenticator, the client should trigger the authorization gesture regardless of the transport
+                let excludeCredentialDescriptor = PublicKeyCredentialDescriptor(id: excludedCred, transports: [])
+                options.excludeCredentials.append(excludeCredentialDescriptor)
+            }
+            
+            //  Authenticator selection
+            options.authenticatorSelection = AuthenticatorSelectionCriteria(requireResidentKey: self.requireResidentKey, userVerification: userVerification)
+            
+            //  Perfrom credential create operation through WebAuthnClient
+            webAuthnClient.create(options, onSuccess: { (credential) in
+                
+                let int8Arr = credential.response.attestationObject.map { Int8(bitPattern: $0) }
+                let attObj = self.convertInt8ArrToStr(int8Arr)
+                //  Expected AM result for successful attestation
+                //  {clientDataJSON as String}::{attestation object in Int8 array}::{hashed credential identifier}
+                let result = "\(credential.response.clientDataJSON)::\(attObj)::\(credential.id)"
+                
+                //  If Node is given, set WebAuthn outcome to designated HiddenValueCallback
+                if let node = node {
+                    FRLog.i("Found optional 'Node' instance, setting WebAuthn outcome to designated HiddenValueCallback", subModule: WebAuthn.module)
+                    self.setWebAuthnOutcome(node: node, outcome: result)
+                }
+                onSuccess(result)
+                
+            }) { (error) in
+                
+                /// Converts internal WAKError into WebAuthnError
+                if let webAuthnError = error as? WAKError {
+                    //  Converts the error to public facing error
+                    let publicError = webAuthnError.convert()
+                    if let node = node {
+                        FRLog.i("Found optional 'Node' instance, setting WebAuthn error outcome to designated HiddenValueCallback", subModule: WebAuthn.module)
+                        //  Converts WebAuthnError to proper WebAuthn error outcome that can be understood by AM
+                        self.setWebAuthnOutcome(node: node, outcome: publicError.convertToWebAuthnOutcome())
+                    }
+                    onError(publicError)
+                }
+                else {
+                    onError(error)
+                }
             }
         }
     }
+    
 }
 
 
@@ -399,5 +414,20 @@ extension WebAuthnRegistrationCallback: PlatformAuthenticatorRegistrationDelegat
             FRLog.e("Missing PlatformAuthenticatorRegistrationDelegate", subModule: WebAuthn.module)
             consentCallback(.reject)
         }
+    }
+}
+
+extension WebAuthnRegistrationCallback: WebAuthnManagerDelegate {
+    // MARK: - WebAuthnManagerDelegate
+    public func didFinishAuthorization() {
+        self.successCallback?("Success")
+    }
+    
+    public func didCompleteWithError(_ error: Error) {
+        self.errorCallback?(error)
+    }
+    
+    public func didCancelModalSheet() {
+        self.successCallback?("Cancel")
     }
 }

--- a/FRAuth/FRAuth/WebAuthn/Client/Client.swift
+++ b/FRAuth/FRAuth/WebAuthn/Client/Client.swift
@@ -47,7 +47,7 @@ class WebAuthnClient: ClientOperationDelegate {
         self.authenticator = authenticator
     }
 
-    
+    //Regsiter
     func create(_ options: PublicKeyCredentialCreationOptions, onSuccess: @escaping CreateResponseCompletion, onError: @escaping ErrorCallback) {
         WAKLogger.debug("<WebAuthnClient> create")
         
@@ -58,6 +58,7 @@ class WebAuthnClient: ClientOperationDelegate {
         op.start(onSuccess: onSuccess, onError: onError)
     }
     
+    //Authenticate
     func get(_ options: PublicKeyCredentialRequestOptions, onSuccess: @escaping GetResponseCompletion, onError: @escaping ErrorCallback) {
         WAKLogger.debug("<WebAuthnClient> get")
         

--- a/FRAuth/FRAuth/WebAuthn/iOS16/WebAuthnManager.swift
+++ b/FRAuth/FRAuth/WebAuthn/iOS16/WebAuthnManager.swift
@@ -1,0 +1,204 @@
+//
+//  WebAuthnManager.swift
+//  FRAuth
+//
+//  Copyright (c) 2021 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+
+import AuthenticationServices
+import Foundation
+import os
+
+public protocol WebAuthnManagerDelegate: NSObject {
+    func didFinishAuthorization()
+    func didCompleteWithError(_ error: Error)
+    func didCancelModalSheet()
+}
+
+@available(iOS 16, *)
+public class WebAuthnManager: NSObject, ASAuthorizationControllerPresentationContextProviding, ASAuthorizationControllerDelegate {
+    
+    public weak var delegate: WebAuthnManagerDelegate?
+    
+    private var authenticationAnchor: ASPresentationAnchor?
+    private var isPerformingModalReqest: Bool = false
+    private var node: Node
+    private let domain: String
+    
+    public init(domain: String, authenticationAnchor: ASPresentationAnchor?, node: Node) {
+        self.domain = domain
+        self.authenticationAnchor = authenticationAnchor
+        self.node = node
+        super.init()
+    }
+    
+    public func signInWith(preferImmediatelyAvailableCredentials: Bool, challenge: Data, allowedCredentialsArray: [[UInt8]]) {
+        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: domain)
+
+        let assertionRequest = publicKeyCredentialProvider.createCredentialAssertionRequest(challenge: challenge)
+        var credentialsArray: [ASAuthorizationPlatformPublicKeyCredentialDescriptor] = []
+        for credID in allowedCredentialsArray {
+            credentialsArray.append(ASAuthorizationPlatformPublicKeyCredentialDescriptor(credentialID: Data(credID)))
+        }
+        assertionRequest.allowedCredentials = credentialsArray
+        // Pass in any mix of supported sign-in request types.
+        let authController = ASAuthorizationController(authorizationRequests: [ assertionRequest ] )
+        authController.delegate = self
+        authController.presentationContextProvider = self
+
+        if preferImmediatelyAvailableCredentials {
+            // If credentials are available, presents a modal sign-in sheet.
+            // If there are no locally saved credentials, no UI appears and
+            // the system passes ASAuthorizationError.Code.canceled to call
+            // `AccountManager.authorizationController(controller:didCompleteWithError:)`.
+            authController.performRequests(options: .preferImmediatelyAvailableCredentials)
+        } else {
+            // If credentials are available, presents a modal sign-in sheet.
+            // If there are no locally saved credentials, the system presents a QR code to allow signing in with a
+            // passkey from a nearby device.
+            authController.performRequests()
+        }
+
+        isPerformingModalReqest = true
+    }
+    
+    public func signUpWith(userName: String, challenge: Data, userID: String) {
+        let publicKeyCredentialProvider = ASAuthorizationPlatformPublicKeyCredentialProvider(relyingPartyIdentifier: domain)
+
+        // Fetch the challenge from the server. The challenge needs to be unique for each request.
+        // The userID is the identifier for the user's account.
+        //let challenge = Data()
+        let userID = Data(userID.utf8)
+        
+        let registrationRequest = publicKeyCredentialProvider.createCredentialRegistrationRequest(challenge: challenge,
+                                                                                                  name: userName, userID: userID)
+        
+        // Use only ASAuthorizationPlatformPublicKeyCredentialRegistrationRequests or
+        // ASAuthorizationSecurityKeyPublicKeyCredentialRegistrationRequests here.
+        let authController = ASAuthorizationController(authorizationRequests: [ registrationRequest ] )
+        authController.delegate = self
+        authController.presentationContextProvider = self
+    
+        authController.performRequests()
+        isPerformingModalReqest = true
+    }
+    
+    //MARK: - ASAuthorizationControllerPresentationContextProviding
+    
+    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return authenticationAnchor!
+    }
+    
+    //MARK: - ASAuthorizationControllerDelegate
+    
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        
+        switch authorization.credential {
+        case let credentialRegistration as ASAuthorizationPlatformPublicKeyCredentialRegistration:
+            FRLog.i("A new passkey was registered: \(credentialRegistration)")
+            // Verify the attestationObject and clientDataJSON with your service.
+            // The attestationObject contains the user's new public key to store and use for subsequent sign-ins.
+            let int8Arr = credentialRegistration.rawAttestationObject?.bytes.map { Int8(bitPattern: $0) }
+            let attestationObject = self.convertInt8ArrToStr(int8Arr!)
+            
+            let clientDataJSON = String(data: credentialRegistration.rawClientDataJSON, encoding: .utf8)!
+            
+            let credID = base64ToBase64url(base64: credentialRegistration.credentialID.base64EncodedString())
+            //  Expected AM result for successful attestation
+            //  {clientDataJSON as String}::{attestation object in Int8 array}::{hashed credential identifier}
+            let result = "\(clientDataJSON)::\(attestationObject)::\(credID)"
+            // After the server verifies the registration and creates the user account, sign in the user with the new account.
+            //didFinishSignIn()
+            self.setWebAuthnOutcome(outcome: result)
+            self.delegate?.didFinishAuthorization()
+        case let credentialAssertion as ASAuthorizationPlatformPublicKeyCredentialAssertion:
+            FRLog.i("A passkey was used to sign in: \(credentialAssertion)")
+            // Verify the below signature and clientDataJSON with your service for the given userID.
+            
+            let signatureInt8 = credentialAssertion.signature.bytes.map { Int8(bitPattern: $0) }
+            let signature = self.convertInt8ArrToStr(signatureInt8)
+            let clientDataJSON = String(data: credentialAssertion.rawClientDataJSON, encoding: .utf8)!
+            let authenticatorDataInt8 = credentialAssertion.rawAuthenticatorData.bytes.map { Int8(bitPattern: $0) }
+            let authenticatorData = self.convertInt8ArrToStr(authenticatorDataInt8)
+            let credID = base64ToBase64url(base64: credentialAssertion.credentialID.base64EncodedString())
+            let userIDString = String(data: credentialAssertion.userID, encoding: .utf8)!
+            //let userIDString = base64ToBase64url(base64: credentialAssertion.userID.base64EncodedString())
+            //  Expected AM result for successful assertion
+            
+            //  {clientDataJSON as String}::{Int8 array of authenticatorData}::{Int8 array of signature}::{assertion identifier}::{user handle}
+            let result = "\(clientDataJSON)::\(authenticatorData)::\(signature)::\(credID)::\(userIDString)"
+            // After the server verifies the assertion, sign in the user.
+            self.setWebAuthnOutcome(outcome: result)
+            self.delegate?.didFinishAuthorization()
+        default:
+            fatalError("Received unknown authorization type.")
+        }
+
+        isPerformingModalReqest = false
+    }
+
+    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        guard let authorizationError = error as? ASAuthorizationError else {
+            isPerformingModalReqest = false
+            FRLog.e("Unexpected authorization error: \(error.localizedDescription)")
+            self.delegate?.didCompleteWithError(error)
+            return
+        }
+
+        if authorizationError.code == .canceled {
+            // Either the system doesn't find any credentials and the request ends silently, or the user cancels the request.
+            // This is a good time to show a traditional login form, or ask the user to create an account.
+            FRLog.i("Request canceled.")
+
+            if isPerformingModalReqest {
+                self.setWebAuthnOutcome(outcome: "ERROR::NotAllowedError:")
+                self.delegate?.didCancelModalSheet()
+            }
+        } else {
+            // Another ASAuthorization error.
+            // Note: The userInfo dictionary contains useful information.
+            self.delegate?.didCompleteWithError(error)
+            FRLog.e("Error: \((error as NSError).userInfo)")
+        }
+
+        isPerformingModalReqest = false
+    }
+    
+    // MARK: - Private Methods
+    private func setWebAuthnOutcome(outcome: String) {
+        for callback in node.callbacks {
+            if let hiddenValueCallback = callback as? HiddenValueCallback, hiddenValueCallback.isWebAuthnOutcome {
+                hiddenValueCallback.setValue(outcome)
+                return
+            }
+        }
+    }
+    
+    private func convertInt8ArrToStr(_ arr: [Int8]) -> String {
+        var str = ""
+        for (index, byte) in arr.enumerated() {
+            str = str + "\(byte)"
+            if index != (arr.count - 1) {
+                str = str + ","
+            }
+        }
+        return str
+    }
+    
+    private func base64ToBase64url(base64: String) -> String {
+        let base64url = base64
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        return base64url
+    }
+}
+fileprivate extension Data {
+    var bytes: [UInt8] {
+        return [UInt8](self)
+    }
+}


### PR DESCRIPTION
Added WebAuthnManager for supporting iOS 16 Passkeys using Apples Native implementation.

Updating WebAuthnCallbacks to support the new file for iOS16 + devices

DO NOT MERGE - - - This is WIP and not tested and is the result of the SPIKE. It proves that our implementation can be mixed with the new Apple WebAuthn features. On iOS 16+ devices the Apple WebAuthn libraries will be used resulting a shared Passkey to be created. 