### PR TITLE
SDKS-1750 Device Binding e2e test cases

### DIFF
--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		3A1B43D0284510B700EAFC9D /* AtomicDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1B43CF284510B700EAFC9D /* AtomicDictionary.swift */; };
 		3A1B43D3284524B900EAFC9D /* AtomicDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1B43D2284524B900EAFC9D /* AtomicDictionaryTests.swift */; };
+		959D7D98290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 959D7D97290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift */; };
 		A54874A028EF336400FF9B99 /* DeviceBindingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = A548749F28EF336400FF9B99 /* DeviceBindingCallback.swift */; };
 		A54874A428F741AA00FF9B99 /* DeviceBindingAuthenticators.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54874A328F741AA00FF9B99 /* DeviceBindingAuthenticators.swift */; };
 		A54874A728F74F5500FF9B99 /* JOSESwift in Frameworks */ = {isa = PBXBuildFile; productRef = A54874A628F74F5500FF9B99 /* JOSESwift */; };
@@ -338,6 +339,7 @@
 /* Begin PBXFileReference section */
 		3A1B43CF284510B700EAFC9D /* AtomicDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicDictionary.swift; sourceTree = "<group>"; };
 		3A1B43D2284524B900EAFC9D /* AtomicDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicDictionaryTests.swift; sourceTree = "<group>"; };
+		959D7D97290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AA-05-DeviceBindingCallbackTest.swift"; sourceTree = "<group>"; };
 		A548749F28EF336400FF9B99 /* DeviceBindingCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBindingCallback.swift; sourceTree = "<group>"; };
 		A54874A328F741AA00FF9B99 /* DeviceBindingAuthenticators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBindingAuthenticators.swift; sourceTree = "<group>"; };
 		A54874A828F8609900FF9B99 /* KeyAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyAware.swift; sourceTree = "<group>"; };
@@ -1233,6 +1235,7 @@
 				D5888C1E25664E920041FD94 /* AA_04_ReCaptchaCallbackTest.swift */,
 				D5888C1F25664E920041FD94 /* AA_04_KbaCreateCallbackTest.swift */,
 				D5888C2025664E920041FD94 /* AA_04_NumberAttributeInputCallbackTest.swift */,
+				959D7D97290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift */,
 			);
 			path = "Callback-Live";
 			sourceTree = "<group>";
@@ -1996,6 +1999,7 @@
 				D5791BDD25F87DE8004B487A /* TokenTests.swift in Sources */,
 				D5791BDE25F87DE8004B487A /* PKCETests.swift in Sources */,
 				D58BC39F2602FB7700254654 /* IdPValueTests.swift in Sources */,
