### PR TITLE
Add SSO support to Device Binding

### DIFF
--- a/FRAuth/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticator.swift
+++ b/FRAuth/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticator.swift
@@ -96,7 +96,7 @@ open class ApplicationPinDeviceAuthenticator: DeviceAuthenticator, CryptoAware {
             throw DeviceBindingStatus.abort
         }
         
-        guard let keyStoreKey = CryptoKey.getSecureKey(keyAlias: userKey.keyAlias, pin: pin) else {
+        guard let keyStoreKey = cryptoKey?.getSecureKey(pin: pin) else {
             throw DeviceBindingStatus.unRegister
         }
         let algorithm = SignatureAlgorithm.ES256

--- a/FRAuth/FRAuth/DeviceBinding/DeviceBindingAuthenticators.swift
+++ b/FRAuth/FRAuth/DeviceBinding/DeviceBindingAuthenticators.swift
@@ -109,7 +109,8 @@ extension DeviceAuthenticator {
     /// - Parameter expiration: experation Date of jws
     /// - Returns: compact serialized jws
     public func sign(userKey: UserKey, challenge: String, expiration: Date) throws -> String {
-        guard let keyStoreKey = CryptoKey.getSecureKey(keyAlias: userKey.keyAlias) else {
+        let cryptoKey = CryptoKey(keyId: userKey.userId, accessGroup: FRAuth.shared?.options?.keychainAccessGroup)
+        guard let keyStoreKey = cryptoKey.getSecureKey() else {
             throw DeviceBindingStatus.unRegister
         }
         let algorithm = SignatureAlgorithm.ES256
@@ -158,7 +159,7 @@ extension DeviceAuthenticator {
     public func initialize(userId: String) {
         
         if let cryptoAware = self as? CryptoAware {
-            cryptoAware.setKey(cryptoKey: CryptoKey(keyId: userId))
+            cryptoAware.setKey(cryptoKey: CryptoKey(keyId: userId, accessGroup: FRAuth.shared?.options?.keychainAccessGroup))
         }
     }
 }

--- a/FRAuth/FRAuth/DeviceBinding/KeychainDeviceRepository.swift
+++ b/FRAuth/FRAuth/DeviceBinding/KeychainDeviceRepository.swift
@@ -39,7 +39,16 @@ internal class KeychainDeviceRepository: DeviceRepository {
     /// Initializes KeychainDeviceRepository with given keychainService
     /// - Parameter keychainService: default value is `FRAuth.shared?.keychainManager.sharedStore ?? KeychainService(service: KeychainDeviceRepository.keychainServiceIdentifier, securedKey: nil)`
     init(keychainService: KeychainService? = nil) {
-        self.keychainService = keychainService ?? KeychainService(service: KeychainDeviceRepository.keychainServiceIdentifier, securedKey: nil)
+        guard let keychainService = keychainService else {
+            if let accessGroup = FRAuth.shared?.options?.keychainAccessGroup {
+                self.keychainService = KeychainService(service: KeychainDeviceRepository.keychainServiceIdentifier, accessGroup: accessGroup)
+            } else {
+                self.keychainService = KeychainService(service: KeychainDeviceRepository.keychainServiceIdentifier)
+            }
+            return
+        }
+        
+        self.keychainService = keychainService
     }
     
     

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Callback/DeviceBindingCallbackTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Callback/DeviceBindingCallbackTests.swift
@@ -593,7 +593,8 @@ class DeviceBindingCallbackTests: FRAuthBaseTest {
                     XCTFail("Callback Execute failed: \(error.errorMessage)")
                 }
             }
-            CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: callback.userId))
+            let cryptoKey = CryptoKey(keyId: callback.userId)
+            cryptoKey.deleteKeys()
         }
         catch {
             XCTFail("Failed to construct callback: \(callbackResponse)")
@@ -623,7 +624,8 @@ class DeviceBindingCallbackTests: FRAuthBaseTest {
                     XCTAssertTrue(callback.inputValues.count == 1)
                 }
             }
-            CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: callback.userId))
+            let cryptoKey = CryptoKey(keyId: callback.userId)
+            cryptoKey.deleteKeys()
         }
         catch {
             XCTFail("Failed to construct callback: \(callbackResponse)")
@@ -648,7 +650,8 @@ class DeviceBindingCallbackTests: FRAuthBaseTest {
                     XCTAssertTrue(callback.inputValues.count == 1)
                 }
             }
