### PR TITLE
Add Custom UI for passcode entry for Application PIN type

### DIFF
--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -28,7 +28,7 @@
 		A5BE3C6A294500360041F990 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BE3C69294500360041F990 /* Binding.swift */; };
 		A5BE3C6D294518A40041F990 /* CryptoAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BE3C6C294518A40041F990 /* CryptoAware.swift */; };
 		A5C4D5392947DB28003024B5 /* ApplicationPinDeviceAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C4D5382947DB28003024B5 /* ApplicationPinDeviceAuthenticator.swift */; };
-		A5CCE859296DF6F9006D98AA /* ApplicationPinDeviceAuthenticatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CCE858296DF6F9006D98AA /* ApplicationPinDeviceAuthenticatorDelegate.swift */; };
+		A5CCE859296DF6F9006D98AA /* PinCollector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CCE858296DF6F9006D98AA /* PinCollector.swift */; };
 		D512CD41240DC41E00AF520E /* FRRestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D512CD40240DC41E00AF520E /* FRRestClient.swift */; };
 		D513F17524DA6B490042228B /* AuthApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D513F17424DA6B490042228B /* AuthApiError.swift */; };
 		D533270B24806665002FF207 /* TokenManagementPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D533270A24806665002FF207 /* TokenManagementPolicy.swift */; };
@@ -369,7 +369,7 @@
 		A5BE3C69294500360041F990 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		A5BE3C6C294518A40041F990 /* CryptoAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoAware.swift; sourceTree = "<group>"; };
 		A5C4D5382947DB28003024B5 /* ApplicationPinDeviceAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPinDeviceAuthenticator.swift; sourceTree = "<group>"; };
-		A5CCE858296DF6F9006D98AA /* ApplicationPinDeviceAuthenticatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPinDeviceAuthenticatorDelegate.swift; sourceTree = "<group>"; };
+		A5CCE858296DF6F9006D98AA /* PinCollector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinCollector.swift; sourceTree = "<group>"; };
 		D5015FEE24996AE50025FEB6 /* MetadataCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataCallbackTests.swift; sourceTree = "<group>"; };
 		D5054B4D244680C3007FBA92 /* DeviceProfileCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceProfileCallbackTests.swift; sourceTree = "<group>"; };
 		D5094CD923DF7F850041D5C1 /* CookieTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieTests.swift; sourceTree = "<group>"; };
@@ -676,7 +676,7 @@
 			isa = PBXGroup;
 			children = (
 				A5C4D5382947DB28003024B5 /* ApplicationPinDeviceAuthenticator.swift */,
-				A5CCE858296DF6F9006D98AA /* ApplicationPinDeviceAuthenticatorDelegate.swift */,
+				A5CCE858296DF6F9006D98AA /* PinCollector.swift */,
 				A54874A328F741AA00FF9B99 /* DeviceBindingAuthenticators.swift */,
 				A5BE3C6C294518A40041F990 /* CryptoAware.swift */,
 				A54874AC28FE158D00FF9B99 /* DeviceBindingStatus.swift */,
@@ -1890,7 +1890,7 @@
 				D53A803D262789BD0093B1CA /* Base64.swift in Sources */,
 				D586CF9623358EE0007A2194 /* PollingWaitCallback.swift in Sources */,
 				D53A8056262789E40093B1CA /* WebAuthnAuthenticationCallback.swift in Sources */,
-				A5CCE859296DF6F9006D98AA /* ApplicationPinDeviceAuthenticatorDelegate.swift in Sources */,
+				A5CCE859296DF6F9006D98AA /* PinCollector.swift in Sources */,
 				D5B2A37E23FC951700764370 /* HiddenValueCallback.swift in Sources */,
 				D53A8040262789BD0093B1CA /* PlatformAuthenticatorGetAssertionSession.swift in Sources */,
 				D5B2A38923FCB25E00764370 /* ActionCallback.swift in Sources */,