+				959D7D98290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift in Sources */,
 				D5791BDF25F87DE8004B487A /* AccessTokenTests.swift in Sources */,
 				D5791BE025F87DE8004B487A /* FRUserTests.swift in Sources */,
 				D5791BE125F87DE8004B487A /* FRUserBrowserTests.swift in Sources */,

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA-05-DeviceBindingCallbackTest.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA-05-DeviceBindingCallbackTest.swift
@@ -1,0 +1,333 @@
+// 
+//  AA-05-DeviceBindingCallbackTest.swift
+//  FRAuthTests
+//
+//  Copyright (c) 2022 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import FRAuth
+
+class AA_05_DeviceBindingCallbackTest: CallbackBaseTest {
+    
+    static var USERNAME: String = "sdkuser"
+    override func setUp() {
+        do {
+            let options = FROptions(url: "https://openam-dbind.forgeblocks.com/am",
+                                    realm: "alpha",
+                                    enableCookie: true,
+                                    cookieName: "afef1acb448a873",
+                                    timeout: "180",
+                                    authServiceName: "device-bind",
+                                    oauthThreshold: "60",
+                                    oauthClientId: "iosclient",
+                                    oauthRedirectUri: "http://localhost:8081",
+                                    oauthScope: "openid profile email address",
+                                    keychainAccessGroup: "com.bitbar.*"
+                                    )
+
+            try FRAuth.start(options: options)
+        }
+        catch {
+            XCTFail("Fail to start the the SDK with custom config.")
+        }
+    }
+    
+    override func tearDown() {
+        FRSession.currentSession?.logout()
+        super.tearDown()
+    }
+    
+    func test_01_test_device_binding_defaults() {
+        var currentNode: Node
+        
+        do {
+            try currentNode = startTest(nodeConfiguration: "default")
+        } catch AuthError.invalidCallbackResponse {
+            XCTFail("Expected a Device Binding node, but got nothing!")
+            return
+        } catch {
+            XCTFail("Unexpected error occured!")
+            return
+        }
+        
+        // We expect DeviceBinding callback with default settings here. Assert its properties...
+        for callback in currentNode.callbacks {
+            if callback is DeviceBindingCallback, let deviceBindingCallback = callback as? DeviceBindingCallback {
+                XCTAssertNotNil(deviceBindingCallback.userId)
+                XCTAssertEqual(deviceBindingCallback.userName, AA_05_DeviceBindingCallbackTest.USERNAME)
+                XCTAssertNotNil(deviceBindingCallback.challenge)
+                XCTAssertEqual(deviceBindingCallback.deviceBindingAuthenticationType, DeviceBindingAuthenticationType.biometricAllowFallback)
+                XCTAssertEqual(deviceBindingCallback.title, "Authentication required")
+                XCTAssertEqual(deviceBindingCallback.subtitle, "Cryptography device binding")
+                XCTAssertEqual(deviceBindingCallback.promptDescription, "Please complete with biometric to proceed")
+                XCTAssertEqual(deviceBindingCallback.timeout, 60)
+                
+                deviceBindingCallback.setClientError("Abort")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        let ex = self.expectation(description: "Submit DeviceBinding callback and continue...")
+        currentNode.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_02_test_device_binding_custom() {
+        var currentNode: Node?
+        
+        do {
+            try currentNode = startTest(nodeConfiguration: "custom")
+        } catch AuthError.invalidCallbackResponse {
+            XCTFail("Expected a Device Binding node, but got nothing!")
+            return
+        } catch {
+            XCTFail("Unexpected error occured!")
+            return
+        }
+        
+        // We expect DeviceBinding callback with custom settings here. Assert its properties...
+        for callback in currentNode!.callbacks {
+            if callback is DeviceBindingCallback, let deviceBindingCallback = callback as? DeviceBindingCallback {
+                
+                XCTAssertNotNil(deviceBindingCallback.userId)
+                XCTAssertEqual(deviceBindingCallback.userName, AA_05_DeviceBindingCallbackTest.USERNAME)
+                XCTAssertNotNil(deviceBindingCallback.challenge)
+                XCTAssertEqual(deviceBindingCallback.deviceBindingAuthenticationType, DeviceBindingAuthenticationType.none)
+                XCTAssertEqual(deviceBindingCallback.title, "Custom title")
+                XCTAssertEqual(deviceBindingCallback.subtitle, "Custom subtitle")
+                XCTAssertEqual(deviceBindingCallback.promptDescription, "Custom description")
+                XCTAssertEqual(deviceBindingCallback.timeout, 5)
+                
+                // Set "Custom" client error - this should trigger the "Custom" outcome of the node
+                deviceBindingCallback.setClientError("Custom")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        var ex = self.expectation(description: "Submit DeviceBinding callback and continue...")
+        currentNode?.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        guard let node = currentNode else {
+            XCTFail("Test Failed: Expected TextOutputCallback and ConfirmationCallback (returned by Message node), but got nothing...")
+            return
+        }
+        
+        // Provide input value for the TextOutputCallback callback
+        for callback in node.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Custom outcome triggered")
+            }
+            else if callback is ConfirmationCallback, let confirmationCallback = callback as? ConfirmationCallback {
+                confirmationCallback.value = 0
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value for the ConfirmationCallback and continue...")
+        currentNode?.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_03_test_device_binding_bind() {
+        
+        // Variable to capture the current Node object
+        var currentNode: Node
+        
+        do {
+            try currentNode = startTest(nodeConfiguration: "custom")
+        } catch AuthError.invalidCallbackResponse {
+            XCTFail("Expected a Device Binding node, but got nothing!")
+            return
+        } catch {
+            XCTFail("Unexpected error occured!")
+            return
+        }
+        
+        // We expect DeviceBinding callback with default settings here. Assert its properties. . .
+        for callback in currentNode.callbacks {
+            if callback is DeviceBindingCallback, let deviceBindingCallback = callback as? DeviceBindingCallback {
+                
+                var bindingResult = ""
+                let ex = self.expectation(description: "Device Binding")
+                deviceBindingCallback.execute(authInterface: nil, deviceId: nil,{ (result) in
+                        switch result {
+                        case .success:
+                            bindingResult = "Success"
+                        case .failure(let error):
+                            bindingResult = error.errorMessage
+                        };
+                        ex.fulfill()
+                    })
+                waitForExpectations(timeout: 60, handler: nil)
+                
+                XCTAssertEqual(bindingResult, "Success")
+
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        let ex = self.expectation(description: "Submit DeviceBinding callback and continue...")
+        currentNode.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_04_test_device_binding_exceed() {
+        var currentNode: Node?
+        
+        do {
+            try currentNode = startTest(nodeConfiguration: "exceed-limit")
+        } catch AuthError.invalidCallbackResponse {
+            XCTFail("Expected a Device Binding node, but got nothing!")
+            return
+        } catch {
+            XCTFail("Unexpected error occured!")
+            return
+        }
+        
+        // We expect DeviceBinding callback to trigger the "Exceed Device Limit" outcome
+        for callback in currentNode!.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Device Limit Exceeded")
+            }
+            else if callback is ConfirmationCallback, let confirmationCallback = callback as? ConfirmationCallback {
+                confirmationCallback.value = 0
+            }
+            else {
+                XCTFail("Device bind node did NOT trigger the expected 'Exceeded Device Limit' outcome")
+            }
+        }
+        
+        let ex = self.expectation(description: "Submit value for the ConfirmationCallback and continue...")
+        currentNode?.next { (token: AccessToken?, node, error) in
+            // Validate resultF
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    /// Common steps for all test cases
+    func startTest(nodeConfiguration: String) throws -> Node  {
+        var currentNode: Node?
+        
+        var ex = self.expectation(description: "Provide username")
+        
+        FRSession.authenticate(authIndexValue: FRAuth.shared!.authServiceName) { (token: Token?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        guard let node = currentNode else {
+            XCTFail("Failed to get Node from the first request")
+            throw AuthError.invalidCallbackResponse("Expected username collector node, but got nothing...")
+        }
+        
+        // Provide input value for the username collector callback
+        for callback in node.callbacks {
+            if callback is NameCallback, let nameCallback = callback as? NameCallback {
+                nameCallback.setValue(AA_05_DeviceBindingCallbackTest.USERNAME)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Second Node submit")
+        currentNode?.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        /// --------------------------------
+        guard let node = currentNode else {
+            XCTFail("Failed to get Node")
+            throw AuthError.invalidCallbackResponse("Expected ChoiceCollector node, but got nothing...")
+        }
+        
+        // Provide input value for the ChoiceCollector callback
+        for callback in node.callbacks {
+            if callback is ChoiceCallback, let choiceCallback = callback as? ChoiceCallback {
+                let choiceIndex = choiceCallback.choices.firstIndex(of: nodeConfiguration)
+                choiceCallback.setValue(choiceIndex)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        } 
+        
+        ex = self.expectation(description: "Submit value to the ChoiceCollector Node")
+        currentNode?.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        guard currentNode != nil else {
+            XCTFail("Failed to get Node from the second request")
+            throw AuthError.invalidCallbackResponse("Expected at least one more node, but got nothing...")
+        }
+        return currentNode!
+    }
+}


### PR DESCRIPTION
# JIRA Ticket

[SDKS-1750](https://bugster.forgerock.org/jira/browse/SDKS-1750) "Device Binding QA"

# Description
- e2e test cases for the Device Binding feature.
- These test cases assume that the target IDCloud instance supports the DeviceBinding node and contains the following authentication tree: 

<img width="1051" alt="image" src="https://user-images.githubusercontent.com/1580960/199338890-4579358a-aa53-43ea-889f-51ca5eedd340.png">