-            CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: callback.userId))
+            let cryptoKey = CryptoKey(keyId: callback.userId)
+            cryptoKey.deleteKeys()
         }
         catch {
             XCTFail("Failed to construct callback: \(callbackResponse)")
@@ -673,7 +676,8 @@ class DeviceBindingCallbackTests: FRAuthBaseTest {
                     XCTAssertTrue(callback.inputValues.count == 1)
                 }
             }
-            CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: callback.userId))
+            let cryptoKey = CryptoKey(keyId: callback.userId)
+            cryptoKey.deleteKeys()
         }
         catch {
             XCTFail("Failed to construct callback: \(callbackResponse)")
@@ -698,7 +702,8 @@ class DeviceBindingCallbackTests: FRAuthBaseTest {
                     XCTAssertTrue(callback.inputValues.count == 1)
                 }
             }
-            CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: callback.userId))
+            let cryptoKey = CryptoKey(keyId: callback.userId)
+            cryptoKey.deleteKeys()
         }
         catch {
             XCTFail("Failed to construct callback: \(callbackResponse)")
@@ -723,7 +728,8 @@ class DeviceBindingCallbackTests: FRAuthBaseTest {
                     XCTAssertTrue(callback.inputValues.count == 1)
                 }
             }
-            CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: callback.userId))
+            let cryptoKey = CryptoKey(keyId: callback.userId)
+            cryptoKey.deleteKeys()
         }
         catch {
             XCTFail("Failed to construct callback: \(callbackResponse)")
@@ -757,7 +763,8 @@ class DeviceBindingCallbackTests: FRAuthBaseTest {
                 }
                 expectation.fulfill()
             }
-            CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: callback.userId))
+            let cryptoKey = CryptoKey(keyId: callback.userId)
+            cryptoKey.deleteKeys()
             waitForExpectations(timeout: 60, handler: nil)
         }
         catch {

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticatorTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/ApplicationPinDeviceAuthenticatorTests.swift
@@ -50,7 +50,8 @@ class ApplicationPinDeviceAuthenticatorTests: FRBaseTestCase {
         } catch {
             XCTFail("Failed to verify JWS signature")
         }
-        CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: userId))
+        let cryptoKey = CryptoKey(keyId: userId)
+        cryptoKey.deleteKeys()
     }
     
     
@@ -90,14 +91,16 @@ class ApplicationPinDeviceAuthenticatorTests: FRBaseTestCase {
         } catch {
             XCTFail("Failed to verify JWS signature")
         }
-        CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: userId))
+        let cryptoKey = CryptoKey(keyId: userId)
+        cryptoKey.deleteKeys()
     }
     
     
     func test_03_generateKeys() throws {
         try XCTSkipIf(!Self.biometricTestsSupported, "This test requires PIN setup on the device")
         let userId = "Test User Id 3"
-        let key = CryptoKey.getKeyAlias(keyName: userId)
+        let cryptoKey = CryptoKey(keyId: userId)
+        let key = cryptoKey.keyAlias
         
         let authenticator = ApplicationPinDeviceAuthenticator(pinCollector: PinCollectorMock())
         authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: "description"))
@@ -107,12 +110,12 @@ class ApplicationPinDeviceAuthenticatorTests: FRBaseTestCase {
             let keyPair = try authenticator.generateKeys()
             XCTAssertEqual(key, keyPair.keyAlias)
             
-            let privateKey = CryptoKey.getSecureKey(keyAlias: key)
+            let privateKey = cryptoKey.getSecureKey()
             XCTAssertNotNil(privateKey)
         } catch {
             XCTFail("Failed to generate keys")
         }
-        CryptoKey.deleteKey(keyAlias: key)
+        cryptoKey.deleteKeys()
     }
     
     

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/DeviceAuthenticatorTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/DeviceBinding/DeviceAuthenticatorTests.swift
@@ -2,7 +2,7 @@
 //  DeviceAuthenticatorTests.swift
 //  FRAuthTests
 //
