### PR TITLE
Sdks 1839 update facebook sdk

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added support for combined MFA in the Authenticator SDK [SDKS-2166]
 - Added support for policy enforcement in the Authenticator SDK [SDKS-2166]
 - Added support for passkeys [SDKS-2140]
+- Updated Facebook SDK Version to 16.0.1 [SDKS-1839]
 
 ## [3.4.1]
 #### Changed

--- a/FRFacebookSignIn.podspec
+++ b/FRFacebookSignIn.podspec
@@ -30,5 +30,5 @@ Pod::Spec.new do |s|
   base_dir = "FRFacebookSignIn/FRFacebookSignIn"
   s.source_files = base_dir + '/**/*.swift', base_dir + '/**/*.c', base_dir + '/**/*.h'
   s.ios.dependency 'FRAuth', '~> 4.0.0-beta5'
-  s.ios.dependency 'FBSDKLoginKit', '~> 9.1.0'
+  s.ios.dependency 'FBSDKLoginKit', '~> 16.0.1'
 end

--- a/FRFacebookSignIn/FRFacebookSignIn.xcodeproj/project.pbxproj
+++ b/FRFacebookSignIn/FRFacebookSignIn.xcodeproj/project.pbxproj
@@ -564,7 +564,7 @@
 			repositoryURL = "https://github.com/facebook/facebook-ios-sdk";
 			requirement = {
 				kind = exactVersion;
-				version = 9.1.0;
+				version = 16.0.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/FRFacebookSignIn/FRFacebookSignIn/Sources/FacebookSignInHandler.swift
+++ b/FRFacebookSignIn/FRFacebookSignIn/Sources/FacebookSignInHandler.swift
@@ -95,25 +95,8 @@ public class FacebookSignInHandler: NSObject, IdPHandler {
     /// - Parameters:
     ///   - application: The application as passed to `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)`.
     ///   - launchOptions: The launch options as passed to `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)`.
-    /// - Returns: `true` if there are any added application observers that themselves return true from calling `application(_:didFinishLaunchingWithOptions:)`.
-    ///    Otherwise will return `false`.
-    public static func handle(_ application: UIApplication, _ launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    /// - Returns: `true` if there are any added application observers that themselves return true from calling `application(_:didFinishLaunchingWithOptions:)`. Otherwise will return `false`.
+    public static func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
         return ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
-    }
-    
-    
-    //  MARK: - iOS 10 Support
-    
-    /// Handles incoming URL for Facebook Sign-in using SFSafariViewController
-    ///
-    ///  Note: This is only required to support iOS 10; this must be called at AppDelegate of the application
-    ///
-    /// - Parameters:
-    ///   - application: UIApplication instance
-    ///   - url: Incoming URL as in URL instance
-    ///   - options: UIApplication.OpenURLOptions
-    /// - Returns: Boolean result whether or not the URL is designated for Facebook Login
-    public static func handle(_ application: UIApplication, _ url: URL, _ options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
-        return ApplicationDelegate.shared.application(application, open: url, options: options)
     }
 }

--- a/FRFacebookSignIn/FRFacebookSignIn/Sources/FacebookSignInHandler.swift
+++ b/FRFacebookSignIn/FRFacebookSignIn/Sources/FacebookSignInHandler.swift
@@ -2,7 +2,7 @@
 //  FacebookSignInHandler.swift
 //  FRFacebookSignIn
 //
-//  Copyright (c) 2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2021-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -86,6 +86,19 @@ public class FacebookSignInHandler: NSObject, IdPHandler {
         let btn = FBLoginButton()
         btn.tooltipColorStyle = colorStyle
         return btn
+    }
+    
+    
+    /// Call this method from the `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)` method of your application delegate. It should be invoked for the proper use of the Facebook SDK.
+    /// As part of SDK initialization, basic auto-logging of app events will occur; this can be controlled via the `FacebookAutoLogAppEventsEnabled` key in the project's Info.plist file.
+    ///
+    /// - Parameters:
+    ///   - application: The application as passed to `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)`.
+    ///   - launchOptions: The launch options as passed to `UIApplicationDelegate.application(_:didFinishLaunchingWithOptions:)`.
+    /// - Returns: `true` if there are any added application observers that themselves return true from calling `application(_:didFinishLaunchingWithOptions:)`.
+    ///    Otherwise will return `false`.
+    public static func handle(_ application: UIApplication, _ launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+        return ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)
     }
     
     

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package (
         .library(name: "FRGoogleSignIn", targets: ["FRGoogleSignIn"])
     ],
     dependencies: [
-        .package(name: "Facebook", url: "https://github.com/facebook/facebook-ios-sdk.git", .exact("9.1.0")),
+        .package(name: "Facebook", url: "https://github.com/facebook/facebook-ios-sdk.git", .exact("16.0.1")),
         .package(name: "GoogleSignIn", url: "https://github.com/google/GoogleSignIn-iOS.git", .exact("6.1.0"))
     ],
     targets: [

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let package = Package (
     name: "ForgeRock-iOS-SDK",
     platforms: [
-        .iOS(.v11)
+        .iOS(.v12)
     ],
     products: [
         .library(name: "FRCore", targets: ["FRCore"]),

--- a/SampleApps/FRExample/FRExample/AppDelegate.swift
+++ b/SampleApps/FRExample/FRExample/AppDelegate.swift
@@ -2,7 +2,7 @@
 //  AppDelegate.swift
 //  FRExample
 //
-//  Copyright (c) 2019-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -25,7 +25,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        
+        #if canImport(FRFacebookSignIn)
+            FacebookSignInHandler.application(application, didFinishLaunchingWithOptions: launchOptions)
+        #endif
         // Enable logs for all level
         FRLog.setLogLevel([ .all])
         return true
@@ -33,11 +35,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     
     func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
         
-        #if canImport(FRFacebookSignIn)
-        if FacebookSignInHandler.handle(app, url, options) {
-            return true
-        }
-        #endif
         #if canImport(FRGoogleSignIn)
         if GoogleSignInHandler.handle(app, url, options) {
             return true


### PR DESCRIPTION
# JIRA Ticket

[SDKS-1839](https://bugster.forgerock.org/jira/browse/SDKS-1839)

# Description

[Spike] Upgrade Facebook SDK iOS

# Definition of Done Checklist:

Upgrade Facebook SDK version from 9.1.0 to 16.0.1 in the following places:
- Package.swift
- FRFacebookSignIn.podspec
- FRFacebookSignIn.xcodeproj/project.pbxproj

Add new `application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool` method in FRFacebookSignIn that calls `ApplicationDelegate.shared.application(application, didFinishLaunchingWithOptions: launchOptions)`. This method needs to be called in AppDelegate's `application(_ , didFinishLaunchingWithOptions)` method as per Facebook SDK's new requirement in order to initialize the Facebook SDK

Update FRExample's AppDelegate 
