### PR TITLE
Add better error handling to Device binding feature and FRExample Login flows

### DIFF
--- a/FRAuth/FRAuth/Callbacks/DeviceBindingCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/DeviceBindingCallback.swift
@@ -194,8 +194,10 @@ open class DeviceBindingCallback: MultipleValuesCallback, Binding {
             completion(.success)
         } catch JOSESwiftError.localAuthenticationFailed {
             handleException(status: .abort, completion: completion)
+        } catch let error as DeviceBindingStatus {
+            handleException(status: error, completion: completion)
         } catch let error {
-            handleException(status: .unsupported(errorMessage: error.localizedDescription), completion: completion)
+            handleException(status: .unknown(errorMessage: error.localizedDescription), completion: completion)
         }
     }
     

--- a/FRAuth/FRAuth/Callbacks/DeviceSigningVerifierCallback.swift
+++ b/FRAuth/FRAuth/Callbacks/DeviceSigningVerifierCallback.swift
@@ -183,8 +183,10 @@ open class DeviceSigningVerifierCallback: MultipleValuesCallback, Binding {
             completion(.success)
         } catch JOSESwiftError.localAuthenticationFailed {
             handleException(status: .abort, completion: completion)
+        } catch let error as DeviceBindingStatus {
+            handleException(status: error, completion: completion)
         } catch let error {
-            handleException(status: .unsupported(errorMessage: error.localizedDescription), completion: completion)
+            handleException(status: .unknown(errorMessage: error.localizedDescription), completion: completion)
         }
     }
     

--- a/FRAuth/FRAuth/DeviceBinding/DeviceBindingAuthenticators.swift
+++ b/FRAuth/FRAuth/DeviceBinding/DeviceBindingAuthenticators.swift
@@ -2,7 +2,7 @@
 //  DeviceBindingAuthenticators.swift
 //  FRAuth
 //
-//  Copyright (c) 2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2022-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -101,7 +101,7 @@ extension DeviceAuthenticator {
     /// - Returns: compact serialized jws
     public func sign(userKey: UserKey, challenge: String, expiration: Date) throws -> String {
         guard let keyStoreKey = CryptoKey.getSecureKey(keyAlias: userKey.keyAlias) else {
-            throw DeviceBindingStatus.unsupported(errorMessage: "Cannot read the private key")
+            throw DeviceBindingStatus.unRegister
         }
         let algorithm = SignatureAlgorithm.ES256
         
@@ -194,8 +194,11 @@ open class BiometricOnly: BiometricAuthenticator, DeviceAuthenticator {
         context.localizedReason = prompt.description
         keyBuilderQuery[String(kSecUseAuthenticationContext)] = context
 #endif
-        
-        return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
+        do {
+            return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
+        } catch {
+            throw DeviceBindingStatus.unsupported(errorMessage: nil)
+        }
     }
     
     
@@ -250,7 +253,11 @@ open class BiometricAndDeviceCredential: BiometricAuthenticator, DeviceAuthentic
         keyBuilderQuery[String(kSecUseAuthenticationContext)] = context
 #endif
         
-        return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
+        do {
+            return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
+        } catch {
+            throw DeviceBindingStatus.unsupported(errorMessage: nil)
+        }
     }
     
     
@@ -290,7 +297,11 @@ open class None: DeviceAuthenticator, CryptoAware {
         }
         
         let keyBuilderQuery = cryptoKey.keyBuilderQuery()
-        return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
+        do {
+            return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
+        } catch {
+            throw DeviceBindingStatus.unsupported(errorMessage: nil)
+        }
     }
     
     

--- a/FRAuth/FRAuth/DeviceBinding/DeviceBindingStatus.swift
+++ b/FRAuth/FRAuth/DeviceBinding/DeviceBindingStatus.swift
@@ -2,7 +2,7 @@
 //  DeviceBindingStatus.swift
 //  FRAuth
 //
-//  Copyright (c) 2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2022-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -19,23 +19,37 @@ public enum DeviceBindingStatus: LocalizedError {
     case abort
     case unsupported(errorMessage: String?)
     case unRegister
