### PR TITLE
SDKS-2024 E2E Test Cases for Device Signing Verifier callback

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,6 @@ name: CI
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-    branches:
-      - master
-      - develop
   push:
     branches:
       - master

--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		3A1B43D0284510B700EAFC9D /* AtomicDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1B43CF284510B700EAFC9D /* AtomicDictionary.swift */; };
 		3A1B43D3284524B900EAFC9D /* AtomicDictionaryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A1B43D2284524B900EAFC9D /* AtomicDictionaryTests.swift */; };
 		959D7D98290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 959D7D97290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift */; };
+		95E180B42992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E180B32992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift */; };
 		A54874A028EF336400FF9B99 /* DeviceBindingCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = A548749F28EF336400FF9B99 /* DeviceBindingCallback.swift */; };
 		A54874A428F741AA00FF9B99 /* DeviceBindingAuthenticators.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54874A328F741AA00FF9B99 /* DeviceBindingAuthenticators.swift */; };
 		A54874A728F74F5500FF9B99 /* JOSESwift in Frameworks */ = {isa = PBXBuildFile; productRef = A54874A628F74F5500FF9B99 /* JOSESwift */; };
@@ -352,6 +353,7 @@
 		3A1B43CF284510B700EAFC9D /* AtomicDictionary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicDictionary.swift; sourceTree = "<group>"; };
 		3A1B43D2284524B900EAFC9D /* AtomicDictionaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AtomicDictionaryTests.swift; sourceTree = "<group>"; };
 		959D7D97290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AA-05-DeviceBindingCallbackTest.swift"; sourceTree = "<group>"; };
+		95E180B32992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AA-06-DeviceSigningVerifierCallbackTest.swift"; sourceTree = "<group>"; };
 		A548749F28EF336400FF9B99 /* DeviceBindingCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBindingCallback.swift; sourceTree = "<group>"; };
 		A54874A328F741AA00FF9B99 /* DeviceBindingAuthenticators.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBindingAuthenticators.swift; sourceTree = "<group>"; };
 		A54874AC28FE158D00FF9B99 /* DeviceBindingStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceBindingStatus.swift; sourceTree = "<group>"; };
@@ -1266,6 +1268,7 @@
 		D5888C1325664E920041FD94 /* Callback-Live */ = {
 			isa = PBXGroup;
 			children = (
+				D5888C1B25664E920041FD94 /* CallbackBaseTest.swift */,
 				D5888C1425664E920041FD94 /* AA_04_PageCallbackTest.swift */,
 				D5888C1525664E920041FD94 /* AA_04_TermsAndConditionCallbackTest.swift */,
 				D5888C1625664E920041FD94 /* AA_04_BooleanAttributeInputCallbackTest.swift */,
@@ -1273,13 +1276,13 @@
 				D5888C1825664E920041FD94 /* AA_04_DeviceProfileCallbackTest.swift */,
 				D5888C1925664E920041FD94 /* AA_04_StringAttributeInputCallbackTest.swift */,
 				D5888C1A25664E920041FD94 /* AA_04_PollingWaitCallbackTest.swift */,
-				D5888C1B25664E920041FD94 /* CallbackBaseTest.swift */,
 				D5888C1C25664E920041FD94 /* AA_04_PageCallback65Test.swift */,
 				D5888C1D25664E920041FD94 /* AA_04_ChoiceCallbackTest.swift */,
 				D5888C1E25664E920041FD94 /* AA_04_ReCaptchaCallbackTest.swift */,
 				D5888C1F25664E920041FD94 /* AA_04_KbaCreateCallbackTest.swift */,
 				D5888C2025664E920041FD94 /* AA_04_NumberAttributeInputCallbackTest.swift */,
 				959D7D97290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift */,
+				95E180B32992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift */,
 			);
 			path = "Callback-Live";
 			sourceTree = "<group>";
@@ -1960,6 +1963,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				95E180B42992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift in Sources */,
 				D53A807026278A5C0093B1CA /* WebAuthnAuthenticationCallbackTests.swift in Sources */,
 				D5791B5025F87DE7004B487A /* CustomCallback.swift in Sources */,
 				A5BE3C43293D99A90041F990 /* DeviceSigningVerifierCallbackTests.swift in Sources */,

--- a/FRAuth/FRAuth/DeviceBinding/UserKeySelector.swift
+++ b/FRAuth/FRAuth/DeviceBinding/UserKeySelector.swift
@@ -31,7 +31,7 @@ public class DefaultUserKeySelector: NSObject, UserKeySelector {
             }
             guard let topVC = topVC else { return }
             
-            let actionSheet = UIAlertController(title: NSLocalizedString("Select User", comment: "User selection list title"), message: nil, preferredStyle: .actionSheet)
+            let actionSheet = UIAlertController(title: NSLocalizedString("Select User", comment: "User selection list title"), message: nil, preferredStyle: UIDevice.current.userInterfaceIdiom == .pad ? .alert : .actionSheet)
             
             for userKey in userKeys {
                 actionSheet.addAction(UIAlertAction(title: userKey.userName, style: .default, handler: { (action) in

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA-05-DeviceBindingCallbackTest.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA-05-DeviceBindingCallbackTest.swift
@@ -14,21 +14,22 @@ import XCTest
 class AA_05_DeviceBindingCallbackTest: CallbackBaseTest {
     
     static var USERNAME: String = "sdkuser"
+    let options = FROptions(url: "https://openam-dbind.forgeblocks.com/am",
+                            realm: "alpha",
+                            enableCookie: true,
+                            cookieName: "afef1acb448a873",
+                            timeout: "180",
+                            authServiceName: "device-bind",
+                            oauthThreshold: "60",
+                            oauthClientId: "iosclient",
+                            oauthRedirectUri: "http://localhost:8081",
+                            oauthScope: "openid profile email address",
+                            keychainAccessGroup: "com.bitbar.*"
+                            )
+
+
     override func setUp() {
         do {
-            let options = FROptions(url: "https://openam-dbind.forgeblocks.com/am",
-                                    realm: "alpha",
-                                    enableCookie: true,
-                                    cookieName: "afef1acb448a873",
-                                    timeout: "180",
-                                    authServiceName: "device-bind",
-                                    oauthThreshold: "60",
-                                    oauthClientId: "iosclient",
-                                    oauthRedirectUri: "http://localhost:8081",
-                                    oauthScope: "openid profile email address",
-                                    keychainAccessGroup: "com.bitbar.*"
-                                    )
-
             try FRAuth.start(options: options)
         }
         catch {
@@ -260,7 +261,7 @@ class AA_05_DeviceBindingCallbackTest: CallbackBaseTest {
         
         var ex = self.expectation(description: "Provide username")
         
-        FRSession.authenticate(authIndexValue: FRAuth.shared!.authServiceName) { (token: Token?, node, error) in
+        FRSession.authenticate(authIndexValue: options.authServiceName) { (token: Token?, node, error) in
             // Validate result
             XCTAssertNil(token)
             XCTAssertNil(error)

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA-06-DeviceSigningVerifierCallbackTest.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA-06-DeviceSigningVerifierCallbackTest.swift
@@ -1,0 +1,848 @@
+//
+//  AA-06-DeviceSigningVerifierCallbackTest.swift
+//  FRAuthTests
+//
+//  Copyright (c) 2023 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import FRAuth
+
+class AA_06_DeviceSigningVerifierCallbackTest: CallbackBaseTest {
+    
+    static var USERNAME: String = "sdkuser"
+    static var APPLICATION_PIN: String = "1111"
+    
+    let options = FROptions(url: "https://openam-dbind.forgeblocks.com/am",
+                            realm: "alpha",
+                            enableCookie: true,
+                            cookieName: "afef1acb448a873",
+                            timeout: "180",
+                            authServiceName: "device-verifier",
+                            oauthThreshold: "60",
+                            oauthClientId: "iosclient",
+                            oauthRedirectUri: "http://localhost:8081",
+                            oauthScope: "openid profile email address",
+                            keychainAccessGroup: "com.bitbar.*"
+                            )
+    
+    override func setUp() {
+        super.setUp()
+        do {
+            try FRAuth.start(options: options)
+        }
+        catch {
+            XCTFail("Fail to start the the SDK with custom config.")
+        }
+    }
+    
+    override func tearDown() {
+        FRUser.currentUser?.logout()
+        super.tearDown()
+    }
+    
+    func test_01_test_device_signing_verifier_defaults() throws {
+        var currentNode: Node?
+        
+        do {
+            try currentNode = startTest(testConfiguration: "default")
+        } catch AuthError.invalidCallbackResponse {
+            XCTFail("Expected a Device Signing Verifier node, but got nothing!")
+            return
+        } catch {
+            XCTFail("Unexpected error occured!")
+            return
+        }
+        
+        // We expect DeviceSigningVerifier callback with default settings here. Assert its properties and abort...
+        for callback in currentNode!.callbacks {
+            if callback is DeviceSigningVerifierCallback, let deviceSigningVerifierCallback = callback as? DeviceSigningVerifierCallback {
+                XCTAssertNotNil(deviceSigningVerifierCallback.userId)
+                XCTAssertNotNil(deviceSigningVerifierCallback.challenge)
+                XCTAssertEqual(deviceSigningVerifierCallback.title, "Authentication required")
+                XCTAssertEqual(deviceSigningVerifierCallback.subtitle, "Cryptography device binding")
+                XCTAssertEqual(deviceSigningVerifierCallback.promptDescription, "Please complete with biometric to proceed")
+                XCTAssertEqual(deviceSigningVerifierCallback.timeout, 60)
+                
+                deviceSigningVerifierCallback.setClientError("Abort")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        var ex = self.expectation(description: "Submit DeviceSigningVerifier callback and continue...")
+        currentNode!.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNotNil(node)
+            XCTAssertNil(error)
+            XCTAssertNil(token)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Ensusre that a TextCallback was received with message "Abort"
+        guard let node = currentNode else {
+            XCTFail("Failed to get next node")
+            throw AuthError.invalidCallbackResponse("Expected TextOutputCallback, but got nothing...")
+        }
+        
+        for callback in node.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Abort")
+                break
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Finish the journey") // Should finish with success and user should be logged in
+        node.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_02_test_device_signing_verifier_custom() throws {
+        var currentNode: Node?
+        
+        do {
+            try currentNode = startTest(testConfiguration: "custom")
+        } catch AuthError.invalidCallbackResponse {
+            XCTFail("Expected a Device Signing Verifier node, but got nothing!")
+            return
+        } catch {
+            XCTFail("Unexpected error occured!")
+            return
+        }
+        
+        /// We expect DeviceSigningVerifier callback with custom settings here. Assert its properties and set "custom" client error (should trigger the "custom" outcome of the node)
+        for callback in currentNode!.callbacks {
+            if callback is DeviceSigningVerifierCallback, let deviceSigningVerifierCallback = callback as? DeviceSigningVerifierCallback {
+                XCTAssertNotNil(deviceSigningVerifierCallback.userId)
+                XCTAssertEqual(deviceSigningVerifierCallback.challenge, "my-hardcoded-challenge")
+                XCTAssertEqual(deviceSigningVerifierCallback.title, "Custom Title")
+                XCTAssertEqual(deviceSigningVerifierCallback.subtitle, "Custom Subtitle")
+                XCTAssertEqual(deviceSigningVerifierCallback.promptDescription, "Custom Description")
+                XCTAssertEqual(deviceSigningVerifierCallback.timeout, 0)
+                
+                deviceSigningVerifierCallback.setClientError("Custom")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        var ex = self.expectation(description: "Submit DeviceSigningVerifier callback and continue...")
+        currentNode!.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNotNil(node)
+            XCTAssertNil(error)
+            XCTAssertNil(token)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        /// Ensusre that a TextCallback is received with message "Custom"
+        guard let node = currentNode else {
+            XCTFail("Failed to get next node...")
+            throw AuthError.invalidCallbackResponse("Expected TextOutputCallback, but got nothing...")
+        }
+        
+        for callback in node.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Custom")
+                break
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Finish the journey") // Should finish with success and user should be logged in
+        node.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_03_test_device_signing_verifier_with_username_collector() throws {
+        // Bind the device with authentication type "None"
+        try bindDevice(nodeConfiguration: "bind")
+        
+        // Advance to the Device Signing Verifier node...
+        var currentNode: Node? = try startTest(testConfiguration: "default")
+        
+        // We expect DeviceSigningVerifier callback at this point...
+        for callback in currentNode!.callbacks {
+            if callback is DeviceSigningVerifierCallback, let deviceSigningVerifierCallback = callback as? DeviceSigningVerifierCallback {
+                var singningResult = ""
+                
+                let ex = self.expectation(description: "Signing the challange (verify the device)")
+                deviceSigningVerifierCallback.sign(completion: { result in
+                    switch result {
+                    case .success:
+                        singningResult = "Success"
+                    case .failure(let error):
+                        singningResult = error.errorMessage
+                    };
+                    ex.fulfill()
+                })
+                waitForExpectations(timeout: 60, handler: nil)
+                XCTAssertEqual(singningResult, "Success")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        // Verify that the server verified the JWT successfully (Device Signing Verifier should trigger the "Success" outcome...)
+        var ex = self.expectation(description: "Submit DeviceSigningVerifier callback and continue...")
+        currentNode!.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNotNil(node)
+            XCTAssertNil(error)
+            XCTAssertNil(token)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Ensusre that a TextOutputCallback is received with message "Success"
+        guard let node = currentNode else {
+            XCTFail("Failed to get next node")
+            throw AuthError.invalidCallbackResponse("Expected TextOutputCallback, but got nothing...")
+        }
+        
+        for callback in node.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Success")
+                break
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Finish the journey")
+        node.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_04_test_device_signing_verifier_usernameless() throws {
+        // Bind the device with authentication type "None"
+        try bindDevice(nodeConfiguration: "bind")
+        
+        // Advance to the Device Signing Verifier node...
+        var currentNode: Node? = try startTest(testConfiguration: "usernameless")
+        
+        // We expect DeviceSigningVerifier callback at this point...
+        for callback in currentNode!.callbacks {
+            if callback is DeviceSigningVerifierCallback, let deviceSigningVerifierCallback = callback as? DeviceSigningVerifierCallback {
+                var singningResult = ""
+                
+                let ex = self.expectation(description: "Signing the challange (verify the device)")
+                deviceSigningVerifierCallback.sign(completion: { result in
+                    switch result {
+                    case .success:
+                        singningResult = "Success"
+                    case .failure(let error):
+                        singningResult = error.errorMessage
+                    };
+                    ex.fulfill()
+                })
+                waitForExpectations(timeout: 60, handler: nil)
+                XCTAssertEqual(singningResult, "Success")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        // Verify that the server verified the JWT successfully (Device Signing Verifier should trigger the "Success" outcome...)
+        var ex = self.expectation(description: "Submit DeviceSigningVerifier callback and continue...")
+        currentNode!.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNotNil(node)
+            XCTAssertNil(error)
+            XCTAssertNil(token)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Ensusre that a TextOutputCallback is received with message "Success"
+        guard let node = currentNode else {
+            XCTFail("Failed to get next node")
+            throw AuthError.invalidCallbackResponse("Expected TextOutputCallback, but got nothing...")
+        }
+        
+        for callback in node.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Success")
+                break
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Finish the journey")
+        node.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_05_test_device_signing_verifier_timout() throws {
+        // Bind the device with authentication type "None"
+        try bindDevice(nodeConfiguration: "bind")
+        
+        // Advance to the Device Signing Verifier node...
+        // Note that the "custom" Device Signing Verifier node is configured with timout=0
+        var currentNode: Node? = try startTest(testConfiguration: "custom")
+        
+        // We expect DeviceSigningVerifier callback at this point...
+        for callback in currentNode!.callbacks {
+            if callback is DeviceSigningVerifierCallback, let deviceSigningVerifierCallback = callback as? DeviceSigningVerifierCallback {
+                var singningResult = ""
+                
+                let ex = self.expectation(description: "Signing the challange (verify the device)")
+                deviceSigningVerifierCallback.sign(completion: { result in
+                    switch result {
+                    case .success:
+                        singningResult = "Success"
+                    case .failure(let error):
+                        singningResult = error.errorMessage
+                    };
+                    ex.fulfill()
+                })
+                waitForExpectations(timeout: 60, handler: nil)
+                XCTAssertEqual(singningResult, "Authentication Timeout")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        // Verify that the server verified the JWT successfully (Device Signing Verifier should trigger the "Timout" outcome...)
+        var ex = self.expectation(description: "Submit DeviceSigningVerifier callback and continue...")
+        currentNode!.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNotNil(node)
+            XCTAssertNil(error)
+            XCTAssertNil(token)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Ensusre that a TextOutputCallback is received with message "Timeout"
+        guard let node = currentNode else {
+            XCTFail("Failed to get next node")
+            throw AuthError.invalidCallbackResponse("Expected TextOutputCallback, but got nothing...")
+        }
+        
+        for callback in node.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Timeout")
+                break
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Finish the journey")
+        node.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_06_test_device_signing_verifier_pin() throws {
+        
+        // This test fails on simulator
+        try XCTSkipIf(isSimulator, "Cannot run this test on simulator")
+        try XCTSkipIf(!Self.biometricTestsSupported, "This test requires PIN setup on the device")
+        
+        // Bind the device with authentication type "APPLICATION_PIN"
+        try bindDevice(nodeConfiguration: "bind-pin")
+        
+        // Advance to the Device Signing Verifier node...
+        var currentNode: Node? = try startTest(testConfiguration: "default")
+
+        // We expect DeviceSigningVerifier callback at this point...
+        for callback in currentNode!.callbacks {
+            if callback is DeviceSigningVerifierCallback, let deviceSigningVerifierCallback = callback as? DeviceSigningVerifierCallback {
+                
+                var singningResult = ""
+                
+                let customDeviceBindingIdentifier: (DeviceBindingAuthenticationType) -> DeviceAuthenticator =  { type in
+                    return ApplicationPinDeviceAuthenticator(pinCollector: CustomPinCollector(pin: AA_06_DeviceSigningVerifierCallbackTest.APPLICATION_PIN))
+                }
+                
+                let ex = self.expectation(description: "Signing the challange (verify the device)")
+                deviceSigningVerifierCallback.sign(
+                    deviceAuthenticator: customDeviceBindingIdentifier,
+                    completion: { result in
+                        switch result {
+                        case .success:
+                            singningResult = "Success"
+                        case .failure(let error):
+                            singningResult = error.errorMessage
+                        };
+                        ex.fulfill()
+                    })
+
+                waitForExpectations(timeout: 60, handler: nil)
+                XCTAssertEqual(singningResult, "Success")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+
+        // Verify that the server verified the JWT successfully (Device Signing Verifier should trigger the "Success" outcome...)
+        var ex = self.expectation(description: "Submit DeviceSigningVerifier callback and continue...")
+        currentNode!.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNotNil(node)
+            XCTAssertNil(error)
+            XCTAssertNil(token)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+
+        // Ensusre that a TextOutputCallback is received with message "Success"
+        guard let node = currentNode else {
+            XCTFail("Failed to get next node")
+            throw AuthError.invalidCallbackResponse("Expected TextOutputCallback, but got nothing...")
+        }
+
+        for callback in node.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Success")
+                break
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+
+        ex = self.expectation(description: "Finish the journey")
+        node.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_07_test_device_signing_verifier_wrong_pin() throws {
+        
+        // This test fails on simulator
+        try XCTSkipIf(isSimulator, "Cannot run this test on simulator")
+        try XCTSkipIf(!Self.biometricTestsSupported, "This test requires PIN setup on the device")
+        
+        // Bind the device with authentication type "APPLICATION_PIN"
+        try bindDevice(nodeConfiguration: "bind-pin")
+        
+        // Advance to the Device Signing Verifier node...
+        var currentNode: Node? = try startTest(testConfiguration: "default")
+
+        // We expect DeviceSigningVerifier callback at this point...
+        for callback in currentNode!.callbacks {
+            if callback is DeviceSigningVerifierCallback, let deviceSigningVerifierCallback = callback as? DeviceSigningVerifierCallback {
+                
+                var singningResult = ""
+                
+                // Setup custom application pin authenticator, and provide wrong pin
+                let customDeviceBindingIdentifier: (DeviceBindingAuthenticationType) -> DeviceAuthenticator =  { type in
+                    return ApplicationPinDeviceAuthenticator(pinCollector: CustomPinCollector(pin: "WRONG-PIN"))
+                }
+                
+                let ex = self.expectation(description: "Signing the challange - should fail with 'Invalid Credentials' error")
+                deviceSigningVerifierCallback.sign(
+                    deviceAuthenticator: customDeviceBindingIdentifier,
+                    completion: { result in
+                        switch result {
+                        case .success:
+                            singningResult = "Success"
+                        case .failure(let error):
+                            singningResult = error.errorMessage
+                        };
+                        ex.fulfill()
+                    })
+
+                waitForExpectations(timeout: 60, handler: nil)
+                XCTAssertEqual(singningResult, "Invalid Credentials")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+
+        // Verify that the "Unsupported" outcome was triggered in AM...
+        var ex = self.expectation(description: "Submit DeviceSigningVerifier callback and continue...")
+        currentNode!.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNotNil(node)
+            XCTAssertNil(error)
+            XCTAssertNil(token)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+
+        // Ensusre that a TextOutputCallback is received with message "Unsupported"
+        guard let node = currentNode else {
+            XCTFail("Failed to get next node")
+            throw AuthError.invalidCallbackResponse("Expected TextOutputCallback, but got nothing...")
+        }
+
+        for callback in node.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Unsupported")
+                break
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+
+        ex = self.expectation(description: "Finish the journey")
+        node.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(node)
+            XCTAssertNotNil(error)
+            XCTAssertNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // User should not have been authenticated...
+        XCTAssertNil(FRUser.currentUser)
+    }
+    
+    /// Bind a device
+    /// Possible values for nodeConfiguration are "bind" or "bind-pin"
+    func bindDevice(nodeConfiguration: String) throws {
+        var currentNode: Node?
+        
+        // Process ChoiceCollector node... (first node)
+        var ex = self.expectation(description: "Select 'collectusername' choice")
+        
+        FRSession.authenticate(authIndexValue: options.authServiceName) { (token: Token?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        guard let node = currentNode else {
+            XCTFail("Failed to get node from the first request")
+            throw AuthError.invalidCallbackResponse("Expected Choice Collector node, but got nothing...")
+        }
+        
+        // Select 'collectusername' value for the Choice Collector callback
+        for callback in node.callbacks {
+            if callback is ChoiceCallback, let choiceCallback = callback as? ChoiceCallback {
+                let choiceIndex = choiceCallback.choices.firstIndex(of: "collectusername")
+                choiceCallback.setValue(choiceIndex)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value to the ChoiceCollector Node")
+        node.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        guard let node = currentNode else {
+            XCTFail("Failed to get Username Collector node")
+            throw AuthError.invalidCallbackResponse("Expected Username Collector node, but got nothing...")
+        }
+        
+        // Process Username Collector node... (second node)
+        for callback in node.callbacks {
+            if callback is NameCallback, let nameCallback = callback as? NameCallback {
+                nameCallback.setValue(AA_06_DeviceSigningVerifierCallbackTest.USERNAME)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value to the NameCollector node")
+        node.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Process Choice Collector node... (third node)
+        guard let node = currentNode else {
+            XCTFail("Failed to get Choice Collector node")
+            throw AuthError.invalidCallbackResponse("Expected ChoiceCollector node, but got nothing...")
+        }
+        
+        // Provide input value for the ChoiceCollector callback (valid options are "bind" or "bind-pin")
+        for callback in node.callbacks {
+            if callback is ChoiceCallback, let choiceCallback = callback as? ChoiceCallback {
+                let choiceIndex = choiceCallback.choices.firstIndex(of: nodeConfiguration)
+                choiceCallback.setValue(choiceIndex)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value to the ChoiceCollector Node")
+        currentNode?.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Process the DeviceBinding node... (fourth node)
+        guard currentNode != nil else {
+            XCTFail("Failed to get DeviceBinding node after selecting \(nodeConfiguration)...")
+            throw AuthError.invalidCallbackResponse("Expected DeviceBinding node, but got nothing...")
+        }
+
+        // We expect DeviceBinding callback here.
+        // Depending on the nodeConfiguration ("bind" or "bind-pin"), the authentication type should be either "NONE" or "APPLICATION_PIN"
+        for callback in currentNode!.callbacks {
+            if callback is DeviceBindingCallback, let deviceBindingCallback = callback as? DeviceBindingCallback {
+                // Bind the device...
+                var bindingResult = ""
+                var applicationPinDeviceAuthenticator: ApplicationPinDeviceAuthenticator? = nil
+                if nodeConfiguration == "bind-pin" {
+                    applicationPinDeviceAuthenticator = ApplicationPinDeviceAuthenticator.init(pinCollector: CustomPinCollector(pin: AA_06_DeviceSigningVerifierCallbackTest.APPLICATION_PIN))
+                }
+                
+                let ex = self.expectation(description: "Device Binding")
+                deviceBindingCallback.execute(authInterface: applicationPinDeviceAuthenticator, { (result) in
+                        switch result {
+                        case .success:
+                            bindingResult = "Success"
+                        case .failure(let error):
+                            bindingResult = error.errorMessage
+                        };
+                        ex.fulfill()
+                    })
+                waitForExpectations(timeout: 60, handler: nil)
+
+                XCTAssertEqual(bindingResult, "Success")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+
+        ex = self.expectation(description: "Submit DeviceBinding callback...") // The journey should finish with "Success" and user logged in...
+        currentNode!.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNotNil(token)
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+        
+        // Logout the user
+        FRUser.currentUser?.logout()
+    }
+    
+    /// Helper function for processing common steps in test cases
+    /// Valid values for "testConfiguration" are "usernameless", "default" or "custom"...
+    func startTest(testConfiguration: String) throws -> Node  {
+        var currentNode: Node?
+        
+        /// Process ChoiceCollector node... (first node)
+        var ex = self.expectation(description: "Select 'collectusername' choice")
+        
+        FRSession.authenticate(authIndexValue: options.authServiceName) { (token: Token?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        guard let node = currentNode else {
+            XCTFail("Failed to get node from the first request")
+            throw AuthError.invalidCallbackResponse("Expected Choice Collector node, but got nothing...")
+        }
+
+        // Select the choice option provided in the "testConfiguration" parameter
+        for callback in node.callbacks {
+            if callback is ChoiceCallback, let choiceCallback = callback as? ChoiceCallback {
+                var choiceIndex = 0
+                if testConfiguration == "usernameless" {
+                    choiceIndex = choiceCallback.choices.firstIndex(of: "usernameless")!
+                }
+                else {
+                    choiceIndex = choiceCallback.choices.firstIndex(of: "collectusername")!
+                }
+                choiceCallback.setValue(choiceIndex)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value to the ChoiceCollector Node")
+        node.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // For usernamless flow we don't need to collect username, so we return the current node.
+        if testConfiguration == "usernameless" {
+            return currentNode!
+        }
+        
+        // For other cases continue processing...
+        guard let node = currentNode else {
+            XCTFail("Failed to get Node")
+            throw AuthError.invalidCallbackResponse("Expected username collector node, but got nothing...")
+        }
+        
+        // Process UserName collector node... (second node)
+        for callback in node.callbacks {
+            if callback is NameCallback, let nameCallback = callback as? NameCallback {
+                nameCallback.setValue(AA_06_DeviceSigningVerifierCallbackTest.USERNAME)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value to the NameCollector node")
+        node.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        guard let node = currentNode else {
+            XCTFail("Failed to get Node from the first request")
+            throw AuthError.invalidCallbackResponse("Expected Choice Collector node, but got nothing...")
+        }
+        
+        // Select the selected "testConfiguration" option in the ChoiceCollector.
+        // The journey should the advance to one of the "DeviceSigningVerifier" nodes (either "default" or "custom")
+        for callback in node.callbacks {
+            if callback is ChoiceCallback, let choiceCallback = callback as? ChoiceCallback {
+                let choiceIndex = choiceCallback.choices.firstIndex(of: testConfiguration)
+                choiceCallback.setValue(choiceIndex)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value to the ChoiceCollector Node")
+        node.next { (token: AccessToken?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        return currentNode! // Should be the DeviceSigningVerifier node
+    }
+    
+    class CustomPinCollector: PinCollector {
+        private var pin : String = ""
+        
+        required public init(pin : String) {
+            self.pin = pin
+        }
+        
+        func collectPin(prompt: Prompt, completion: @escaping (String?) -> Void) {
+            completion(self.pin)
+        }
+    }
+    
+}

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticatorTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticatorTests.swift
@@ -16,7 +16,8 @@ import JOSESwift
 
 class ApplicationPinDeviceAuthenticatorTests: FRBaseTestCase {
     
-    func test_01_sign() {
+    func test_01_sign() throws {
+        try XCTSkipIf(!Self.biometricTestsSupported, "This test requires PIN setup on the device")
         let userId = "Test User Id 1"
         let challenge = "challenge"
         let expiration = Date().addingTimeInterval(60.0)
@@ -55,6 +56,7 @@ class ApplicationPinDeviceAuthenticatorTests: FRBaseTestCase {
     
     func test_02_sign_with_userKey() throws {
         try XCTSkipIf(self.isSimulator, "LAContext().setCredential(...) call is not supported on iOS Simulator.")
+        try XCTSkipIf(!Self.biometricTestsSupported, "This test requires PIN setup on the device")
         let userId = "Test User Id 2"
         let challenge = "challenge"
         let expiration = Date().addingTimeInterval(60.0)
@@ -92,7 +94,8 @@ class ApplicationPinDeviceAuthenticatorTests: FRBaseTestCase {
     }
     
     
-    func test_03_generateKeys() {
+    func test_03_generateKeys() throws {
+        try XCTSkipIf(!Self.biometricTestsSupported, "This test requires PIN setup on the device")
         let userId = "Test User Id 3"
         let key = CryptoKey.getKeyAlias(keyName: userId)
         

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/DeviceAuthenticatorTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/DeviceAuthenticatorTests.swift
@@ -149,6 +149,7 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
         // Skip the test on iOS 15 Simulator due to the bug when private key generation fails with Access Control Flags set
         // https://stackoverflow.com/questions/69279715/ios-15-xcode-13-cannot-generate-private-key-on-simulator-running-ios-15-with-s
         try XCTSkipIf(self.isSimulator && isIOS15, "on iOS 15 Simulator private key generation fails with Access Control Flags set")
+        try XCTSkipIf(!Self.biometricTestsSupported, "This test requires PIN setup on the device")
         
         let userId = "Test User Id 5"
         let key = CryptoKey.getKeyAlias(keyName: userId)
@@ -220,6 +221,7 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
         // Skip the test on iOS 15 Simulator due to the bug when private key generation fails with Access Control Flags set
         // https://stackoverflow.com/questions/69279715/ios-15-xcode-13-cannot-generate-private-key-on-simulator-running-ios-15-with-s
         try XCTSkipIf(self.isSimulator && isIOS15, "on iOS 15 Simulator private key generation fails with Access Control Flags set")
+        try XCTSkipIf(!Self.biometricTestsSupported, "This test requires PIN setup on the device")
         
         let userId = "Test User Id 7"
         let key = CryptoKey.getKeyAlias(keyName: userId)


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2024](https://bugster.forgerock.org/jira/browse/SDKS-2024) JWS Verifier QA 

# Description

Added e2e test cases for the Device Signing Verifier node/callback. 
Note that this test cases assume that `device-verifier` tree is present on the target AM with the following configuration:

<img width="1302" alt="image" src="https://user-images.githubusercontent.com/1580960/217299004-1034f214-6d68-41c5-9d1b-fcf3fd33d0bf.png">