-//  Copyright (c) 2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2022-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -78,13 +78,15 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
         } catch {
             XCTFail("Failed to verify JWS signature")
         }
-        CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: userId))
+        let cryptoKey = CryptoKey(keyId: userId)
+        cryptoKey.deleteKeys()
     }
     
     
     func test_03_None_generateKeys() {
         let userId = "Test User Id 3"
-        let key = CryptoKey.getKeyAlias(keyName: userId)
+        let cryptoKey = CryptoKey(keyId: userId)
+        let key = cryptoKey.keyAlias
         
         let authenticator = None()
         authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: ""))
@@ -94,12 +96,13 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
             let keyPair = try authenticator.generateKeys()
             XCTAssertEqual(key, keyPair.keyAlias)
             
-            let privateKey = CryptoKey.getSecureKey(keyAlias: key)
+            
+            let privateKey = cryptoKey.getSecureKey()
             XCTAssertNotNil(privateKey)
         } catch {
             XCTFail("Failed to generate keys")
         }
-        CryptoKey.deleteKey(keyAlias: key)
+        cryptoKey.deleteKeys()
     }
     
     
@@ -141,7 +144,8 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
         } catch {
             XCTFail("Failed to verify JWS signature")
         }
-        CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: userId))
+        let cryptoKey = CryptoKey(keyId: userId)
+        cryptoKey.deleteKeys()
     }
     
     
@@ -152,7 +156,8 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
         try XCTSkipIf(!Self.biometricTestsSupported, "This test requires PIN setup on the device")
         
         let userId = "Test User Id 5"
-        let key = CryptoKey.getKeyAlias(keyName: userId)
+        let cryptoKey = CryptoKey(keyId: userId)
+        let key = cryptoKey.keyAlias
         
         let authenticator = BiometricOnly()
         authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: "Description"))
@@ -166,12 +171,12 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
             let keyPair = try authenticator.generateKeys()
             XCTAssertEqual(key, keyPair.keyAlias)
             
-            let privateKey = CryptoKey.getSecureKey(keyAlias: key)
+            let privateKey = cryptoKey.getSecureKey()
             XCTAssertNotNil(privateKey)
         } catch {
             XCTFail("Failed to generate keys")
         }
-        CryptoKey.deleteKey(keyAlias: key)
+        cryptoKey.deleteKeys()
     }
     
     
@@ -213,7 +218,8 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
         } catch {
             XCTFail("Failed to verify JWS signature")
         }
-        CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: userId))
+        let cryptoKey = CryptoKey(keyId: userId)
+        cryptoKey.deleteKeys()
     }
     
     
@@ -224,7 +230,8 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
         try XCTSkipIf(!Self.biometricTestsSupported, "This test requires PIN setup on the device")
         
         let userId = "Test User Id 7"
-        let key = CryptoKey.getKeyAlias(keyName: userId)
+        let cryptoKey = CryptoKey(keyId: userId)
+        let key = cryptoKey.keyAlias
         
         let authenticator = BiometricAndDeviceCredential()
         authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: "Description"))
@@ -235,12 +242,12 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
             let keyPair = try authenticator.generateKeys()
             XCTAssertEqual(key, keyPair.keyAlias)
             
-            let privateKey = CryptoKey.getSecureKey(keyAlias: key)
+            let privateKey = cryptoKey.getSecureKey()
             XCTAssertNotNil(privateKey)
         } catch {
             XCTFail("Failed to generate keys")
         }
-        CryptoKey.deleteKey(keyAlias: key)
+        cryptoKey.deleteKeys()
     }
     
     
@@ -278,7 +285,8 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
         } catch {
             XCTFail("Failed to verify JWS signature")
         }
-        CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: userId))
+        let cryptoKey = CryptoKey(keyId: userId)
+        cryptoKey.deleteKeys()
     }
     
     
@@ -321,7 +329,8 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
         } catch {
             XCTFail("Failed to verify JWS signature")
         }
-        CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: userId))
+        let cryptoKey = CryptoKey(keyId: userId)
+        cryptoKey.deleteKeys()
     }
     
     
@@ -364,7 +373,8 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
         } catch {
             XCTFail("Failed to verify JWS signature")
         }
