### PR TITLE
SDKS-2279_Deleting WebAuthn Credentials

### DIFF
--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -283,6 +283,7 @@
 		EC7EA0F427D10FA70003F878 /* AppleSignInUserStructs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7EA0F327D10FA70003F878 /* AppleSignInUserStructs.swift */; };
 		EC8BCAFF273C3EC100C3B2D8 /* FRHTTPCookie.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8BCAFD273C3EC100C3B2D8 /* FRHTTPCookie.swift */; };
 		ECDF5F4929674E9E007BB721 /* FRWebAuthn.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECDF5F4829674E9E007BB721 /* FRWebAuthn.swift */; };
+		ECDF5F4C296851DD007BB721 /* FRWebAuthnTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECDF5F4B296851DD007BB721 /* FRWebAuthnTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -614,6 +615,7 @@
 		EC7EA0F327D10FA70003F878 /* AppleSignInUserStructs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInUserStructs.swift; sourceTree = "<group>"; };
 		EC8BCAFD273C3EC100C3B2D8 /* FRHTTPCookie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRHTTPCookie.swift; sourceTree = "<group>"; };
 		ECDF5F4829674E9E007BB721 /* FRWebAuthn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRWebAuthn.swift; sourceTree = "<group>"; };
+		ECDF5F4B296851DD007BB721 /* FRWebAuthnTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRWebAuthnTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -893,6 +895,7 @@
 		D53A806126278A410093B1CA /* WebAuthn */ = {
 			isa = PBXGroup;
 			children = (
+				ECDF5F4B296851DD007BB721 /* FRWebAuthnTests.swift */,
 				D53A806226278A410093B1CA /* WebAuthnRegistrationTests.swift */,
 				D53A806326278A410093B1CA /* WebAuthnSharedUtils.swift */,
 				D53A806426278A410093B1CA /* WebAuthnAuthenticationTests.swift */,
@@ -1964,6 +1967,7 @@
 				D5791BDD25F87DE8004B487A /* TokenTests.swift in Sources */,
 				D5791BDE25F87DE8004B487A /* PKCETests.swift in Sources */,
 				D58BC39F2602FB7700254654 /* IdPValueTests.swift in Sources */,
+				ECDF5F4C296851DD007BB721 /* FRWebAuthnTests.swift in Sources */,
 				D5791BDF25F87DE8004B487A /* AccessTokenTests.swift in Sources */,
 				D5791BE025F87DE8004B487A /* FRUserTests.swift in Sources */,
 				D5791BE125F87DE8004B487A /* FRUserBrowserTests.swift in Sources */,

--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -282,6 +282,7 @@
 		EC0BA2FA2863325B00F8326E /* FROptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0BA2F92863325B00F8326E /* FROptionsTests.swift */; };
 		EC7EA0F427D10FA70003F878 /* AppleSignInUserStructs.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7EA0F327D10FA70003F878 /* AppleSignInUserStructs.swift */; };
 		EC8BCAFF273C3EC100C3B2D8 /* FRHTTPCookie.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC8BCAFD273C3EC100C3B2D8 /* FRHTTPCookie.swift */; };
+		ECDF5F4929674E9E007BB721 /* FRWebAuthn.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECDF5F4829674E9E007BB721 /* FRWebAuthn.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -612,6 +613,7 @@
 		EC0BA2F92863325B00F8326E /* FROptionsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FROptionsTests.swift; sourceTree = "<group>"; };
 		EC7EA0F327D10FA70003F878 /* AppleSignInUserStructs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInUserStructs.swift; sourceTree = "<group>"; };
 		EC8BCAFD273C3EC100C3B2D8 /* FRHTTPCookie.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRHTTPCookie.swift; sourceTree = "<group>"; };
+		ECDF5F4829674E9E007BB721 /* FRWebAuthn.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRWebAuthn.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -818,6 +820,7 @@
 				D53A8025262789BD0093B1CA /* Authenticator */,
 				D53A8033262789BD0093B1CA /* Client */,
 				D53A8038262789BD0093B1CA /* WAKTypes.swift */,