--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -28,6 +28,7 @@
 		A5BE3C6A294500360041F990 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BE3C69294500360041F990 /* Binding.swift */; };
 		A5BE3C6D294518A40041F990 /* CryptoAware.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BE3C6C294518A40041F990 /* CryptoAware.swift */; };
 		A5C4D5392947DB28003024B5 /* ApplicationPinDeviceAuthenticator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C4D5382947DB28003024B5 /* ApplicationPinDeviceAuthenticator.swift */; };
+		A5CCE859296DF6F9006D98AA /* ApplicationPinDeviceAuthenticatorDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5CCE858296DF6F9006D98AA /* ApplicationPinDeviceAuthenticatorDelegate.swift */; };
 		D512CD41240DC41E00AF520E /* FRRestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D512CD40240DC41E00AF520E /* FRRestClient.swift */; };
 		D513F17524DA6B490042228B /* AuthApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D513F17424DA6B490042228B /* AuthApiError.swift */; };
 		D533270B24806665002FF207 /* TokenManagementPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D533270A24806665002FF207 /* TokenManagementPolicy.swift */; };
@@ -368,6 +369,7 @@
 		A5BE3C69294500360041F990 /* Binding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
 		A5BE3C6C294518A40041F990 /* CryptoAware.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CryptoAware.swift; sourceTree = "<group>"; };
 		A5C4D5382947DB28003024B5 /* ApplicationPinDeviceAuthenticator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPinDeviceAuthenticator.swift; sourceTree = "<group>"; };
+		A5CCE858296DF6F9006D98AA /* ApplicationPinDeviceAuthenticatorDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationPinDeviceAuthenticatorDelegate.swift; sourceTree = "<group>"; };
 		D5015FEE24996AE50025FEB6 /* MetadataCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataCallbackTests.swift; sourceTree = "<group>"; };
 		D5054B4D244680C3007FBA92 /* DeviceProfileCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceProfileCallbackTests.swift; sourceTree = "<group>"; };
 		D5094CD923DF7F850041D5C1 /* CookieTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieTests.swift; sourceTree = "<group>"; };
@@ -674,6 +676,7 @@
 			isa = PBXGroup;
 			children = (
 				A5C4D5382947DB28003024B5 /* ApplicationPinDeviceAuthenticator.swift */,
+				A5CCE858296DF6F9006D98AA /* ApplicationPinDeviceAuthenticatorDelegate.swift */,
 				A54874A328F741AA00FF9B99 /* DeviceBindingAuthenticators.swift */,
 				A5BE3C6C294518A40041F990 /* CryptoAware.swift */,
 				A54874AC28FE158D00FF9B99 /* DeviceBindingStatus.swift */,
@@ -1887,6 +1890,7 @@
 				D53A803D262789BD0093B1CA /* Base64.swift in Sources */,
 				D586CF9623358EE0007A2194 /* PollingWaitCallback.swift in Sources */,
 				D53A8056262789E40093B1CA /* WebAuthnAuthenticationCallback.swift in Sources */,
+				A5CCE859296DF6F9006D98AA /* ApplicationPinDeviceAuthenticatorDelegate.swift in Sources */,
 				D5B2A37E23FC951700764370 /* HiddenValueCallback.swift in Sources */,
 				D53A8040262789BD0093B1CA /* PlatformAuthenticatorGetAssertionSession.swift in Sources */,
 				D5B2A38923FCB25E00764370 /* ActionCallback.swift in Sources */,