-        CryptoKey.deleteKey(keyAlias: CryptoKey.getKeyAlias(keyName: userId))
+        let cryptoKey = CryptoKey(keyId: userId)
+        cryptoKey.deleteKeys()
     }
     
     

--- a/FRCore/FRCore/Authenticator/AppPinAuthenticator.swift
+++ b/FRCore/FRCore/Authenticator/AppPinAuthenticator.swift
@@ -51,7 +51,7 @@ public class AppPinAuthenticator {
     
     
     func getPrivateKey(pin: String) -> SecKey? {
-        return CryptoKey.getSecureKey(keyAlias: cryptoKey.keyAlias, pin: pin)
+        return cryptoKey.getSecureKey(pin: pin)
     }
     
     

--- a/FRCore/FRCoreTests/FRCore/Authenticator/AppPinAuthenticatorTests.swift
+++ b/FRCore/FRCoreTests/FRCore/Authenticator/AppPinAuthenticatorTests.swift
@@ -25,12 +25,12 @@ class AppPinAuthenticatorTests: FRBaseTestCase {
             let keyPair = try appPinAuthenticator.generateKeys(description: "Description", pin: pin)
             XCTAssertEqual(cryptoKey.keyAlias, keyPair.keyAlias)
             
-            let privateKey = CryptoKey.getSecureKey(keyAlias: cryptoKey.keyAlias, pin: pin)
+            let privateKey = cryptoKey.getSecureKey(pin: pin)
             XCTAssertNotNil(privateKey)
         } catch {
             XCTFail("Failed to generate keys")
         }
-        CryptoKey.deleteKey(keyAlias: cryptoKey.keyAlias)
+        cryptoKey.deleteKeys()
     }
     
     
@@ -41,7 +41,7 @@ class AppPinAuthenticatorTests: FRBaseTestCase {
         
         XCTAssertEqual(cryptoKey.keyAlias, appPinAuthenticator.getKeyAlias())
         
-        CryptoKey.deleteKey(keyAlias: cryptoKey.keyAlias)
+        cryptoKey.deleteKeys()
     }
     
     
@@ -56,7 +56,7 @@ class AppPinAuthenticatorTests: FRBaseTestCase {
             let keyPair = try appPinAuthenticator.generateKeys(description: "Description", pin: pin)
             XCTAssertEqual(cryptoKey.keyAlias, keyPair.keyAlias)
             
-            let cryptoPrivateKey = CryptoKey.getSecureKey(keyAlias: cryptoKey.keyAlias, pin: pin)
+            let cryptoPrivateKey = cryptoKey.getSecureKey(pin: pin)
             XCTAssertNotNil(cryptoPrivateKey)
             
             let privateKey = appPinAuthenticator.getPrivateKey(pin: pin)
@@ -66,6 +66,6 @@ class AppPinAuthenticatorTests: FRBaseTestCase {
         } catch {
             XCTFail("Failed to generate keys")
         }
-        CryptoKey.deleteKey(keyAlias: cryptoKey.keyAlias)
+        cryptoKey.deleteKeys()
     }
 }

--- a/FRCore/FRCoreTests/FRCore/Authenticator/CryptoKeyTests.swift
+++ b/FRCore/FRCoreTests/FRCore/Authenticator/CryptoKeyTests.swift
@@ -2,7 +2,7 @@
 //  CryptoKeyTests.swift
 //  FRCoreTests
 //
-//  Copyright (c) 2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2022-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -49,54 +49,52 @@ class CryptoKeyTests: XCTestCase {
         var privateKey: SecKey?
         
         do {
-            privateKey = CryptoKey.getSecureKey(keyAlias: key)
+            privateKey = cryptoKey.getSecureKey()
             XCTAssertNil(privateKey)
             
             let keyPair = try cryptoKey.createKeyPair(builderQuery: query)
             XCTAssertEqual(keyPair.keyAlias, key)
             
-            privateKey = CryptoKey.getSecureKey(keyAlias: key)
+            privateKey = cryptoKey.getSecureKey()
             XCTAssertNotNil(privateKey)
         } catch {
             XCTFail("Failed to create KeyPair")
         }