+				ECDF5F4829674E9E007BB721 /* FRWebAuthn.swift */,
 			);
 			path = WebAuthn;
 			sourceTree = "<group>";
@@ -1855,6 +1858,7 @@
 				D586CFB323358EE0007A2194 /* PlatformCollector.swift in Sources */,
 				D5723C3C23F4C65800557AA8 /* AuthService.swift in Sources */,
 				D5791C1E25F8869C004B487A /* JBUtil.c in Sources */,
+				ECDF5F4929674E9E007BB721 /* FRWebAuthn.swift in Sources */,
 				D5E86BBD2481E5B800DFD5E0 /* FRURLProtocol.swift in Sources */,
 				D53A803C262789BD0093B1CA /* JSON.swift in Sources */,
 				D586CF9B23358EE0007A2194 /* ReCaptchaCallback.swift in Sources */,

--- a/FRAuth/FRAuth/Callbacks/WebAuthnRegistrationCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/WebAuthnRegistrationCallback.swift
@@ -57,6 +57,7 @@ open class WebAuthnRegistrationCallback: WebAuthnCallback {
     /// Boolean indicator whether or not Callback response is AM 7.1.0 or above
     var isNewJSONFormat: Bool = false
     var pubCredAlg: [COSEAlgorithmIdentifier] = []
+    var platformAuthenticator: PlatformAuthenticator?
     
     //  MARK: - Lifecycle
     
@@ -293,7 +294,11 @@ open class WebAuthnRegistrationCallback: WebAuthnCallback {
         }
         
         //  Platform Authenticator
-        let platformAuthenticator = PlatformAuthenticator(registrationDelegate: self)
+        self.platformAuthenticator = PlatformAuthenticator(registrationDelegate: self)
+        guard let platformAuthenticator = self.platformAuthenticator else {
+            onError(FRWAKError.unknown(platformError: nil, message: "Failed to create PlatformAuthenticator"))
+            return
+        }
         //  For AM 7.0.0, origin only supports https scheme; to be updated for AM 7.1.0
         var origin = CBConstants.originScheme + (Bundle.main.bundleIdentifier ?? CBConstants.defaultOrigin)
         //  For AM 7.1.0 or above, origin should follow origin format according to FIDO AppId and Facet specification
@@ -372,6 +377,10 @@ open class WebAuthnRegistrationCallback: WebAuthnCallback {
                 onError(error)
             }
         }
+    }
+    
+    public func clearAllCredentials() {
+        self.platformAuthenticator?.clearAllCredentialsFromCredentialStore(rpId: self.relyingPartyId)
     }
 }
 

--- a/FRAuth/FRAuth/Callbacks/WebAuthnRegistrationCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/WebAuthnRegistrationCallback.swift
@@ -2,7 +2,7 @@
 //  WebAuthnRegistrationCallback.swift
 //  FRAuth
 //
-//  Copyright (c) 2021-2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2021-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/Callbacks/WebAuthnRegistrationCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/WebAuthnRegistrationCallback.swift
@@ -378,10 +378,6 @@ open class WebAuthnRegistrationCallback: WebAuthnCallback {
             }
         }
     }
-    
-    public func clearAllCredentials() {
-        self.platformAuthenticator?.clearAllCredentialsFromCredentialStore(rpId: self.relyingPartyId)
-    }
 }
 
 

--- a/FRAuth/FRAuth/User/FRUser.swift
+++ b/FRAuth/FRAuth/User/FRUser.swift
@@ -2,7 +2,7 @@
 //  FRUser.swift
 //  FRAuth
 //
-//  Copyright (c) 2019-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/User/FRUser.swift
+++ b/FRAuth/FRAuth/User/FRUser.swift
@@ -376,13 +376,6 @@ public class FRUser: NSObject, NSSecureCoding {
         return BrowserBuilder(oAuth2Client, frAuth.keychainManager)
     }
     