+    case unAuthorize
+    case unknown(errorMessage: String?)
+}
+
+struct BindingStatusConstants {
+    static let abort = "Abort"
+    static let timeout = "Timeout"
+    static let unsupported = "Unsupported"
 }
 
 
 ///Extention to add computed properties for DeviceBindingStatus
 public extension DeviceBindingStatus {
     
+    
+    
     /// Client error string for DeviceBindingStatus
     var clientError: String {
         switch self {
         case .timeout:
-            return "Timeout"
+            return BindingStatusConstants.timeout
         case .abort:
-            return "Abort"
+            return BindingStatusConstants.abort
         case .unsupported:
-            return "Unsupported"
+            return BindingStatusConstants.unsupported
         case .unRegister:
-            return "Unsupported"
+            return BindingStatusConstants.unsupported
+        case .unAuthorize:
+            return BindingStatusConstants.unsupported
+        case .unknown:
+            return BindingStatusConstants.abort
         }
     }
     
@@ -44,13 +58,17 @@ public extension DeviceBindingStatus {
     var errorMessage: String {
         switch self {
         case .timeout:
-            return "Biometric Timeout"
+            return "Authentication Timeout"
         case .abort:
             return "User Terminates the Authentication"
         case .unsupported(let errorMessage):
             return errorMessage ?? "Device not supported. Please verify the biometric or Pin settings"
         case .unRegister:
             return "PublicKey or PrivateKey Not found in Device"
+        case .unAuthorize:
+            return "Invalid Credentials"
+        case .unknown(let errorMessage):
+            return errorMessage ?? "Unknown"
         }
     }
 }

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Callback/DeviceBindingCallbackTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Callback/DeviceBindingCallbackTests.swift
@@ -2,7 +2,7 @@
 //  DeviceBindingCallbackTests.swift
 //  FRAuthTests
 //
-//  Copyright (c) 2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2022-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -647,7 +647,7 @@ class DeviceBindingCallbackTests: FRAuthBaseTest {
                 case .success:
                     XCTFail("Callback Execute succeeded instead of unsupported")
                 case .failure(let error):
-                    XCTAssertEqual(error.clientError, DeviceBindingStatus.unsupported(errorMessage: "").clientError)
+                    XCTAssertEqual(error.clientError, DeviceBindingStatus.unknown(errorMessage: "").clientError)
                     XCTAssertTrue(callback.inputValues.count == 1)
                 }
             }
@@ -672,7 +672,7 @@ class DeviceBindingCallbackTests: FRAuthBaseTest {
                 case .success:
                     XCTFail("Callback Execute succeeded instead of unsupported")
                 case .failure(let error):
-                    XCTAssertEqual(error.clientError, DeviceBindingStatus.unsupported(errorMessage: "").clientError)
+                    XCTAssertEqual(error.clientError, DeviceBindingStatus.unknown(errorMessage: "").clientError)
                     XCTAssertTrue(callback.inputValues.count == 1)
                 }
             }

--- a/FRCore/FRCore/Authenticator/CryptoKey.swift
+++ b/FRCore/FRCore/Authenticator/CryptoKey.swift
@@ -85,8 +85,8 @@ public struct CryptoKey {
         if let pin = pin {
             let context = LAContext()
             context.setCredential(pin.data(using: .utf8), type: .applicationPassword)
+            context.interactionNotAllowed = false
             query[kSecUseAuthenticationContext as String] = context
-            query[kSecUseAuthenticationUI as String] = kSecUseAuthenticationUIFail
         }
 
         var item: CFTypeRef?

--- a/FRUI/FRUI/ViewControllers/AuthStepViewController.swift
+++ b/FRUI/FRUI/ViewControllers/AuthStepViewController.swift
@@ -2,7 +2,7 @@
 //  AuthStepViewController.swift
 //  FRUI
 //
-//  Copyright (c) 2019-2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -208,7 +208,7 @@ class AuthStepViewController: UIViewController {
                             
                             let alert = UIAlertController(title: "Binding Result", message: bindingResult, preferredStyle: .alert)
                             let action = UIAlertAction(title: "Ok", style: .cancel, handler: { _ in
-                                self.renderAuthStep()
+                                self.submitCurrentNode()
                                 
                             })
                             alert.addAction(action)
@@ -241,7 +241,7 @@ class AuthStepViewController: UIViewController {
                             
                             let alert = UIAlertController(title: "Signing Verifier Result", message: bindingResult, preferredStyle: .alert)
                             let action = UIAlertAction(title: "Ok", style: .cancel, handler: { _ in
-                                self.renderAuthStep()
+                                self.submitCurrentNode()
                                 
                             })
                             alert.addAction(action)


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2271](https://bugster.forgerock.org/jira/browse/SDKS-2271)

# Description

Add two more error case in DeviceBindingStatus (.unAuthorize and .unknown)
Improve Error messaging and align with the latest android changes
Review and improve the errors thrown during entire device binding and device signing flow
Improve Login with UI flow
Add  device binding and device signing callbacks support to Login without UI flow