-        CryptoKey.deleteKey(keyAlias: key)
+        cryptoKey.deleteKeys()
     }
     
     
     func test_04_getSecureKey() {
         let userId = "Test User Id 4"
-        let key = CryptoKey.getKeyAlias(keyName: userId)
         let cryptoKey = CryptoKey(keyId: userId)
         let query = cryptoKey.keyBuilderQuery()
         var privateKey: SecKey?
         
-        privateKey = CryptoKey.getSecureKey(keyAlias: key)
+        privateKey = cryptoKey.getSecureKey()
         XCTAssertNil(privateKey)
         
         SecKeyCreateRandomKey(query as CFDictionary, nil)
         
-        privateKey = CryptoKey.getSecureKey(keyAlias: key)
+        privateKey = cryptoKey.getSecureKey()
         XCTAssertNotNil(privateKey)
         
-        CryptoKey.deleteKey(keyAlias: key)
+        cryptoKey.deleteKeys()
     }
     
     
     func test_05_deleteKey() {
         let userId = "Test User Id 5"
-        let key = CryptoKey.getKeyAlias(keyName: userId)
         let cryptoKey = CryptoKey(keyId: userId)
         let query = cryptoKey.keyBuilderQuery()
         var privateKey: SecKey?
         
         SecKeyCreateRandomKey(query as CFDictionary, nil)
         
-        privateKey = CryptoKey.getSecureKey(keyAlias: key)
+        privateKey = cryptoKey.getSecureKey()
         XCTAssertNotNil(privateKey)
         
-        CryptoKey.deleteKey(keyAlias: key)
-        privateKey = CryptoKey.getSecureKey(keyAlias: key)
+        cryptoKey.deleteKeys()
+        privateKey = cryptoKey.getSecureKey()
         XCTAssertNil(privateKey)
     }
     