-    @objc
-    public func clearWebAuthnCredentialsForRpId(_ rpId: String) {
-        let platformAuthenticator = PlatformAuthenticator()
-        platformAuthenticator.clearAllCredentialsFromCredentialStore(rpId: rpId)
-    }
-    
-    
     // MARK: - Private methods
     
     /// Refreshes user's session with refresh_token regardless of validity of current access_token

--- a/FRAuth/FRAuth/User/FRUser.swift
+++ b/FRAuth/FRAuth/User/FRUser.swift
@@ -376,6 +376,12 @@ public class FRUser: NSObject, NSSecureCoding {
         return BrowserBuilder(oAuth2Client, frAuth.keychainManager)
     }
     
+    @objc
+    public func clearWebAuthnCredentialsForRpId(_ rpId: String) {
+        let platformAuthenticator = PlatformAuthenticator()
+        platformAuthenticator.clearAllCredentialsFromCredentialStore(rpId: rpId)
+    }
+    
     
     // MARK: - Private methods
     

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/Internal/CredentialSource.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/Internal/CredentialSource.swift
@@ -4,12 +4,22 @@
 //
 //  Created by Lyo Kato on 2018/11/23.
 //  Original work Copyright © 2018 Lyo Kato. All rights reserved.
-//  Modified work Copyright © 2021 ForgeRock, Inc.
+//  Modified work Copyright © 2021-2023 ForgeRock, Inc.
 //
 
 import Foundation
 import FRCore
 
