### PR TITLE
SDKS-2226_WebAuthn_error_fixes

### DIFF
--- a/FRAuth/FRAuth/Callbacks/WebAuthnAuthenticationCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/WebAuthnAuthenticationCallback.swift
@@ -242,7 +242,7 @@ open class WebAuthnAuthenticationCallback: WebAuthnCallback {
         }) { (error) in
         
             /// Converts internal WAKError into WebAuthnError
-            if let webAuthnError = error as? WAKError {
+            if let webAuthnError = error as? FRWAKError {
                 //  Converts the error to public facing error
                 let publicError = webAuthnError.convert()
                 if let node = node {

--- a/FRAuth/FRAuth/Callbacks/WebAuthnAuthenticationCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/WebAuthnAuthenticationCallback.swift
@@ -2,7 +2,7 @@
 //  WebAuthnAuthenticationCallback.swift
 //  FRAuth
 //
-//  Copyright (c) 2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2021-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/Callbacks/WebAuthnRegistrationCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/WebAuthnRegistrationCallback.swift
@@ -2,7 +2,7 @@
 //  WebAuthnRegistrationCallback.swift
 //  FRAuth
 //
-//  Copyright (c) 2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2021-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/Callbacks/WebAuthnRegistrationCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/WebAuthnRegistrationCallback.swift
@@ -358,7 +358,7 @@ open class WebAuthnRegistrationCallback: WebAuthnCallback {
         }) { (error) in
         
             /// Converts internal WAKError into WebAuthnError
-            if let webAuthnError = error as? WAKError {
+            if let webAuthnError = error as? FRWAKError {
                 //  Converts the error to public facing error
                 let publicError = webAuthnError.convert()
                 if let node = node {

--- a/FRAuth/FRAuth/Constants/Typealias.swift
+++ b/FRAuth/FRAuth/Constants/Typealias.swift
@@ -2,7 +2,7 @@
 //  Typealias.swift
 //  FRAuth
 //
-//  Copyright (c) 2019-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/Error/WebAuthnError.swift
+++ b/FRAuth/FRAuth/Error/WebAuthnError.swift
@@ -17,7 +17,7 @@ import FRCore
 ///
 
 public struct WebAuthnError: FRError {
-    public enum WebAuthnError: FRError {
+    public enum WebAuthnErrorCases: FRError {
         case badData
         case badOperation
         case invalidState
@@ -29,7 +29,7 @@ public struct WebAuthnError: FRError {
         case unknown
     }
 
-    public let webAuthnError: WebAuthnError
+    public let webAuthnErrorCase: WebAuthnErrorCases
     public let platformError: Error?
     public let message: String?
 }
@@ -39,7 +39,7 @@ extension WebAuthnError {
     /// Converts WebAuthnError to matching type of AM's Error enum
     /// - Returns: String value of matching error type in AM
     func convertToAMErrorType() -> String {
-        switch self.webAuthnError {
+        switch self.webAuthnErrorCase {
         case .badData:
             return "DataError"
         case .badOperation:
@@ -84,7 +84,7 @@ public extension WebAuthnError {
     ///
     /// - Returns: Int value of unique error code
     func parseErrorCode() -> Int {
-        switch self.webAuthnError {
+        switch self.webAuthnErrorCase {
         case .badData:
             return 1600001
         case .badOperation:
@@ -109,7 +109,7 @@ public extension WebAuthnError {
     /// Converts WebAuthnError into String representation of error that can be used as WebAuthn outcome in WebAuthn HiddenValueCallback
     /// - Returns: String value of WebAuthn error outcome
     func convertToWebAuthnOutcome() -> String {
-        switch self.webAuthnError {
+        switch self.webAuthnErrorCase {
         case .unsupported:
             return "unsupported"
         default:
@@ -132,7 +132,7 @@ extension WebAuthnError: CustomNSError {
     
     /// Error UserInfo
     public var errorUserInfo: [String : Any] {
-        switch self.webAuthnError {
+        switch self.webAuthnErrorCase {
         case .badData:
             return [NSLocalizedDescriptionKey: "Provided data is inadequate"]
         case .badOperation:
@@ -159,23 +159,23 @@ extension FRWAKError {
     func convert() -> WebAuthnError {
         switch self.error {
         case .badData:
-            return WebAuthnError(webAuthnError: .badData, platformError: self.platformError, message: self.message)
+            return WebAuthnError(webAuthnErrorCase: .badData, platformError: self.platformError, message: self.message)
         case .badOperation:
-            return WebAuthnError(webAuthnError: .badOperation, platformError: self.platformError, message: self.message)
+            return WebAuthnError(webAuthnErrorCase: .badOperation, platformError: self.platformError, message: self.message)
         case .invalidState:
-            return WebAuthnError(webAuthnError: .invalidState, platformError: self.platformError, message: self.message)
+            return WebAuthnError(webAuthnErrorCase: .invalidState, platformError: self.platformError, message: self.message)
         case .constraint:
-            return WebAuthnError(webAuthnError: .constraint, platformError: self.platformError, message: self.message)
+            return WebAuthnError(webAuthnErrorCase: .constraint, platformError: self.platformError, message: self.message)
         case .cancelled:
-            return WebAuthnError(webAuthnError: .cancelled, platformError: self.platformError, message: self.message)
+            return WebAuthnError(webAuthnErrorCase: .cancelled, platformError: self.platformError, message: self.message)
         case .timeout:
-            return WebAuthnError(webAuthnError: .timeout, platformError: self.platformError, message: self.message)
+            return WebAuthnError(webAuthnErrorCase: .timeout, platformError: self.platformError, message: self.message)
         case .notAllowed:
-            return WebAuthnError(webAuthnError: .notAllowed, platformError: self.platformError, message: self.message)
+            return WebAuthnError(webAuthnErrorCase: .notAllowed, platformError: self.platformError, message: self.message)
         case .unsupported:
-            return WebAuthnError(webAuthnError: .unsupported, platformError: self.platformError, message: self.message)
+            return WebAuthnError(webAuthnErrorCase: .unsupported, platformError: self.platformError, message: self.message)
         case .unknown:
-            return WebAuthnError(webAuthnError: .unknown, platformError: self.platformError, message: self.message)
+            return WebAuthnError(webAuthnErrorCase: .unknown, platformError: self.platformError, message: self.message)
         }
     }
 }

--- a/FRAuth/FRAuth/Error/WebAuthnError.swift
+++ b/FRAuth/FRAuth/Error/WebAuthnError.swift
@@ -2,7 +2,7 @@
 //  WebAuthnError.swift
 //  FRAuth
 //
-//  Copyright (c) 2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2021-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/Error/WebAuthnError.swift
+++ b/FRAuth/FRAuth/Error/WebAuthnError.swift
@@ -16,22 +16,46 @@ import FRCore
 /// WebAuthnError represents an error captured by FRAuth SDK for WebAuthn related operation
 ///
 
-public struct WebAuthnError: FRError {
-    public enum WebAuthnErrorCases: FRError {
-        case badData
-        case badOperation
-        case invalidState
-        case constraint
-        case cancelled
-        case timeout
-        case notAllowed
-        case unsupported
-        case unknown
+public enum WebAuthnError: Error {
+    case badData(platformError: Error?, message: String?)
+    case badOperation(platformError: Error?, message: String?)
+    case invalidState(platformError: Error?, message: String?)
+    case constraint(platformError: Error?, message: String?)
+    case cancelled(platformError: Error?, message: String?)
+    case timeout(platformError: Error?, message: String?)
+    case notAllowed(platformError: Error?, message: String?)
+    case unsupported(platformError: Error?, message: String?)
+    case unknown(platformError: Error?, message: String?)
+    
+    public func platformError() -> Error? {
+        switch self {
+        case .badData(platformError: let platformError, message: _),
+                .badOperation(platformError: let platformError, message: _),
+                .invalidState(platformError: let platformError, message: _),
+                .constraint(platformError: let platformError, message: _),
+                .cancelled(platformError: let platformError, message: _),
+                .timeout(platformError: let platformError, message: _),
+                .notAllowed(platformError: let platformError, message: _),
+                .unsupported(platformError: let platformError, message: _),
+                .unknown(platformError: let platformError, message: _):
+            return platformError
+        }
     }
-
-    public let webAuthnErrorCase: WebAuthnErrorCases
-    public let platformError: Error?
-    public let message: String?
+    
+    public func message() -> String? {
+        switch self {
+        case .badData(platformError: _, message: let message),
+                .badOperation(platformError: _, message: let message),
+                .invalidState(platformError: _, message: let message),
+                .constraint(platformError: _, message: let message),
+                .cancelled(platformError: _, message: let message),
+                .timeout(platformError: _, message: let message),
+                .notAllowed(platformError: _, message: let message),
+                .unsupported(platformError: _, message: let message),
+                .unknown(platformError: _, message: let message):
+            return message
+        }
+    }
 }
 
 extension WebAuthnError {
@@ -39,7 +63,7 @@ extension WebAuthnError {
     /// Converts WebAuthnError to matching type of AM's Error enum
     /// - Returns: String value of matching error type in AM
     func convertToAMErrorType() -> String {
-        switch self.webAuthnErrorCase {
+        switch self {
         case .badData:
             return "DataError"
         case .badOperation:
@@ -62,9 +86,9 @@ extension WebAuthnError {
     }
     
     func extractErrorDescription() -> String? {
-        if let nsError = self.platformError as? NSError {
+        if let nsError = self.platformError() as? NSError {
             return (nsError.userInfo["NSDebugDescription"] as? String) ?? nsError.localizedDescription
-        } else if let errorDescription = self.message {
+        } else if let errorDescription = self.message() {
             return errorDescription
         } else {
             return nil
@@ -84,7 +108,7 @@ public extension WebAuthnError {
     ///
     /// - Returns: Int value of unique error code
     func parseErrorCode() -> Int {
-        switch self.webAuthnErrorCase {
+        switch self {
         case .badData:
             return 1600001
         case .badOperation:
@@ -109,7 +133,7 @@ public extension WebAuthnError {
     /// Converts WebAuthnError into String representation of error that can be used as WebAuthn outcome in WebAuthn HiddenValueCallback
     /// - Returns: String value of WebAuthn error outcome
     func convertToWebAuthnOutcome() -> String {
-        switch self.webAuthnErrorCase {
+        switch self {
         case .unsupported:
             return "unsupported"
         default:
@@ -132,7 +156,7 @@ extension WebAuthnError: CustomNSError {
     
     /// Error UserInfo
     public var errorUserInfo: [String : Any] {
-        switch self.webAuthnErrorCase {
+        switch self {
         case .badData:
             return [NSLocalizedDescriptionKey: "Provided data is inadequate"]
         case .badOperation:
@@ -157,25 +181,25 @@ extension WebAuthnError: CustomNSError {
 
 extension FRWAKError {
     func convert() -> WebAuthnError {
-        switch self.error {
+        switch self {
         case .badData:
-            return WebAuthnError(webAuthnErrorCase: .badData, platformError: self.platformError, message: self.message)
+            return WebAuthnError.badData(platformError: self.platformError(), message: self.message())
         case .badOperation:
-            return WebAuthnError(webAuthnErrorCase: .badOperation, platformError: self.platformError, message: self.message)
+            return WebAuthnError.badOperation(platformError: self.platformError(), message: self.message())
         case .invalidState:
-            return WebAuthnError(webAuthnErrorCase: .invalidState, platformError: self.platformError, message: self.message)
+            return WebAuthnError.invalidState(platformError: self.platformError(), message: self.message())
         case .constraint:
-            return WebAuthnError(webAuthnErrorCase: .constraint, platformError: self.platformError, message: self.message)
+            return WebAuthnError.constraint(platformError: self.platformError(), message: self.message())
         case .cancelled:
-            return WebAuthnError(webAuthnErrorCase: .cancelled, platformError: self.platformError, message: self.message)
+            return WebAuthnError.cancelled(platformError: self.platformError(), message: self.message())
         case .timeout:
-            return WebAuthnError(webAuthnErrorCase: .timeout, platformError: self.platformError, message: self.message)
+            return WebAuthnError.timeout(platformError: self.platformError(), message: self.message())
         case .notAllowed:
-            return WebAuthnError(webAuthnErrorCase: .notAllowed, platformError: self.platformError, message: self.message)
+            return WebAuthnError.notAllowed(platformError: self.platformError(), message: self.message())
         case .unsupported:
-            return WebAuthnError(webAuthnErrorCase: .unsupported, platformError: self.platformError, message: self.message)
+            return WebAuthnError.unsupported(platformError: self.platformError(), message: self.message())
         case .unknown:
-            return WebAuthnError(webAuthnErrorCase: .unknown, platformError: self.platformError, message: self.message)
+            return WebAuthnError.unknown(platformError: self.platformError(), message: self.message())
         }
     }
 }

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/Authenticator.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/Authenticator.swift
@@ -23,14 +23,14 @@ struct AuthenticatorAssertionResult {
 protocol AuthenticatorMakeCredentialSessionDelegate: class {
     func authenticatorSessionDidBecomeAvailable(session: AuthenticatorMakeCredentialSession)
     func authenticatorSessionDidBecomeUnavailable(session: AuthenticatorMakeCredentialSession)
-    func authenticatorSessionDidStopOperation(session: AuthenticatorMakeCredentialSession, reason: WAKError)
+    func authenticatorSessionDidStopOperation(session: AuthenticatorMakeCredentialSession, reason: FRWAKError)
     func authenticatorSessionDidMakeCredential(session: AuthenticatorMakeCredentialSession, attestation: AttestationObject)
 }
 
 protocol AuthenticatorGetAssertionSessionDelegate: class {
     func authenticatorSessionDidBecomeAvailable(session: AuthenticatorGetAssertionSession)
     func authenticatorSessionDidBecomeUnavailable(session: AuthenticatorGetAssertionSession)
-    func authenticatorSessionDidStopOperation(session: AuthenticatorGetAssertionSession, reason: WAKError)
+    func authenticatorSessionDidStopOperation(session: AuthenticatorGetAssertionSession, reason: FRWAKError)
     func authenticatorSessionDidDiscoverCredential(session: AuthenticatorGetAssertionSession, assertion: AuthenticatorAssertionResult)
 }
 
@@ -53,7 +53,7 @@ protocol AuthenticatorGetAssertionSession {
     func canPerformUserVerification() -> Bool
     
     func start()
-    func cancel(reason: WAKError)
+    func cancel(reason: FRWAKError)
 
 }
 
@@ -80,7 +80,7 @@ protocol AuthenticatorMakeCredentialSession {
     func canStoreResidentKey() -> Bool
     
     func start()
-    func cancel(reason: WAKError)
+    func cancel(reason: FRWAKError)
 
 }
 

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/Authenticator.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/Authenticator.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Lyo Kato on 2018/11/20.
 //  Original work Copyright © 2018 Lyo Kato. All rights reserved.
-//  Modified work Copyright © 2021 ForgeRock, Inc.
+//  Modified work Copyright © 2021-2022 ForgeRock, Inc.
 //
 
 import Foundation

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorGetAssertionSession.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorGetAssertionSession.swift
@@ -99,8 +99,8 @@ class PlatformAuthenticatorGetAssertionSession: AuthenticatorGetAssertionSession
     
     /// Cancels the session's operation to generate assertion
     /// - Parameter reason: cancellation reason as in WAKError
-    func cancel(reason: WAKError) {
-        FRLog.v("getAssertion cancelled: \(reason.localizedDescription)", subModule: WebAuthn.module)
+    func cancel(reason: FRWAKError) {
+        FRLog.v("getAssertion cancelled: \(reason.error.localizedDescription)", subModule: WebAuthn.module)
         guard !self.didStop else {
             return
         }
@@ -110,8 +110,8 @@ class PlatformAuthenticatorGetAssertionSession: AuthenticatorGetAssertionSession
     
     /// Stops the session's operation to generate assertion
     /// - Parameter reason: stopping reason as in WAKError
-    func stop(reason: WAKError) {
-        FRLog.v("getAssertion stopped: \(reason.localizedDescription)", subModule: WebAuthn.module)
+    func stop(reason: FRWAKError) {
+        FRLog.v("getAssertion stopped: \(reason.error.localizedDescription)", subModule: WebAuthn.module)
         guard self.inProgress else {
             return
         }
@@ -146,8 +146,9 @@ class PlatformAuthenticatorGetAssertionSession: AuthenticatorGetAssertionSession
         //  Get an array of credentials with allowed credentials, and relyingPartyId
         let credSources = self.getCredentialsSources(rpId: rpId, allowCredentialDescriptorList: allowCredentialDescriptorList)
         guard !credSources.isEmpty else {
-            FRLog.w("Credential source is empty; stopping the operation", subModule: WebAuthn.module)
-            self.stop(reason: .notAllowed)
+            let logMessage = "Credential source is empty; stopping the operation"
+            FRLog.w(logMessage, subModule: WebAuthn.module)
+            self.stop(reason: FRWAKError(error: .notAllowed, message: logMessage))
             return
         }
         
@@ -158,11 +159,11 @@ class PlatformAuthenticatorGetAssertionSession: AuthenticatorGetAssertionSession
                 FRLog.v("Performing User Verification", subModule: WebAuthn.module)
                 self.performUserVerification(requireUserVerification: requireUserVerification) { (error) in
                     guard error == nil else {
-                        if let wakErr = error as? WAKError {
+                        if let wakErr = error as? FRWAKError {
                             self.stop(reason: wakErr)
                         }
                         else {
-                            self.stop(reason: .unknown)
+                            self.stop(reason: FRWAKError(error: .unknown))
                         }
                         return
                     }
@@ -175,8 +176,9 @@ class PlatformAuthenticatorGetAssertionSession: AuthenticatorGetAssertionSession
                     
                     //  Store updated credential source
                     guard self.credentialsStore.saveCredentialSource(copiedCred) else {
-                        FRLog.e("Updating credential source for signing count failed", subModule: WebAuthn.module)
-                        self.stop(reason: .unknown)
+                        let logMessage = "Updating credential source for signing count failed"
+                        FRLog.e(logMessage, subModule: WebAuthn.module)
+                        self.stop(reason: FRWAKError(error: .unknown, message: logMessage))
                         return
                     }
                     FRLog.v("Signing count updated", subModule: WebAuthn.module)
@@ -190,20 +192,23 @@ class PlatformAuthenticatorGetAssertionSession: AuthenticatorGetAssertionSession
                     data.append(contentsOf: hash)
                     
                     guard let alg = COSEAlgorithmIdentifier.fromInt(selectedCredentials.alg) else {
-                        FRLog.e("Unknown key algorithm (\(selectedCredentials.alg)), stopping operation", subModule: WebAuthn.module)
-                        self.stop(reason: .unsupported)
+                        let logMessage = "Unknown key algorithm (\(selectedCredentials.alg)), stopping operation"
+                        FRLog.e(logMessage, subModule: WebAuthn.module)
+                        self.stop(reason: FRWAKError(error: .unsupported, message: logMessage))
                         return
                     }
                     
                     guard let keySupport = self.keySupportChooser.choose([alg]) else {
-                        FRLog.e("Not supported key algorithm (\(selectedCredentials.alg)), stopping operation", subModule: WebAuthn.module)
-                        self.stop(reason: .unsupported)
+                        let logMessage = "Not supported key algorithm (\(selectedCredentials.alg)), stopping operation"
+                        FRLog.e(logMessage, subModule: WebAuthn.module)
+                        self.stop(reason: FRWAKError(error: .unsupported, message: logMessage))
                         return
                     }
                     
                     guard let signature = keySupport.sign(data: data, label: selectedCredentials.keyLabel) else {
-                        FRLog.e("Failed to sign the data", subModule: WebAuthn.module)
-                        self.stop(reason: .unknown)
+                        let logMessage = "Failed to sign the data"
+                        FRLog.e(logMessage, subModule: WebAuthn.module)
+                        self.stop(reason: FRWAKError(error: .unknown, message: logMessage))
                         return
                     }
                     
@@ -220,8 +225,9 @@ class PlatformAuthenticatorGetAssertionSession: AuthenticatorGetAssertionSession
                 }
             }
             else {
-                FRLog.e("Unknwon 'keyName' is returned; stopping the operation", subModule: WebAuthn.module)
-                self.stop(reason: .notAllowed)
+                let logMessage = "Unknwon 'keyName' is returned; stopping the operation"
+                FRLog.e(logMessage, subModule: WebAuthn.module)
+                self.stop(reason: FRWAKError(error: .notAllowed, message: logMessage))
                 return
             }
         }
@@ -294,51 +300,59 @@ class PlatformAuthenticatorGetAssertionSession: AuthenticatorGetAssertionSession
                 let context = LAContext()
                 var evalError: NSError?
                 if context.canEvaluatePolicy(.deviceOwnerAuthentication, error: &evalError) {
+                    if let error = evalError {
+                        completion(self.wakErrorForEvalError(evalError: error))
+                        return
+                    }
                     FRLog.v("Evaluation with LocalContext is available, performing biometric LocalAuthentication", subModule: WebAuthn.module)
-                    context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: NSLocalizedString(WebAuthn.localAuthenticationString, comment: "Description text for local authentication reason displayed in iOS' local authentication screen.")) { (result, error) in
-                        
+                    context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: NSLocalizedString(WebAuthn.localAuthenticationString, comment: "Description text for local authentication reason displayed in iOS' local authentication screen.")) { [weak self] (result, error) in
                         if result {
                             FRLog.v("User Verification is completed", subModule: WebAuthn.module)
                             completion(nil)
                         }
-                        else if let error = error {
-                            switch LAError(_nsError: error as NSError) {
-                            case LAError.userFallback:
-                                FRLog.e("LAContext - User fallback", subModule: WebAuthn.module)
-                                completion(WAKError.notAllowed)
-                            case LAError.userCancel:
-                                FRLog.e("LAContext - User cancelled", subModule: WebAuthn.module)
-                                completion(WAKError.notAllowed)
-                            case LAError.authenticationFailed:
-                                FRLog.e("LAContext - User authentication failed", subModule: WebAuthn.module)
-                                completion(WAKError.notAllowed)
-                            case LAError.passcodeNotSet:
-                                FRLog.e("LAContext - Passcode is not set", subModule: WebAuthn.module)
-                                completion(WAKError.notAllowed)
-                            case LAError.systemCancel:
-                                FRLog.e("LAContext - System cancel", subModule: WebAuthn.module)
-                                completion(WAKError.notAllowed)
-                            default:
-                                FRLog.e("LAContext - Unexpected error: \(error.localizedDescription)", subModule: WebAuthn.module)
-                                completion(WAKError.unknown)
-                            }
+                        else if let error = error as? NSError {
+                            completion(self?.wakErrorForEvalError(evalError: error))
                         }
                         else {
                             FRLog.e("LAContext - Unknown", subModule: WebAuthn.module)
-                            completion(WAKError.unknown)
+                            completion(FRWAKError(error: .unknown))
                         }
                     }
                 }
                 else {
                     let reason = evalError?.localizedDescription ?? ""
-                    FRLog.e("LocalAuthentication with biometric is not available (\(reason)); getAssertion operation is not allowed", subModule: WebAuthn.module)
-                    completion(WAKError.notAllowed)
+                    let logMessage = "LocalAuthentication with biometric is not available (\(reason)); getAssertion operation is not allowed"
+                    FRLog.e(logMessage, subModule: WebAuthn.module)
+                    completion(FRWAKError(error: .notAllowed, message: logMessage))
                 }
             }
         }
         else {
             FRLog.v("User Verification is not required; proceed with getAssertion operation", subModule: WebAuthn.module)
             completion(nil)
+        }
+    }
+    
+    private func wakErrorForEvalError(evalError: NSError) -> FRWAKError {
+        switch LAError(_nsError: evalError) {
+        case LAError.userFallback:
+            FRLog.e("LAContext - User fallback", subModule: WebAuthn.module)
+            return FRWAKError(error: .notAllowed, platformError: evalError)
+        case LAError.userCancel:
+            FRLog.e("LAContext - User cancelled", subModule: WebAuthn.module)
+            return FRWAKError(error: .notAllowed, platformError: evalError)
+        case LAError.authenticationFailed:
+            FRLog.e("LAContext - User authentication failed", subModule: WebAuthn.module)
+            return FRWAKError(error: .notAllowed, platformError: evalError)
+        case LAError.passcodeNotSet:
+            FRLog.e("LAContext - Passcode is not set", subModule: WebAuthn.module)
+            return FRWAKError(error: .notAllowed, platformError: evalError)
+        case LAError.systemCancel:
+            FRLog.e("LAContext - System cancel", subModule: WebAuthn.module)
+            return FRWAKError(error: .notAllowed, platformError: evalError)
+        default:
+            FRLog.e("LAContext - Unexpected error: \(evalError.localizedDescription)", subModule: WebAuthn.module)
+            return FRWAKError(error: .unknown, platformError: evalError, message: evalError.localizedDescription)
         }
     }
 }

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorGetAssertionSession.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorGetAssertionSession.swift
@@ -2,7 +2,7 @@
 //  PlatformAuthenticatorGetAssertionSession.swift
 //  FRAuth
 //
-//  Copyright (c) 2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2021-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorGetAssertionSession.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorGetAssertionSession.swift
@@ -306,7 +306,7 @@ class PlatformAuthenticatorGetAssertionSession: AuthenticatorGetAssertionSession
                     }
                     FRLog.v("Evaluation with LocalContext is available, performing biometric LocalAuthentication", subModule: WebAuthn.module)
                     context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: NSLocalizedString(WebAuthn.localAuthenticationString, comment: "Description text for local authentication reason displayed in iOS' local authentication screen.")) { [weak self] (result, error) in
-                        if result {
+                        if result && error != nil {
                             FRLog.v("User Verification is completed", subModule: WebAuthn.module)
                             completion(nil)
                         }

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorMakeCredentialSession.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorMakeCredentialSession.swift
@@ -231,7 +231,7 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                     }
                     context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: NSLocalizedString(WebAuthn.localAuthenticationString, comment: "Description text for local authentication reason displayed in iOS' local authentication screen.")) { [weak self] (result, error) in
                         
-                        if result {
+                        if result && error != nil {
                             completion(nil)
                         }
                         else if let error = error as? NSError {

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorMakeCredentialSession.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorMakeCredentialSession.swift
@@ -163,19 +163,19 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                     case .allow:
                         let logMessage = "User allowed the operation; invalid state for excluded credentials"
                         FRLog.w(logMessage, subModule: WebAuthn.module)
-                        completion(FRWAKError(error: .invalidState, message: logMessage))
+                        completion(FRWAKError.invalidState(platformError: nil, message: logMessage))
                         break
                     case .reject:
                         let logMessage = "User rejected the operation; not allowed for excluded credentials"
                         FRLog.w(logMessage, subModule: WebAuthn.module)
-                        completion(FRWAKError(error: .notAllowed, message: logMessage))
+                        completion(FRWAKError.notAllowed(platformError: nil, message: logMessage))
                         break
                     }
                 }
             }
             else {
                 FRLog.e("PlatformAuthenticatorDelegate is missing", subModule: WebAuthn.module)
-                completion(FRWAKError(error: .unknown))
+                completion(FRWAKError.unknown(platformError: nil, message: nil))
             }
         }
         else {
@@ -203,14 +203,14 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                 case .reject:
                     let logMessage = "User rejected to generate new credential"
                     FRLog.e(logMessage, subModule: WebAuthn.module)
-                    completion(FRWAKError(error: .cancelled, message: logMessage))
+                    completion(FRWAKError.cancelled(platformError: nil, message: logMessage))
                     break
                 }
             }
         }
         else {
             FRLog.e("PlatformAuthenticatorDelegate is missing", subModule: WebAuthn.module)
-            completion(FRWAKError(error: .unknown))
+            completion(FRWAKError.unknown(platformError: nil, message: nil))
         }
     }
     
@@ -231,7 +231,7 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                     }
                     context.evaluatePolicy(.deviceOwnerAuthentication, localizedReason: NSLocalizedString(WebAuthn.localAuthenticationString, comment: "Description text for local authentication reason displayed in iOS' local authentication screen.")) { [weak self] (result, error) in
                         
-                        if result && error != nil {
+                        if result && (error == nil) {
                             completion(nil)
                         }
                         else if let error = error as? NSError {
@@ -239,7 +239,7 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                         }
                         else {
                             WAKLogger.debug("<UserConsentUI> must not come here")
-                            completion(FRWAKError(error: .unknown))
+                            completion(FRWAKError.unknown(platformError: nil, message: nil))
                         }
                     }
                 }
@@ -247,7 +247,7 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                     let reason = evalError?.localizedDescription ?? ""
                     let logMessage = "<UserConsentUI> device not supported: \(reason)"
                     WAKLogger.debug(logMessage)
-                    completion(FRWAKError(error: .notAllowed, message: logMessage))
+                    completion(FRWAKError.notAllowed(platformError: nil, message: logMessage))
                 }
             }
         }
@@ -260,22 +260,22 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
         switch LAError(_nsError: evalError) {
         case LAError.userFallback:
             WAKLogger.debug("<UserConsentUI> user fallback")
-            return FRWAKError(error: .notAllowed, platformError: evalError)
+            return FRWAKError.notAllowed(platformError: evalError, message: "<UserConsentUI> user fallback")
         case LAError.userCancel:
             WAKLogger.debug("<UserConsentUI> user cancel")
-            return FRWAKError(error: .notAllowed, platformError: evalError)
+            return FRWAKError.notAllowed(platformError: evalError, message: "<UserConsentUI> user cancel")
         case LAError.authenticationFailed:
             WAKLogger.debug("<UserConsentUI> authentication failed")
-            return FRWAKError(error: .notAllowed, platformError: evalError)
+            return FRWAKError.notAllowed(platformError: evalError, message: "<UserConsentUI> authentication failed")
         case LAError.passcodeNotSet:
             WAKLogger.debug("<UserConsentUI> passcode not set")
-            return FRWAKError(error: .notAllowed, platformError: evalError)
+            return FRWAKError.notAllowed(platformError: evalError, message: "<UserConsentUI> passcode not set")
         case LAError.systemCancel:
             WAKLogger.debug("<UserConsentUI> system cancel")
-            return FRWAKError(error: .notAllowed, platformError: evalError)
+            return FRWAKError.notAllowed(platformError: evalError, message: "<UserConsentUI> system cancel")
         default:
             WAKLogger.debug("<UserConsentUI> must not come here")
-            return FRWAKError(error: .unknown, platformError: evalError)
+            return FRWAKError.unknown(platformError: evalError, message: "<UserConsentUI> must not come here")
         }
     }
     
@@ -306,7 +306,7 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
         guard let keySupport = self.keySupportChooser.choose(requestedAlgs) else {
             let logMessage = "Requested key algorithm(s) not supported; stopping the operation"
             FRLog.e(logMessage, subModule: WebAuthn.module)
-            self.stop(reason: FRWAKError(error: .unsupported, message: logMessage))
+            self.stop(reason: FRWAKError.unsupported(platformError: nil, message: logMessage))
             return
         }
         
@@ -317,7 +317,7 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                     self.stop(reason: wakErr)
                 }
                 else {
-                    self.stop(reason: FRWAKError(error: .unknown))
+                    self.stop(reason: FRWAKError.unknown(platformError: nil, message: nil))
                 }
                 return
             }
@@ -326,7 +326,7 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
             if requireUserVerification && !self.config.allowUserVerification {
                 let logMessage = "User Verification is required, but not supported"
                 FRLog.e(logMessage, subModule: WebAuthn.module)
-                self.stop(reason: FRWAKError(error: .constraint, message: logMessage))
+                self.stop(reason: FRWAKError.constraint(platformError: nil, message: logMessage))
                 return
             }
             
@@ -342,7 +342,7 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                         self.stop(reason: wakErr)
                     }
                     else {
-                        self.stop(reason: FRWAKError(error: .unknown))
+                        self.stop(reason: FRWAKError.unknown(platformError: nil, message: nil))
                     }
                     return
                 }
@@ -353,7 +353,7 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                             self.stop(reason: wakErr)
                         }
                         else {
-                            self.stop(reason: FRWAKError(error: .unknown))
+                            self.stop(reason: FRWAKError.unknown(platformError: nil, message: nil))
                         }
                         return
                     }
@@ -372,14 +372,14 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                     guard let publicKeyCOSE = keySupport.createKeyPair(label: credSource.keyLabel) else {
                         let logMessage = "Failed to generate new key"
                         FRLog.e(logMessage, subModule: WebAuthn.module)
-                        self.stop(reason: FRWAKError(error: .unknown, message: logMessage))
+                        self.stop(reason: FRWAKError.unknown(platformError: nil, message: logMessage))
                         return
                     }
                     
                     guard self.credentialsStore.saveCredentialSource(credSource) else {
                         let logMessage = "Failed to store new credential"
                         FRLog.e(logMessage, subModule: WebAuthn.module)
-                        self.stop(reason: FRWAKError(error: .unknown, message: logMessage))
+                        self.stop(reason: FRWAKError.unknown(platformError: nil, message: logMessage))
                         return
                     }
                     
@@ -392,7 +392,7 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                     guard let attestation = PlatformAttestation.create(authData: authenticatorData, clientDataHash: hash, alg: keySupport.selectedAlg, keyLabel: credSource.keyLabel, attestationPreference: attestationPreference) else {
                         let logMessage = "Failed to create Attestation object"
                         FRLog.e(logMessage, subModule: WebAuthn.module)
-                        self.stop(reason: FRWAKError(error: .unknown, message: logMessage))
+                        self.stop(reason: FRWAKError.unknown(platformError: nil, message: logMessage))
                         return
                     }
                     

--- a/FRAuth/FRAuth/WebAuthn/Client/Client.swift
+++ b/FRAuth/FRAuth/WebAuthn/Client/Client.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Lyo Kato on 2018/11/20.
 //  Original work Copyright © 2018 Lyo Kato. All rights reserved.
-//  Modified work Copyright © 2021 ForgeRock, Inc.
+//  Modified work Copyright © 2021-2022 ForgeRock, Inc.
 //
 
 import Foundation

--- a/FRAuth/FRAuth/WebAuthn/Client/Operation/ClientCreateOperation.swift
+++ b/FRAuth/FRAuth/WebAuthn/Client/Operation/ClientCreateOperation.swift
@@ -62,14 +62,14 @@ class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
             if self.stopped {
                 let logMessage = "<CreateOperation> already stopped"
                 WAKLogger.debug(logMessage)
-                onError(FRWAKError(error: .badOperation, message: logMessage))
+                onError(FRWAKError.badOperation(platformError: nil, message: logMessage))
                 self.delegate?.operationDidFinish(opType: self.type, opId: self.id)
                 return
             }
             if self.completion != nil {
                 let logMessage = "<CreateOperation> already started"
                 WAKLogger.debug(logMessage)
-                onError(FRWAKError(error: .badOperation, message: logMessage))
+                onError(FRWAKError.badOperation(platformError: nil, message: logMessage))
                 self.delegate?.operationDidFinish(opType: self.type, opId: self.id)
                 return
             }
@@ -84,7 +84,7 @@ class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
         
     }
 
-    func cancel(reason: FRWAKError = FRWAKError(error: .cancelled)) {
+    func cancel(reason: FRWAKError = FRWAKError.cancelled(platformError: nil, message: nil)) {
         WAKLogger.debug("<CreateOperation> cancel")
         if self.completion != nil && !self.stopped {
             DispatchQueue.global().async {
@@ -94,10 +94,10 @@ class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
                     // At the timing like that,
                     // it causes trouble if this operation tries to close.
                     // So, let the session to start closing
-                    if reason.error == .timeout {
-                        self.session.cancel(reason: FRWAKError(error: .timeout, message: "<CreateOperation> timeout"))
+                    if case FRWAKError.timeout(let platformError, let message) = reason {
+                        self.session.cancel(reason: FRWAKError.timeout(platformError: platformError, message: message ?? "<CreateOperation> timeout"))
                     } else {
-                        self.session.cancel(reason: FRWAKError(error: .cancelled, message: "<CreateOperation> cancelled"))
+                        self.session.cancel(reason: FRWAKError.cancelled(platformError: nil, message: "<CreateOperation> cancelled"))
                     }
                 } else {
                     self.stop(by: reason)
@@ -180,7 +180,7 @@ class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
         let logMessage = "<CreateOperation> timeout"
         WAKLogger.debug(logMessage)
         self.stopLifetimeTimer()
-        self.cancel(reason: FRWAKError(error: .timeout, message: logMessage))
+        self.cancel(reason: FRWAKError.timeout(platformError: nil, message: logMessage))
     }
 
     private func judgeUserVerificationExecution(_ session: AuthenticatorMakeCredentialSession) -> Bool {
@@ -216,7 +216,7 @@ class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
                 if attachment != session.attachment {
                     let logMessage = "<CreateOperation> authenticator's attachment doesn't match to RP's request"
                     WAKLogger.debug(logMessage)
-                    self.stop(by: FRWAKError(error: .unsupported, message: logMessage))
+                    self.stop(by: FRWAKError.unsupported(platformError: nil, message: logMessage))
                     return
                 }
             }
@@ -225,7 +225,7 @@ class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
                 && !session.canStoreResidentKey() {
                 let logMessage = "<CreateOperation> This authenticator can't store resident-key"
                 WAKLogger.debug(logMessage)
-                self.stop(by: FRWAKError(error: .unsupported, message: logMessage))
+                self.stop(by: FRWAKError.unsupported(platformError: nil, message: logMessage))
                 return
             }
 
@@ -233,7 +233,7 @@ class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
                 && !session.canPerformUserVerification() {
                 let logMessage = "<CreateOperation> This authenticator can't perform user verification"
                 WAKLogger.debug(logMessage)
-                self.stop(by: FRWAKError(error: .unsupported, message: logMessage))
+                self.stop(by: FRWAKError.unsupported(platformError: nil, message: logMessage))
                 return
             }
         }
@@ -277,7 +277,7 @@ class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
     func authenticatorSessionDidBecomeUnavailable(session: AuthenticatorMakeCredentialSession) {
         let logMessage = "<CreateOperation> authenticator become unavailable"
         WAKLogger.debug(logMessage)
-        self.stop(by: FRWAKError(error: .notAllowed, message: logMessage))
+        self.stop(by: FRWAKError.notAllowed(platformError: nil, message: logMessage))
     }
 
     func authenticatorSessionDidMakeCredential(
@@ -290,7 +290,7 @@ class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
             attestation.authData.attestedCredentialData else {
             let logMessage = "<CreateOperation> attested credential data not found"
             WAKLogger.debug(logMessage)
-            self.dispatchError(FRWAKError(error: .unknown, message: logMessage))
+            self.dispatchError(FRWAKError.unknown(platformError: nil, message: logMessage))
             return
         }
 
@@ -308,7 +308,7 @@ class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
             guard let bytes = atts.toBytes() else {
                 let logMessage = "<CreateOperation> failed to build attestation-object"
                 WAKLogger.debug(logMessage)
-                self.dispatchError(FRWAKError(error: .unknown, message: logMessage))
+                self.dispatchError(FRWAKError.unknown(platformError: nil, message: logMessage))
                 return
             }
             attestationObject = bytes
@@ -318,7 +318,7 @@ class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
             guard let bytes = atts.toBytes() else {
                 let logMessage = "<CreateOperation> failed to build attestation-object"
                 WAKLogger.debug(logMessage)
-                self.dispatchError(FRWAKError(error: .unknown, message: logMessage))
+                self.dispatchError(FRWAKError.unknown(platformError: nil, message: logMessage))
                 return
             }
             attestationObject = bytes

--- a/FRAuth/FRAuth/WebAuthn/Client/Operation/ClientCreateOperation.swift
+++ b/FRAuth/FRAuth/WebAuthn/Client/Operation/ClientCreateOperation.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Lyo Kato on 2018/11/20.
 //  Original work Copyright © 2018 Lyo Kato. All rights reserved.
-//  Modified work Copyright © 2021 ForgeRock, Inc.
+//  Modified work Copyright © 2021-2022 ForgeRock, Inc.
 //
 
 import Foundation

--- a/FRAuth/FRAuth/WebAuthn/Client/Operation/ClientGetOperation.swift
+++ b/FRAuth/FRAuth/WebAuthn/Client/Operation/ClientGetOperation.swift
@@ -62,7 +62,7 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
             if self.stopped {
                 let logMessage = "<GetOperation> already stopped"
                 WAKLogger.debug(logMessage)
-                onError(FRWAKError(error: .badOperation, message: logMessage))
+                onError(FRWAKError.badOperation(platformError: nil, message: logMessage))
                 self.delegate?.operationDidFinish(opType: self.type, opId: self.id)
                 return
             }
@@ -71,7 +71,7 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
             if !transports.isEmpty && !transports.contains(self.session.transport) {
                 let logMessage = "<GetOperation> transport mismatch"
                 WAKLogger.debug(logMessage)
-                onError(FRWAKError(error: .notAllowed, message: logMessage))
+                onError(FRWAKError.notAllowed(platformError: nil, message: logMessage))
                 self.delegate?.operationDidFinish(opType: self.type, opId: self.id)
                 return
             }
@@ -87,7 +87,7 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
         }
     }
     
-    func cancel(reason: FRWAKError = FRWAKError(error: .cancelled)) {
+    func cancel(reason: FRWAKError = FRWAKError.cancelled(platformError: nil, message: nil)) {
         WAKLogger.debug("<GetOperation> cancel")
         if self.completion != nil && !self.stopped {
             DispatchQueue.global().async {
@@ -179,7 +179,7 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
         let logMessage = "<GetOperation> timeout"
         WAKLogger.debug(logMessage)
         self.stopLifetimeTimer()
-        self.cancel(reason: FRWAKError(error: .timeout, message: logMessage))
+        self.cancel(reason: FRWAKError.timeout(platformError: nil, message: logMessage))
     }
 
     private func judgeUserVerificationExecution(_ session: AuthenticatorGetAssertionSession) -> Bool {
@@ -209,7 +209,7 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
             && !session.canPerformUserVerification() {
             let logMessage = "<GetOperation> user-verification is required, but this authenticator doesn't support"
             WAKLogger.debug(logMessage)
-            self.stop(by: FRWAKError(error: .unsupported, message: logMessage))
+            self.stop(by: FRWAKError.unsupported(platformError: nil, message: logMessage))
             return
         }
 
@@ -238,7 +238,7 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
             if (allowCredentialDescriptorList.isEmpty) {
                 let logMessage = "<GetOperation> no matched credential on this authenticator"
                 WAKLogger.debug(logMessage)
-                self.stop(by: FRWAKError(error: .notAllowed, message: logMessage))
+                self.stop(by: FRWAKError.notAllowed(platformError: nil, message: logMessage))
                 return
             }
 
@@ -275,7 +275,7 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
             guard let resultId = assertion.credentailId else {
                 let logMessage = "<GetOperation> credentialId not found"
                 WAKLogger.debug(logMessage)
-                self.dispatchError(FRWAKError(error: .unknown, message: logMessage))
+                self.dispatchError(FRWAKError.unknown(platformError: nil, message: logMessage))
                 return
             }
             credentialId = resultId
@@ -304,7 +304,7 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
     func authenticatorSessionDidBecomeUnavailable(session: AuthenticatorGetAssertionSession) {
         let logMessage = "<GetOperation> authenticator become unavailable"
         WAKLogger.debug(logMessage)
-        self.stop(by: FRWAKError(error: .notAllowed, message: logMessage))
+        self.stop(by: FRWAKError.notAllowed(platformError: nil, message: logMessage))
     }
 
     func authenticatorSessionDidStopOperation(

--- a/FRAuth/FRAuth/WebAuthn/Client/Operation/ClientGetOperation.swift
+++ b/FRAuth/FRAuth/WebAuthn/Client/Operation/ClientGetOperation.swift
@@ -60,16 +60,18 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
         WAKLogger.debug("<GetOperation> start")
         DispatchQueue.global().async {
             if self.stopped {
-                WAKLogger.debug("<GetOperation> already stopped")
-                onError(WAKError.badOperation)
+                let logMessage = "<GetOperation> already stopped"
+                WAKLogger.debug(logMessage)
+                onError(FRWAKError(error: .badOperation, message: logMessage))
                 self.delegate?.operationDidFinish(opType: self.type, opId: self.id)
                 return
             }
             
             let transports: [AuthenticatorTransport] = self.options.allowCredentials.flatMap { $0.transports }
             if !transports.isEmpty && !transports.contains(self.session.transport) {
-                WAKLogger.debug("<GetOperation> transport mismatch")
-                onError(WAKError.notAllowed)
+                let logMessage = "<GetOperation> transport mismatch"
+                WAKLogger.debug(logMessage)
+                onError(FRWAKError(error: .notAllowed, message: logMessage))
                 self.delegate?.operationDidFinish(opType: self.type, opId: self.id)
                 return
             }
@@ -85,7 +87,7 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
         }
     }
     
-    func cancel(reason: WAKError = .cancelled) {
+    func cancel(reason: FRWAKError = FRWAKError(error: .cancelled)) {
         WAKLogger.debug("<GetOperation> cancel")
         if self.completion != nil && !self.stopped {
             DispatchQueue.global().async {
@@ -120,7 +122,7 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
         self.delegate?.operationDidFinish(opType: self.type, opId: self.id)
     }
 
-    private func stopInternal(reason: WAKError) {
+    private func stopInternal(reason: FRWAKError) {
         WAKLogger.debug("<GetOperation> stop")
         if self.completion == nil {
             WAKLogger.debug("<GetOperation> not started")
@@ -152,13 +154,13 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
         }
     }
 
-    private func stop(by error: WAKError) {
+    private func stop(by error: FRWAKError) {
         WAKLogger.debug("<GetOperation> stop by")
         self.stopInternal(reason: error)
         self.dispatchError(error)
     }
 
-    private func dispatchError(_ error: WAKError) {
+    private func dispatchError(_ error: FRWAKError) {
         WAKLogger.debug("<GetOperation> dispatchError")
         
         if let completion = self.completion {
@@ -174,9 +176,10 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
     }
 
     @objc func lifetimeTimerTimeout() {
-        WAKLogger.debug("<GetOperation> timeout")
+        let logMessage = "<GetOperation> timeout"
+        WAKLogger.debug(logMessage)
         self.stopLifetimeTimer()
-        self.cancel(reason: .timeout)
+        self.cancel(reason: FRWAKError(error: .timeout, message: logMessage))
     }
 
     private func judgeUserVerificationExecution(_ session: AuthenticatorGetAssertionSession) -> Bool {
@@ -204,8 +207,9 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
 
         if self.options.userVerification == .required
             && !session.canPerformUserVerification() {
-            WAKLogger.debug("<GetOperation> user-verification is required, but this authenticator doesn't support")
-            self.stop(by: .unsupported)
+            let logMessage = "<GetOperation> user-verification is required, but this authenticator doesn't support"
+            WAKLogger.debug(logMessage)
+            self.stop(by: FRWAKError(error: .unsupported, message: logMessage))
             return
         }
 
@@ -232,8 +236,9 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
             }
 
             if (allowCredentialDescriptorList.isEmpty) {
-                WAKLogger.debug("<GetOperation> no matched credential on this authenticator")
-                self.stop(by: .notAllowed)
+                let logMessage = "<GetOperation> no matched credential on this authenticator"
+                WAKLogger.debug(logMessage)
+                self.stop(by: FRWAKError(error: .notAllowed, message: logMessage))
                 return
             }
 
@@ -268,8 +273,9 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
         } else {
             WAKLogger.debug("<GetOperation> use credentialId from authenticator")
             guard let resultId = assertion.credentailId else {
-                WAKLogger.debug("<GetOperation> credentialId not found")
-                self.dispatchError(.unknown)
+                let logMessage = "<GetOperation> credentialId not found"
+                WAKLogger.debug(logMessage)
+                self.dispatchError(FRWAKError(error: .unknown, message: logMessage))
                 return
             }
             credentialId = resultId
@@ -296,13 +302,14 @@ class ClientGetOperation: AuthenticatorGetAssertionSessionDelegate {
     }
 
     func authenticatorSessionDidBecomeUnavailable(session: AuthenticatorGetAssertionSession) {
-        WAKLogger.debug("<GetOperation> authenticator become unavailable")
-        self.stop(by: .notAllowed)
+        let logMessage = "<GetOperation> authenticator become unavailable"
+        WAKLogger.debug(logMessage)
+        self.stop(by: FRWAKError(error: .notAllowed, message: logMessage))
     }
 
     func authenticatorSessionDidStopOperation(
         session: AuthenticatorGetAssertionSession,
-        reason:  WAKError
+        reason:  FRWAKError
     ) {
         WAKLogger.debug("<GetOperation> authenticator stopped operation")
         self.stop(by: reason)

--- a/FRAuth/FRAuth/WebAuthn/Client/Operation/ClientGetOperation.swift
+++ b/FRAuth/FRAuth/WebAuthn/Client/Operation/ClientGetOperation.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Lyo Kato on 2018/11/20.
 //  Original work Copyright © 2018 Lyo Kato. All rights reserved.
-//  Modified work Copyright © 2021 ForgeRock, Inc.
+//  Modified work Copyright © 2021-2022 ForgeRock, Inc.
 //
 
 import Foundation

--- a/FRAuth/FRAuth/WebAuthn/WAKTypes.swift
+++ b/FRAuth/FRAuth/WebAuthn/WAKTypes.swift
@@ -9,16 +9,22 @@
 
 import Foundation
 
-enum WAKError : Error {
-    case badData
-    case badOperation
-    case invalidState
-    case constraint
-    case cancelled
-    case timeout
-    case notAllowed
-    case unsupported
-    case unknown
+struct FRWAKError: Error {
+    enum WAKError : Error {
+        case badData
+        case badOperation
+        case invalidState
+        case constraint
+        case cancelled
+        case timeout
+        case notAllowed
+        case unsupported
+        case unknown
+    }
+    
+    var error: WAKError
+    var platformError: Error?
+    var message: String?
 }
 
 enum WAKResult<T, Error: Swift.Error> {

--- a/FRAuth/FRAuth/WebAuthn/WAKTypes.swift
+++ b/FRAuth/FRAuth/WebAuthn/WAKTypes.swift
@@ -9,22 +9,46 @@
 
 import Foundation
 
-struct FRWAKError: Error {
-    enum WAKError : Error {
-        case badData
-        case badOperation
-        case invalidState
-        case constraint
-        case cancelled
-        case timeout
-        case notAllowed
-        case unsupported
-        case unknown
+enum FRWAKError: Error {
+    case badData(platformError: Error?, message: String?)
+    case badOperation(platformError: Error?, message: String?)
+    case invalidState(platformError: Error?, message: String?)
+    case constraint(platformError: Error?, message: String?)
+    case cancelled(platformError: Error?, message: String?)
+    case timeout(platformError: Error?, message: String?)
+    case notAllowed(platformError: Error?, message: String?)
+    case unsupported(platformError: Error?, message: String?)
+    case unknown(platformError: Error?, message: String?)
+    
+    func platformError() -> Error? {
+        switch self {
+        case .badData(platformError: let platformError, message: _),
+                .badOperation(platformError: let platformError, message: _),
+                .invalidState(platformError: let platformError, message: _),
+                .constraint(platformError: let platformError, message: _),
+                .cancelled(platformError: let platformError, message: _),
+                .timeout(platformError: let platformError, message: _),
+                .notAllowed(platformError: let platformError, message: _),
+                .unsupported(platformError: let platformError, message: _),
+                .unknown(platformError: let platformError, message: _):
+            return platformError
+        }
     }
     
-    var error: WAKError
-    var platformError: Error?
-    var message: String?
+    func message() -> String? {
+        switch self {
+        case .badData(platformError: _, message: let message),
+                .badOperation(platformError: _, message: let message),
+                .invalidState(platformError: _, message: let message),
+                .constraint(platformError: _, message: let message),
+                .cancelled(platformError: _, message: let message),
+                .timeout(platformError: _, message: let message),
+                .notAllowed(platformError: _, message: let message),
+                .unsupported(platformError: _, message: let message),
+                .unknown(platformError: _, message: let message):
+            return message
+        }
+    }
 }
 
 enum WAKResult<T, Error: Swift.Error> {

--- a/FRAuth/FRAuth/WebAuthn/WAKTypes.swift
+++ b/FRAuth/FRAuth/WebAuthn/WAKTypes.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Lyo Kato on 2018/11/20.
 //  Original work Copyright © 2018 Lyo Kato. All rights reserved.
-//  Modified work Copyright © 2021 ForgeRock, Inc.
+//  Modified work Copyright © 2021-2022 ForgeRock, Inc.
 //
 
 import Foundation

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Callback/WebAuthnRegistrationCallbackTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Callback/WebAuthnRegistrationCallbackTests.swift
@@ -2,7 +2,7 @@
 //  WebAuthnRegistrationCallbackTests.swift
 //  FRAuthTests
 //
-//  Copyright (c) 2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2021-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnAuthenticationTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnAuthenticationTests.swift
@@ -2,7 +2,7 @@
 //  WebAuthnAuthenticationTests.swift
 //  FRAuthTests
 //
-//  Copyright (c) 2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2021-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnAuthenticationTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnAuthenticationTests.swift
@@ -223,6 +223,7 @@ class WebAuthnAuthenticationTests: WebAuthnSharedUtils {
                 if let webAuthnError = error as? WebAuthnError {
                     switch webAuthnError.webAuthnError {
                     case .notAllowed:
+                        XCTAssertNotNil(webAuthnError.message)
                         break
                     default:
                         XCTFail("Failed with unexpected error: \(error.localizedDescription)")

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnAuthenticationTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnAuthenticationTests.swift
@@ -221,7 +221,7 @@ class WebAuthnAuthenticationTests: WebAuthnSharedUtils {
             }) { (error) in
                 
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnError {
+                    switch webAuthnError.webAuthnErrorCase {
                     case .notAllowed:
                         XCTAssertNotNil(webAuthnError.message)
                         break
@@ -404,7 +404,7 @@ class WebAuthnAuthenticationTests: WebAuthnSharedUtils {
             }) { (error) in
                 
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnError {
+                    switch webAuthnError.webAuthnErrorCase {
                     case .timeout:
                         break
                     default:

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnAuthenticationTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnAuthenticationTests.swift
@@ -221,7 +221,7 @@ class WebAuthnAuthenticationTests: WebAuthnSharedUtils {
             }) { (error) in
                 
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError {
+                    switch webAuthnError.webAuthnError {
                     case .notAllowed:
                         break
                     default:
@@ -403,7 +403,7 @@ class WebAuthnAuthenticationTests: WebAuthnSharedUtils {
             }) { (error) in
                 
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError {
+                    switch webAuthnError.webAuthnError {
                     case .timeout:
                         break
                     default:

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnRegistrationTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnRegistrationTests.swift
@@ -93,7 +93,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError {
+                    switch webAuthnError.webAuthnError {
                     case .timeout:
                         break
                     default:
@@ -136,7 +136,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError {
+                    switch webAuthnError.webAuthnError {
                     case .cancelled:
                         break
                     default:
@@ -179,7 +179,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError {
+                    switch webAuthnError.webAuthnError {
                     case .cancelled:
                         break
                     default:
@@ -224,7 +224,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError {
+                    switch webAuthnError.webAuthnError {
                     case .unsupported:
                         break
                     default:
@@ -304,7 +304,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError {
+                    switch webAuthnError.webAuthnError {
                     case .invalidState:
                         break
                     default:
@@ -341,7 +341,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError {
+                    switch webAuthnError.webAuthnError {
                     case .notAllowed:
                         break
                     default:

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnRegistrationTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnRegistrationTests.swift
@@ -343,6 +343,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
                 if let webAuthnError = error as? WebAuthnError {
                     switch webAuthnError.webAuthnError {
                     case .notAllowed:
+                        XCTAssertNotNil(webAuthnError.message)
                         break
                     default:
                         XCTFail("Failed with unexpected error: \(error.localizedDescription)")

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnRegistrationTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnRegistrationTests.swift
@@ -93,7 +93,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnError {
+                    switch webAuthnError.webAuthnErrorCase {
                     case .timeout:
                         break
                     default:
@@ -136,7 +136,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnError {
+                    switch webAuthnError.webAuthnErrorCase {
                     case .cancelled:
                         break
                     default:
@@ -179,7 +179,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnError {
+                    switch webAuthnError.webAuthnErrorCase {
                     case .cancelled:
                         break
                     default:
@@ -224,7 +224,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnError {
+                    switch webAuthnError.webAuthnErrorCase {
                     case .unsupported:
                         break
                     default:
@@ -304,7 +304,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnError {
+                    switch webAuthnError.webAuthnErrorCase {
                     case .invalidState:
                         break
                     default:
@@ -341,7 +341,7 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnError {
+                    switch webAuthnError.webAuthnErrorCase {
                     case .notAllowed:
                         XCTAssertNotNil(webAuthnError.message)
                         break

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnRegistrationTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnRegistrationTests.swift
@@ -2,7 +2,7 @@
 //  WebAuthnRegistrationTests.swift
 //  FRAuthTests
 //
-//  Copyright (c) 2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2021-2022 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnRegistrationTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/WebAuthnRegistrationTests.swift
@@ -93,8 +93,9 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnErrorCase {
+                    switch webAuthnError {
                     case .timeout:
+                        XCTAssertNotNil(webAuthnError.message())
                         break
                     default:
                         XCTFail("Failed with unexpected error: \(error.localizedDescription)")
@@ -136,8 +137,9 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnErrorCase {
+                    switch webAuthnError {
                     case .cancelled:
+                        XCTAssertNotNil(webAuthnError.message())
                         break
                     default:
                         XCTFail("Failed with unexpected error: \(error.localizedDescription)")
@@ -179,8 +181,9 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnErrorCase {
+                    switch webAuthnError {
                     case .cancelled:
+                        XCTAssertNotNil(webAuthnError.message())
                         break
                     default:
                         XCTFail("Failed with unexpected error: \(error.localizedDescription)")
@@ -224,8 +227,9 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnErrorCase {
+                    switch webAuthnError {
                     case .unsupported:
+                        XCTAssertNotNil(webAuthnError.message())
                         break
                     default:
                         XCTFail("Failed with unexpected error: \(error.localizedDescription)")
@@ -304,8 +308,9 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnErrorCase {
+                    switch webAuthnError {
                     case .invalidState:
+                        XCTAssertNotNil(webAuthnError.message())
                         break
                     default:
                         XCTFail("Failed with unexpected error: \(error.localizedDescription)")
@@ -341,9 +346,9 @@ class WebAuthnRegistrationTests: WebAuthnSharedUtils {
             }) { (error) in
             
                 if let webAuthnError = error as? WebAuthnError {
-                    switch webAuthnError.webAuthnErrorCase {
+                    switch webAuthnError {
                     case .notAllowed:
-                        XCTAssertNotNil(webAuthnError.message)
+                        XCTAssertNotNil(webAuthnError.message())
                         break
                     default:
                         XCTFail("Failed with unexpected error: \(error.localizedDescription)")


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2226](https://bugster.forgerock.org/jira/browse/SDKS-2226)

# Description

Made the WAKError and WebAuthError structs to hold more information and surface the platform error and message description

Updated the submitted message to contain the ErrorMessage as the protocol (AM) defines where available

Updated tests