@@ -118,11 +116,142 @@ class CryptoKeyTests: XCTestCase {
         
         SecKeyCreateRandomKey(query as CFDictionary, nil)
         
-        privateKey = CryptoKey.getSecureKey(keyAlias: cryptoKey.keyAlias)
+        privateKey = cryptoKey.getSecureKey()
         XCTAssertNotNil(privateKey)
         
         cryptoKey.deleteKeys()
-        privateKey = CryptoKey.getSecureKey(keyAlias: cryptoKey.keyAlias)
+        privateKey = cryptoKey.getSecureKey()
         XCTAssertNil(privateKey)
+    }
+    
+    
+    func test_08_same_accessGroup() {
+        let userId = "Test User Id 8"
+        let accessGroup = "com.forgerock.ios.shared" //com.forgerock.ios.FRTestHost
+        let cryptoKey = CryptoKey(keyId: userId, accessGroup: accessGroup)
+        
+        let query = cryptoKey.keyBuilderQuery()
+        var privateKey: SecKey?
+        
+        do {
+            privateKey = cryptoKey.getSecureKey()
+            XCTAssertNil(privateKey)
+            
+            let keyPair = try cryptoKey.createKeyPair(builderQuery: query)
+            XCTAssertNotNil(keyPair.privateKey)
+            
+            privateKey = cryptoKey.getSecureKey()
+            XCTAssertNotNil(privateKey)
+            
+            XCTAssertEqual(keyPair.privateKey, privateKey)
+            
+            let cryptoKey2 = CryptoKey(keyId: userId, accessGroup: accessGroup)
+            XCTAssertEqual(keyPair.privateKey, cryptoKey2.getSecureKey())
+        } catch {
+            XCTFail("Failed to create KeyPair")
+        }
+        
+        cryptoKey.deleteKeys()
+        privateKey = cryptoKey.getSecureKey()
+        XCTAssertNil(privateKey)
+    }
+    
+    
+    func test_09_different_accessGroup() {
+        let userId = "Test User Id 9"
+        let accessGroup1 = "com.forgerock.ios.shared"
+        let accessGroup2 = "com.forgerock.ios.FRTestHost"
+        let cryptoKey1 = CryptoKey(keyId: userId, accessGroup: accessGroup1)
+        let cryptoKey2 = CryptoKey(keyId: userId, accessGroup: accessGroup2)
+        let query1 = cryptoKey1.keyBuilderQuery()
+        let query2 = cryptoKey2.keyBuilderQuery()
+        var privateKey1: SecKey?
+        var privateKey2: SecKey?
+        
+        do {
+            // Access Group 1
+            privateKey1 = cryptoKey1.getSecureKey()
+            XCTAssertNil(privateKey1)
+            
+            let keyPair1 = try cryptoKey1.createKeyPair(builderQuery: query1)
+            XCTAssertNotNil(keyPair1.privateKey)
+            
+            privateKey1 = cryptoKey1.getSecureKey()
+            XCTAssertNotNil(privateKey1)
+            
+            XCTAssertEqual(keyPair1.privateKey, privateKey1)
+            
+            // Access Group 2
+            privateKey2 = cryptoKey2.getSecureKey()
+            XCTAssertNil(privateKey2)
+            
+            let keyPair2 = try cryptoKey2.createKeyPair(builderQuery: query2)
+            XCTAssertNotNil(keyPair2.privateKey)
+            
+            privateKey2 = cryptoKey2.getSecureKey()
+            XCTAssertNotNil(privateKey2)
+            
+            XCTAssertEqual(keyPair2.privateKey, privateKey2)
+            
+            // Compare keys from Access Group 1 and 2
+            XCTAssertNotEqual(privateKey1, privateKey2)
+            
+        } catch {
+            XCTFail("Failed to create KeyPair")
+        }
+        
+        cryptoKey1.deleteKeys()
+        privateKey1 = cryptoKey1.getSecureKey()
+        XCTAssertNil(privateKey1)
+        
+        cryptoKey2.deleteKeys()
+        privateKey2 = cryptoKey2.getSecureKey()
+        XCTAssertNil(privateKey2)
+    }
+    
+    
+    func test_10_with_and_without_accessGroup() {
+        let userId = "Test User Id 10"
+        let accessGroup1 = "com.forgerock.ios.shared"
+        let cryptoKey1 = CryptoKey(keyId: userId, accessGroup: accessGroup1)
+        let cryptoKey2 = CryptoKey(keyId: userId)
+        let query1 = cryptoKey1.keyBuilderQuery()
+        let query2 = cryptoKey2.keyBuilderQuery()
+        var privateKey1: SecKey?
+        var privateKey2: SecKey?
+        
+        do {
+            // With Access Group
+            let keyPair1 = try cryptoKey1.createKeyPair(builderQuery: query1)
+            XCTAssertNotNil(keyPair1.privateKey)
+            
+            privateKey1 = cryptoKey1.getSecureKey()
+            XCTAssertNotNil(privateKey1)
+            
+            XCTAssertEqual(keyPair1.privateKey, privateKey1)
+            
+            // Without Access Group
+            let keyPair2 = try cryptoKey2.createKeyPair(builderQuery: query2)
+            XCTAssertNotNil(keyPair2.privateKey)
+            
+            privateKey2 = cryptoKey2.getSecureKey()
+            XCTAssertNotNil(privateKey2)
+            
+            XCTAssertEqual(keyPair2.privateKey, privateKey2)
+            
+            // Compare keys
+            XCTAssertNotEqual(privateKey1, privateKey2)
+            
+        } catch {
+            XCTFail("Failed to create KeyPair")
+        }
+        
+        cryptoKey1.deleteKeys()
+        privateKey1 = cryptoKey1.getSecureKey()
+        XCTAssertNil(privateKey1)
+        
+        cryptoKey2.deleteKeys()
+        privateKey2 = cryptoKey2.getSecureKey()
+        XCTAssertNil(privateKey2)
     }
 }


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2358](https://bugster.forgerock.org/jira/browse/SDKS-2358) [iOS] Enable Keychain sharing(SSO) for device binding

# Description

Add _accessGroup_ to _CryptoKey_
In _CryptoKey_ make _getSecureKey_ and _deleteKeys_ instance methods (used to be static)
Add unit tests in _CryptoKeyTests_
        
Set _accessGroup_ in _KeychainDeviceRepository_
Add unit tests in _KeychainDeviceRepositoryTests_
        
In _DeviceBindingCallback_ move _deleteKeys_ out of _handleException_ method and call it on _authInterface_
Assign _accessGroup_ in _DeviceBindingAuthenticators_