+/**
+ PublicKeyCredentialSource is a struct representing a WebAuthn Public Key credential. The initializer expects the folowing variables:
+ `id: [UInt8]`,
+ `rpId: String`,
+ `userHandle: [UInt8]?`,
+ `signCount: UInt32`,
+ `alg: Int`,
+ `otherUI: String`
+ PublicKeyCredentialSources are used to list and stored credentials on the device.
+ */
 public struct PublicKeyCredentialSource {
     
     var keyLabel: String {

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/Internal/CredentialSource.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/Internal/CredentialSource.swift
@@ -22,7 +22,7 @@ import FRCore
  */
 public struct PublicKeyCredentialSource {
     
-    var keyLabel: String {
+    public var keyLabel: String {
         get {
             let idHex = self.id.toHexString()
             return "\(self.rpId)/\(idHex)"
@@ -35,7 +35,7 @@ public struct PublicKeyCredentialSource {
     var rpId:       String
     var userHandle: [UInt8]?
     var alg:        Int = COSEAlgorithmIdentifier.rs256.rawValue
-    var otherUI:    String
+    public var otherUI:    String
     
     init(
         id:         [UInt8],

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/Internal/CredentialSource.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/Internal/CredentialSource.swift
@@ -10,7 +10,7 @@
 import Foundation
 import FRCore
 
-struct PublicKeyCredentialSource {
+public struct PublicKeyCredentialSource {
     
     var keyLabel: String {
         get {

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticator.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticator.swift
@@ -108,4 +108,11 @@ class PlatformAuthenticator: Authenticator {
         FRLog.v("Starting getAssertionSession", subModule: WebAuthn.module)
         return PlatformAuthenticatorGetAssertionSession(config: self.config, keySupportChooser: self.keySupportChooser, credentialsStore: self.credentialsStore, authenticatorDelegate: self.authenticationDelegate)
     }
+    
+    func clearAllCredentialsFromCredentialStore(rpId: String) {
+        let credentialSources = self.credentialsStore.loadAllCredentialSources(rpId: rpId)
+        credentialSources.forEach {
+            _ = self.credentialsStore.deleteCredentialSource($0)
+        }
+    }
 }

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticator.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticator.swift
@@ -115,4 +115,12 @@ class PlatformAuthenticator: Authenticator {
             _ = self.credentialsStore.deleteCredentialSource($0)
         }
     }
+    
+    func loadAllCredentials(rpId: String) ->  [PublicKeyCredentialSource] {
+        return self.credentialsStore.loadAllCredentialSources(rpId: rpId)
+    }
+    
+    func deleteCredential(publicKeyCredentialSource: PublicKeyCredentialSource) {
+        _ = self.credentialsStore.deleteCredentialSource(publicKeyCredentialSource)
+    }
 }

--- a/FRAuth/FRAuth/WebAuthn/FRWebAuthn.swift
+++ b/FRAuth/FRAuth/WebAuthn/FRWebAuthn.swift
@@ -1,0 +1,30 @@
+// 
+//  FRWebAuthn.swift
+//  FRAuth
+//
+//  Copyright (c) 2023 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+
+import Foundation
+import FRCore
+
+public class FRWebAuthn: NSObject {
+    public static func deleteCredentials(by rpId: String) {
+        let platformAuthenticator = PlatformAuthenticator()
+        platformAuthenticator.clearAllCredentialsFromCredentialStore(rpId: rpId)
+    }
+    
+    public static func loadAllCredentials(by rpId: String) ->  [PublicKeyCredentialSource] {
+        let platformAuthenticator = PlatformAuthenticator()
+        return platformAuthenticator.loadAllCredentials(rpId: rpId)
+    }
+    
+    public static func deleteCredential(with publicKeyCredentialSource: PublicKeyCredentialSource) {
+        let platformAuthenticator = PlatformAuthenticator()
+        return platformAuthenticator.deleteCredential(publicKeyCredentialSource: publicKeyCredentialSource)
+    }
+}

--- a/FRAuth/FRAuth/WebAuthn/FRWebAuthn.swift
+++ b/FRAuth/FRAuth/WebAuthn/FRWebAuthn.swift
@@ -12,17 +12,36 @@
 import Foundation
 import FRCore
 
+/**
+ FRWebAuthn is a utility class providing helper methods for listing and deleting WebAuthn keys stored on the device.
+ The provided static methods are:
+ `public static func deleteCredentials(by rpId: String)`
+ `public static func loadAllCredentials(by rpId: String) ->  [PublicKeyCredentialSource]`
+ `public static func deleteCredential(with publicKeyCredentialSource: PublicKeyCredentialSource)`
+ */
 public class FRWebAuthn: NSObject {
+    /// Deletes stored credentials for a specific Relying Party Identifier
+    ///
+    /// - Parameters:
+    ///   - rpId: Relying Party Identifier
     public static func deleteCredentials(by rpId: String) {
         let platformAuthenticator = PlatformAuthenticator()
         platformAuthenticator.clearAllCredentialsFromCredentialStore(rpId: rpId)
     }
     
+    /// Returns all the stored credentials for a specific Relying Party Identifier
+    ///
+    /// - Parameters:
+    ///   - rpId: Relying Party Identifier
     public static func loadAllCredentials(by rpId: String) ->  [PublicKeyCredentialSource] {
         let platformAuthenticator = PlatformAuthenticator()
         return platformAuthenticator.loadAllCredentials(rpId: rpId)
     }
     
+    /// Deletes a stored WebAuthn Credential (PublicKeyCredentialSource)
+    ///
+    /// - Parameters:
+    ///   - publicKeyCredentialSource: PublicKeyCredentialSource
     public static func deleteCredential(with publicKeyCredentialSource: PublicKeyCredentialSource) {
         let platformAuthenticator = PlatformAuthenticator()
         return platformAuthenticator.deleteCredential(publicKeyCredentialSource: publicKeyCredentialSource)

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/FRWebAuthnTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/WebAuthn/FRWebAuthnTests.swift
@@ -1,0 +1,161 @@
+// 
+//  FRWebAuthnTests.swift
+//  FRAuthTests
+//
+//  Copyright (c) 2023 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+
+import XCTest
+@testable import FRAuth
+
+final class FRWebAuthnTests: WebAuthnSharedUtils {
+
+    var relyingPartyId: String = "com.forgerock.ios.webauthn.registration.test"
+    var excludeConsentResult: WebAuthnUserConsentResult?
+    var createNewKeyConsentResult: WebAuthnUserConsentResult?
+    static var registeredCredentialids: [[UInt8]] = []
+    static var registeredKeyName: [String] = []
+    var causeDelay: Int = 0
+    
+    override func setUp() {
+        self.configFileName = "Config"
+        super.setUp()
+        
+        self.startSDK()
+    }
+    
+    
+    override func tearDown() {
+        super.tearDown()
+        
+        FRWebAuthn.deleteCredentials(by: relyingPartyId)
+        
+        self.excludeConsentResult = nil
+        self.createNewKeyConsentResult = nil
+    }
+    
+    func test_01_loadAllCredentials() {
+        //  Perform registration first
+        self.performWebAuthnRegistration()
+        
+        //Load all discoverable credentials
+        let registeredCredentials = FRWebAuthn.loadAllCredentials(by: relyingPartyId)
+        XCTAssertTrue(registeredCredentials.count == 1)
+    }
+    
+    func test_02_deleteByRpId() {
+        //  Perform registration first
+        self.performWebAuthnRegistration()
+        //  Twice
+        self.performWebAuthnRegistration()
+        
+        //Load all discoverable credentials
+        let registeredCredentials = FRWebAuthn.loadAllCredentials(by: relyingPartyId)
+        XCTAssertTrue(registeredCredentials.count == 2)
+        
+        //Delete all based on the RpId
+        FRWebAuthn.deleteCredentials(by: relyingPartyId)
+        
+        //Load all discoverable credentials
+        let registeredCredentialsAfterDeletion = FRWebAuthn.loadAllCredentials(by: relyingPartyId)
+        XCTAssertTrue(registeredCredentialsAfterDeletion.count == 0)
+        
+    }
+    
+    func test_03_deleteWithCredential() {
+        //  Perform registration first
+        self.performWebAuthnRegistration()
+        //  Twice
+        self.performWebAuthnRegistration()
+        
+        //Load all discoverable credentials
+        let registeredCredentials = FRWebAuthn.loadAllCredentials(by: relyingPartyId)
+        XCTAssertTrue(registeredCredentials.count == 2)
+        
+        //Delete one by one based on the CredentialSource
+        for credential in registeredCredentials {
+            FRWebAuthn.deleteCredential(with: credential)
+        }
+        
+        //Load all discoverable credentials
+        let registeredCredentialsAfterDeletion = FRWebAuthn.loadAllCredentials(by: relyingPartyId)
+        XCTAssertTrue(registeredCredentialsAfterDeletion.count == 0)
+    }
+    
+    //  MARK: - Helper for registration
+    
+    fileprivate func performWebAuthnRegistration(requireResidentKey: Bool = false, userName: String = "527490d2-0d91-483e-bf0b-853ff3bb2447", displayName: String = "527490d2-0d91-483e-bf0b-853ff3bb2447", userId: String = "NTI3NDkwZDItMGQ5MS00ODNlLWJmMGItODUzZmYzYmIyNDQ3") {
+        var result: String?
+        
+        //  Perform Registration first
+        do {
+            let callback = try self.createRegistrationCallback(userName: userName, displayName: displayName, userId: userId)
+            
+            //  Disable UV for testing
+            callback.userVerification = .discouraged
+            //  Set rpId
+            callback.relyingPartyId = self.relyingPartyId
+            //  Set requireResidentKey
+            callback.requireResidentKey = requireResidentKey
+            //  Set delegate
+            callback.delegate = self
+            //  Require residentKey, to make the credential client discoverable.
+            callback.requireResidentKey = true
+            
+            //  Set delegation consent result
+            self.createNewKeyConsentResult = .allow
+            
+            //  Perform registration
+            let ex = self.expectation(description: "WebAuthn Registration")
+            callback.register(onSuccess: { (webAuthnOutcome) in
+                result = webAuthnOutcome
+                XCTAssertNotNil(webAuthnOutcome)
+                ex.fulfill()
+            }) { (error) in
+                XCTFail("Failed with unexpected error: \(error.localizedDescription)")
+                ex.fulfill()
+            }
+            waitForExpectations(timeout: 60, handler: nil)
+        }
+        catch {
+            XCTFail("Failed with unexpected error")
+        }
+        
+        //  Make sure that successful WebAuthn outcome is captured
+        guard let webAuthnResult = result else {
+            XCTFail("Failed to capture successful WebAuthn result")
+            return
+        }
+        
+        //  Parse AttestationObject, AuthenticatorData, and AttestedCredentialData to extract credentialId from WebAuthnOutcome
+        let credentialStore = KeychainCredentialStore()
+        guard let attestationObj = self.parseAttestationObjectFromRegistrationResult(str: webAuthnResult), let credentialData = attestationObj.authData.attestedCredentialData, let userCredentials = credentialStore.lookupCredentialSource(rpId: self.relyingPartyId, credentialId: credentialData.credentialId) else {
+            XCTFail("Failed to parse AuthenticatorData from WebAuthnOutcome result")
+            return
+        }
+        //  Capture registered credential identifier
+        FRWebAuthnTests.registeredCredentialids.append(credentialData.credentialId)
+        FRWebAuthnTests.registeredKeyName.append(userCredentials.otherUI)
+        //  Cause 1 second delay to avoid duplicate in KeyName
+        sleep(1)
+    }
+    
+}
+
+extension FRWebAuthnTests: PlatformAuthenticatorRegistrationDelegate {
+    func excludeCredentialDescriptorConsent(consentCallback: @escaping WebAuthnUserConsentCallback) {
+        if let result = self.excludeConsentResult {
+            consentCallback(result)
+        }
+    }
+    
+    func createNewCredentialConsent(keyName: String, rpName: String, rpId: String?, userName: String, userDisplayName: String, consentCallback: @escaping WebAuthnUserConsentCallback) {
+        if let result = self.createNewKeyConsentResult {
+            consentCallback(result)
+        }
+    }
+}

--- a/SampleApps/FRExample/FRExample/ViewController.swift
+++ b/SampleApps/FRExample/FRExample/ViewController.swift
@@ -2,7 +2,7 @@
 //  ViewController.swift
 //  FRExample
 //
-//  Copyright (c) 2019-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -14,6 +14,7 @@ import FRCore
 import FRUI
 import CoreLocation
 import QuartzCore
+import SwiftUI
 
 class ViewController: UIViewController {
 
@@ -150,7 +151,8 @@ class ViewController: UIViewController {
             "Login without UI (Accesstoken)",
             "FRSession.authenticate without UI (Token)",
             "Display Configurations",
-            "Revoke Access Token"
+            "Revoke Access Token",
+            "List WebAuthn Credentials"
         ]
         self.commandField?.setTitle("Login with UI (FRUser)", for: .normal)
         
@@ -592,6 +594,27 @@ class ViewController: UIViewController {
         })
     }
     
+    func listWebAuthnCredentialsByRpId() {
+        
+        let alert = UIAlertController(title: "List WebAuthn Credentials",
+                                      message: "List all credentials by RpId", preferredStyle: .alert)
+        alert.addTextField { (textField) in
+            textField.placeholder = "RpId"
+        }
+        
+        alert.addAction(UIAlertAction(title: "List", style: .default, handler: { [weak alert] (_) in
+            guard let textField = alert?.textFields?[0], let rpid = textField.text else { return }
+            
+            let viewController = WebAuthnCredentialsTableViewController(rpId: rpid)
+            alert!.view.addSubview(viewController.view)
+            self.present(viewController, animated: true, completion: nil)
+        }))
+        
+        alert.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+
+        self.present(alert, animated: true, completion: nil)
+    }
+    
     
     func performJailbreakDetector() {
         let result = FRJailbreakDetector.shared.analyze()
@@ -785,6 +808,10 @@ class ViewController: UIViewController {
             // Revoke Access Token
             self.revokeAccessToken()
             break
+        case 19:
+            // List WebAuthn Credentials by rpId
+            self.listWebAuthnCredentialsByRpId()
+            break
         default:
             break
         }
@@ -869,4 +896,89 @@ extension ViewController: AuthorizationPolicyDelegate {
 //        mutableRequest.setValue(txId, forHTTPHeaderField: "transactionId")
 //        return mutableRequest as URLRequest
 //    }
+}
+
+class WebAuthnCredentialsTableViewController: UITableViewController {
+    let identifier = "cell"
+    var rpId = ""
+    var credentialSource: [PublicKeyCredentialSource] = []
+    
+    init(rpId: String) {
+        self.rpId = rpId
+        self.credentialSource = FRWebAuthn.loadAllCredentials(by: rpId)
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.tableView.register(UITableViewCell.self, forCellReuseIdentifier: self.identifier)
+    }
+    
+    override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return credentialSource.count
+    }
+    
+    override func numberOfSections(in tableView: UITableView) -> Int {
+        return 1
+    }
+    
+    override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: self.identifier)!
+        cell.textLabel?.text = self.credentialSource[indexPath.row].otherUI
+        return cell
+    }
+    
+    override func tableView(_ tableView: UITableView, editingStyleForRowAt indexPath: IndexPath) -> UITableViewCell.EditingStyle {
+        return .delete
+    }
+    
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        
+      if(editingStyle == .delete) {
+        FRWebAuthn.deleteCredential(with: self.credentialSource[indexPath.row])
+        self.credentialSource = FRWebAuthn.loadAllCredentials(by: self.rpId)
+        tableView.reloadData()
+       }
+    }
+    
+    override func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        return "Found \(credentialSource.count) WebAuthn Credentials for rpID \"\(self.rpId)\""
+    }
+    
+    override func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        let footerView = UIView()
+        let deleteAllButton = UIButton()
+        deleteAllButton.frame = CGRect(x: 0, y: 0, width: self.view.frame.width, height: 30)
+        deleteAllButton.setTitle("Delete All", for: .normal)
+        deleteAllButton.setTitleColor(.white, for: .normal)
+        deleteAllButton.backgroundColor = .red
+        deleteAllButton.addTarget(self, action: #selector(deleteAllAction), for: .touchUpInside)
+        
+        footerView.addSubview(deleteAllButton)
+        return footerView
+    }
+    
+    override func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
+        return 30
+    }
+    
+    @objc func deleteAllAction(sender: UIButton!) {
+        let alert = UIAlertController(title: "Delete WebAuthn Credentials",
+                                      message: "Are you sure you want to delete all credentials for RpId \"\(self.rpId)\"?",
+                                      preferredStyle: .alert)
+
+        alert.addAction(UIAlertAction(title: "Yes", style: .destructive, handler: { (alert: UIAlertAction!) in
+            FRWebAuthn.deleteCredentials(by: self.rpId)
+            self.credentialSource = FRWebAuthn.loadAllCredentials(by: self.rpId)
+            self.tableView.reloadData()
+        }))
+        
+        alert.addAction(UIAlertAction(title: "No", style: .cancel, handler: nil))
+
+        self.present(alert, animated: true, completion: nil)
+    }
 }

--- a/SampleApps/FRExample/FRExample/ViewController.swift
+++ b/SampleApps/FRExample/FRExample/ViewController.swift
@@ -14,7 +14,6 @@ import FRCore
 import FRUI
 import CoreLocation
 import QuartzCore
-import SwiftUI
 
 class ViewController: UIViewController {
 


### PR DESCRIPTION
Exposing method to clear the credentials for WebAuthn from the WebAuthnRegistration callback and the FRUser class

# JIRA Ticket

[SDKS-2279](https://bugster.forgerock.org/jira/browse/SDKS-2279)