--- a/FRAuth/FRAuth/Callbacks/DeviceBindingCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/DeviceBindingCallback.swift
@@ -145,7 +145,10 @@ open class DeviceBindingCallback: MultipleValuesCallback, Binding {
     /// Bind the device.
     /// - Parameter completion Completion block for Device binding result callback
     open func bind(completion: @escaping DeviceBindingResultCallback) {
-        execute(authInterface: nil, deviceId: nil, encryptedPreference: nil, completion)
+        let dispatchQueue = DispatchQueue(label: "com.forgerock.concurrentQueue", qos: .background)
+        dispatchQueue.async {
+            self.execute(authInterface: nil, deviceId: nil, encryptedPreference: nil, completion)
+        }
     }
     
     

--- a/FRAuth/FRAuth/Callbacks/DeviceBindingCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/DeviceBindingCallback.swift
@@ -2,7 +2,7 @@
 //  DeviceBindingCallback.swift
 //  FRAuth
 //
-//  Copyright (c) 2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2022-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/Callbacks/DeviceBindingCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/DeviceBindingCallback.swift
@@ -145,7 +145,7 @@ open class DeviceBindingCallback: MultipleValuesCallback, Binding {
     /// Bind the device.
     /// - Parameter completion Completion block for Device binding result callback
     open func bind(completion: @escaping DeviceBindingResultCallback) {
-        let dispatchQueue = DispatchQueue(label: "com.forgerock.concurrentQueue", qos: .background)
+        let dispatchQueue = DispatchQueue(label: "com.forgerock.concurrentQueue", qos: .userInitiated)
         dispatchQueue.async {
             self.execute(authInterface: nil, deviceId: nil, encryptedPreference: nil, completion)
         }

--- a/FRAuth/FRAuth/Callbacks/DeviceSigningVerifierCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/DeviceSigningVerifierCallback.swift
@@ -2,7 +2,7 @@
 //  DeviceSigningVerifierCallback.swift
 //  FRAuth
 //
-//  Copyright (c) 2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2022-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/Callbacks/DeviceSigningVerifierCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/DeviceSigningVerifierCallback.swift
@@ -115,7 +115,7 @@ open class DeviceSigningVerifierCallback: MultipleValuesCallback, Binding {
     /// Sign the device.
     /// - Parameter completion: Completion block for Device binding result callback
     open func sign(completion: @escaping DeviceSigningResultCallback) {
-        let dispatchQueue = DispatchQueue(label: "com.forgerock.concurrentQueue", qos: .background)
+        let dispatchQueue = DispatchQueue(label: "com.forgerock.concurrentQueue", qos: .userInitiated)
         dispatchQueue.async {
             self.execute(userKeyService: nil, completion)
         }

--- a/FRAuth/FRAuth/Callbacks/DeviceSigningVerifierCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/DeviceSigningVerifierCallback.swift
@@ -113,9 +113,12 @@ open class DeviceSigningVerifierCallback: MultipleValuesCallback, Binding {
     
     
     /// Sign the device.
-    /// - Parameter completion Completion block for Device binding result callback
+    /// - Parameter completion: Completion block for Device binding result callback
     open func sign(completion: @escaping DeviceSigningResultCallback) {
-        execute(userKeyService: nil, completion)
+        let dispatchQueue = DispatchQueue(label: "com.forgerock.concurrentQueue", qos: .background)
+        dispatchQueue.async {
+            self.execute(userKeyService: nil, completion)
+        }
     }
     
     

--- a/FRAuth/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticator.swift
+++ b/FRAuth/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticator.swift
@@ -2,16 +2,17 @@
 //  ApplicationPinDeviceAuthenticator.swift
 //  FRAuth
 //
-//  Copyright (c) 2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2022-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
 //
 
 
-import Foundation
+import UIKit
 import LocalAuthentication
 import FRCore
+import JOSESwift
 
 
 /// DeviceAuthenticator adoption for Application Pin authentication
@@ -22,15 +23,34 @@ open class ApplicationPinDeviceAuthenticator: DeviceAuthenticator, CryptoAware {
     var cryptoKey: CryptoKey?
     /// AppPinAuthenticator to take care of key generation
     var appPinAuthenticator: AppPinAuthenticator?
+    /// ApplicationPinDeviceAuthenticatorDelegate for collection the Pin
+    public var delegate: ApplicationPinDeviceAuthenticatorDelegate?
     
+    init() {
+        delegate = ApplicationPinDeviceAuthenticatorDefaultDelegate()
+    }
     
     /// Generate public and private key pair
     open func generateKeys() throws -> KeyPair {
+        
         guard let appPinAuthenticator = appPinAuthenticator, let prompt = prompt else {
             throw DeviceBindingStatus.unsupported(errorMessage: "Cannot generate keys, missing appPinAuthenticator or prompt")
         }
         
-        return try appPinAuthenticator.generateKeys(description: prompt.description)
+        // Use DispatchSemaphore to wait for the delegate to finish collecting the pin from the user before continuing
+        let semaphore = DispatchSemaphore(value: 0)
+        var pin: String? = nil
+        delegate?.collectPin(prompt: prompt, completion: { collectedPin in
+            pin = collectedPin
+            semaphore.signal()
+        })
+        semaphore.wait()
+        
+        if let pin = pin {
+            return try appPinAuthenticator.generateKeys(description: prompt.description, pin: pin)
+        } else {
+            throw DeviceBindingStatus.abort
+        }
     }
     
     
@@ -59,5 +79,55 @@ open class ApplicationPinDeviceAuthenticator: DeviceAuthenticator, CryptoAware {
     
     open func setPrompt(_ prompt: Prompt) {
         self.prompt = prompt
+    }
+    
+    
+    // Default implemention
+    /// Sign the challenge sent from the server and generate signed JWT
+    /// - Parameter userKey: user Information
+    /// - Parameter challenge: challenge received from server
+    /// - Parameter expiration: experation Date of jws
+    /// - Returns: compact serialized jws
+    public func sign(userKey: UserKey, challenge: String, expiration: Date) throws -> String {
+        guard let prompt = prompt else {
+            throw DeviceBindingStatus.unsupported(errorMessage: "Cannot retrive keys, missing prompt")
+        }
+        // Use DispatchSemaphore to wait for the delegate to finish collecting the pin from the user before continuing
+        let semaphore = DispatchSemaphore(value: 0)
+        var pin: String? = nil
+        delegate?.collectPin(prompt: prompt, completion: { collectedPin in
+            pin = collectedPin
+            semaphore.signal()
+        })
+        semaphore.wait()
+        
+        guard let pin = pin else {
+            throw DeviceBindingStatus.abort
+        }
+        
+        guard let keyStoreKey = CryptoKey.getSecureKey(keyAlias: userKey.keyAlias, pin: pin) else {
+            throw DeviceBindingStatus.unsupported(errorMessage: "Cannot read the private key")
+        }
+        let algorithm = SignatureAlgorithm.ES256
+        
+        //create header
+        var header = JWSHeader(algorithm: algorithm)
+        header.kid = userKey.kid
+        header.typ = "JWS"
+        
+        //create payload
+        let params: [String: Any] = ["sub": userKey.userId, "challenge": challenge, "exp": (Int(expiration.timeIntervalSince1970))]
+        let message = try JSONSerialization.data(withJSONObject: params, options: [])
+        let payload = Payload(message)
+        
+        //create signer
+        guard let signer = Signer(signingAlgorithm: algorithm, key: keyStoreKey) else {
+            throw DeviceBindingStatus.unsupported(errorMessage: "Cannot create a signer for jws")
+        }
+        
+        //create jws
+        let jws = try JWS(header: header, payload: payload, signer: signer)
+        
+        return jws.compactSerializedString
     }
 }

--- a/FRAuth/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticatorDelegate.swift
+++ b/FRAuth/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticatorDelegate.swift
@@ -1,0 +1,72 @@
+// 
+//  ApplicationPinDeviceAuthenticatorDelegate.swift
+//  FRAuth
+//
+//  Copyright (c) 2023 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+
+import UIKit
+
+
+/// ApplicationPinDeviceAuthenticatorDelegate for collecting the Pin
+public protocol ApplicationPinDeviceAuthenticatorDelegate: AnyObject {
+    /// Delegate method to collect the Pin
+    func collectPin(prompt: Prompt, completion: @escaping (String?) -> Void)
+}
+
+
+/// Default implementation for ApplicationPinDeviceAuthenticatorDelegate
+public class ApplicationPinDeviceAuthenticatorDefaultDelegate: NSObject, ApplicationPinDeviceAuthenticatorDelegate {
+    
+    var alert: UIAlertController!
+    
+    public func collectPin(prompt: Prompt, completion: @escaping (String?) -> Void) {
+        
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else {
+                completion(nil)
+                return
+            }
+            
+            let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+            var topVC = keyWindow?.rootViewController
+            while let presentedViewController = topVC?.presentedViewController {
+                topVC = presentedViewController
+            }
+            guard let topVC = topVC else {
+                completion(nil)
+                return
+            }
+            
+            self.alert =  UIAlertController(title: prompt.title, message: prompt.description, preferredStyle: .alert)
+            self.alert.addTextField { textField in
+                textField.keyboardType = .numberPad
+                textField.addTarget(self, action: #selector(self.textFieldDidChange), for: UIControl.Event.editingChanged)
+            }
+            
+            let okAction = UIAlertAction(title: "Ok", style: .default) { (_) in
+                completion(self.alert.textFields?.first?.text)
+            }
+            okAction.isEnabled = false
+            self.alert.addAction(okAction)
+            
+            let cancelAction = UIAlertAction(title: "Cancel", style: .cancel, handler: { (_) in
+                completion(nil)
+            })
+            self.alert.addAction(cancelAction)
+            
+            topVC.present(self.alert, animated: true, completion: nil)
+        }
+    }
+    
+    
+    // Disable Ok button if textfield is empty
+    @objc func textFieldDidChange(_ sender: UITextField) {
+        alert?.actions.first?.isEnabled = sender.text!.count > 0
+    }
+    
+}

--- a/FRAuth/FRAuth/DeviceBinding/PinCollector.swift
+++ b/FRAuth/FRAuth/DeviceBinding/PinCollector.swift
@@ -1,5 +1,5 @@
 // 
-//  ApplicationPinDeviceAuthenticatorDelegate.swift
+//  PinCollector.swift
 //  FRAuth
 //
 //  Copyright (c) 2023 ForgeRock. All rights reserved.
@@ -12,15 +12,15 @@
 import UIKit
 
 
-/// ApplicationPinDeviceAuthenticatorDelegate for collecting the Pin
-public protocol ApplicationPinDeviceAuthenticatorDelegate: AnyObject {
+/// Protocol for collecting the Pin
+public protocol PinCollector: AnyObject {
     /// Delegate method to collect the Pin
     func collectPin(prompt: Prompt, completion: @escaping (String?) -> Void)
 }
 
 
-/// Default implementation for ApplicationPinDeviceAuthenticatorDelegate
-public class ApplicationPinDeviceAuthenticatorDefaultDelegate: NSObject, ApplicationPinDeviceAuthenticatorDelegate {
+/// Default implementation for PinCollector protocol
+public class DefaultPinCollector: NSObject, PinCollector {
     
     var alert: UIAlertController!
     

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticatorTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticatorTests.swift
@@ -22,8 +22,7 @@ class ApplicationPinDeviceAuthenticatorTests: XCTestCase {
         let expiration = Date().addingTimeInterval(60.0)
         let kid = UUID().uuidString
         
-        let authenticator = ApplicationPinDeviceAuthenticator()
-        authenticator.delegate = ApplicationPinDeviceAuthenticatorDelegateMock()
+        let authenticator = ApplicationPinDeviceAuthenticator(pinCollector: PinCollectorMock())
         authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: "description"))
         do {
             let keyPair = try authenticator.generateKeys()
@@ -60,8 +59,7 @@ class ApplicationPinDeviceAuthenticatorTests: XCTestCase {
         let expiration = Date().addingTimeInterval(60.0)
         let kid = UUID().uuidString
         
-        let authenticator = ApplicationPinDeviceAuthenticator()
-        authenticator.delegate = ApplicationPinDeviceAuthenticatorDelegateMock()
+        let authenticator = ApplicationPinDeviceAuthenticator(pinCollector: PinCollectorMock())
         authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: "description"))
         do {
             let keyPair = try authenticator.generateKeys()
@@ -97,8 +95,7 @@ class ApplicationPinDeviceAuthenticatorTests: XCTestCase {
         let userId = "Test User Id 3"
         let key = CryptoKey.getKeyAlias(keyName: userId)
         
-        let authenticator = ApplicationPinDeviceAuthenticator()
-        authenticator.delegate = ApplicationPinDeviceAuthenticatorDelegateMock()
+        let authenticator = ApplicationPinDeviceAuthenticator(pinCollector: PinCollectorMock())
         authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: "description"))
         XCTAssertTrue(authenticator.isSupported())
         XCTAssertNotNil(authenticator.accessControl())
@@ -129,7 +126,7 @@ class ApplicationPinDeviceAuthenticatorTests: XCTestCase {
         }
     }
     
-    class ApplicationPinDeviceAuthenticatorDelegateMock: ApplicationPinDeviceAuthenticatorDelegate {
+    class PinCollectorMock: PinCollector {
         func collectPin(prompt: Prompt, completion: @escaping (String?) -> Void) {
             completion("1234")
         }

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticatorTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticatorTests.swift
@@ -2,7 +2,7 @@
 //  ApplicationPinDeviceAuthenticatorTests.swift
 //  FRAuthTests
 //
-//  Copyright (c) 2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2022-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticatorTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticatorTests.swift
@@ -23,6 +23,7 @@ class ApplicationPinDeviceAuthenticatorTests: XCTestCase {
         let kid = UUID().uuidString
         
         let authenticator = ApplicationPinDeviceAuthenticator()
+        authenticator.delegate = ApplicationPinDeviceAuthenticatorDelegateMock()
         authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: "description"))
         do {
             let keyPair = try authenticator.generateKeys()
@@ -60,6 +61,7 @@ class ApplicationPinDeviceAuthenticatorTests: XCTestCase {
         let kid = UUID().uuidString
         
         let authenticator = ApplicationPinDeviceAuthenticator()
+        authenticator.delegate = ApplicationPinDeviceAuthenticatorDelegateMock()
         authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: "description"))
         do {
             let keyPair = try authenticator.generateKeys()
@@ -96,6 +98,7 @@ class ApplicationPinDeviceAuthenticatorTests: XCTestCase {
         let key = CryptoKey.getKeyAlias(keyName: userId)
         
         let authenticator = ApplicationPinDeviceAuthenticator()
+        authenticator.delegate = ApplicationPinDeviceAuthenticatorDelegateMock()
         authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: "description"))
         XCTAssertTrue(authenticator.isSupported())
         XCTAssertNotNil(authenticator.accessControl())
@@ -123,6 +126,12 @@ class ApplicationPinDeviceAuthenticatorTests: XCTestCase {
             
         } catch {
             //all good, do nothing
+        }
+    }
+    
+    class ApplicationPinDeviceAuthenticatorDelegateMock: ApplicationPinDeviceAuthenticatorDelegate {
+        func collectPin(prompt: Prompt, completion: @escaping (String?) -> Void) {
+            completion("1234")
         }
     }
 }

--- a/FRCore/FRCore/Authenticator/AppPinAuthenticator.swift
+++ b/FRCore/FRCore/Authenticator/AppPinAuthenticator.swift
@@ -2,7 +2,7 @@
 //  AppPinAuthenticator.swift
 //  FRCore
 //
-//  Copyright (c) 2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2022-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRCore/FRCore/Authenticator/AppPinAuthenticator.swift
+++ b/FRCore/FRCore/Authenticator/AppPinAuthenticator.swift
@@ -24,13 +24,14 @@ public class AppPinAuthenticator {
     
     
     /// Generate public and private key pair
-    open func generateKeys(description: String) throws -> KeyPair {
+    open func generateKeys(description: String, pin: String) throws -> KeyPair {
         var keyBuilderQuery = cryptoKey.keyBuilderQuery()
         keyBuilderQuery[String(kSecAttrAccessControl)] = accessControl()
         
 #if !targetEnvironment(simulator)
         let context = LAContext()
         context.localizedReason = description
+        context.setCredential(pin.data(using: .utf8), type: .applicationPassword)
         keyBuilderQuery[String(kSecUseAuthenticationContext)] = context
 #endif
         
@@ -48,8 +49,8 @@ public class AppPinAuthenticator {
     }
     
     
-    func getPrivateKey() -> SecKey? {
-        return CryptoKey.getSecureKey(keyAlias: cryptoKey.keyAlias)
+    func getPrivateKey(pin: String) -> SecKey? {
+        return CryptoKey.getSecureKey(keyAlias: cryptoKey.keyAlias, pin: pin)
     }
     
     

--- a/FRCore/FRCoreTests/FRCore/Authenticator/AppPinAuthenticatorTests.swift
+++ b/FRCore/FRCoreTests/FRCore/Authenticator/AppPinAuthenticatorTests.swift
@@ -2,7 +2,7 @@
 //  AppPinAuthenticatorTests.swift
 //  FRCoreTests
 //
-//  Copyright (c) 2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2022-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRCore/FRCoreTests/FRCore/Authenticator/AppPinAuthenticatorTests.swift
+++ b/FRCore/FRCoreTests/FRCore/Authenticator/AppPinAuthenticatorTests.swift
@@ -18,12 +18,13 @@ class AppPinAuthenticatorTests: XCTestCase {
         let userId = "Test User Id 1"
         let cryptoKey = CryptoKey(keyId: userId)
         let appPinAuthenticator = AppPinAuthenticator(cryptoKey: cryptoKey)
+        let pin = "1234"
         
         do {
-            let keyPair = try appPinAuthenticator.generateKeys(description: "Description")
+            let keyPair = try appPinAuthenticator.generateKeys(description: "Description", pin: pin)
             XCTAssertEqual(cryptoKey.keyAlias, keyPair.keyAlias)
             
-            let privateKey = CryptoKey.getSecureKey(keyAlias: cryptoKey.keyAlias)
+            let privateKey = CryptoKey.getSecureKey(keyAlias: cryptoKey.keyAlias, pin: pin)
             XCTAssertNotNil(privateKey)
         } catch {
             XCTFail("Failed to generate keys")
@@ -47,15 +48,16 @@ class AppPinAuthenticatorTests: XCTestCase {
         let userId = "Test User Id 3"
         let cryptoKey = CryptoKey(keyId: userId)
         let appPinAuthenticator = AppPinAuthenticator(cryptoKey: cryptoKey)
+        let pin = "1234"
         
         do {
-            let keyPair = try appPinAuthenticator.generateKeys(description: "Description")
+            let keyPair = try appPinAuthenticator.generateKeys(description: "Description", pin: pin)
             XCTAssertEqual(cryptoKey.keyAlias, keyPair.keyAlias)
             
-            let cryptoPrivateKey = CryptoKey.getSecureKey(keyAlias: cryptoKey.keyAlias)
+            let cryptoPrivateKey = CryptoKey.getSecureKey(keyAlias: cryptoKey.keyAlias, pin: pin)
             XCTAssertNotNil(cryptoPrivateKey)
             
-            let privateKey = appPinAuthenticator.getPrivateKey()
+            let privateKey = appPinAuthenticator.getPrivateKey(pin: pin)
             XCTAssertNotNil(privateKey)
             
             XCTAssertEqual(cryptoPrivateKey, privateKey)


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2270](https://bugster.forgerock.org/jira/browse/SDKS-2270)

# Description

**Custom UI for passcode entry for Application PIN type**

- Added new ApplicationPinDeviceAuthenticatorDelegate for Collecting Pin
- Added new ApplicationPinDeviceAuthenticatorDefaultDelegate for providing default UI for collecting Pin
- Private Key generation and retrieval now accepts optional pin String
- Moved _DeviceBindingCallback.bind_ and _DeviceSigningVerifierCallback.sign_ methods to background thread
- Updated tests

