### PR TITLE
Revoke old access_token upon force refresh

### DIFF
--- a/FRAuth/FRAuth/Config/OAuth2Client.swift
+++ b/FRAuth/FRAuth/Config/OAuth2Client.swift
@@ -2,7 +2,7 @@
 //  OAuth2Client.swift
 //  FRAuth
 //
-//  Copyright (c) 2019-2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -56,12 +56,16 @@ public class OAuth2Client: NSObject, Codable {
     ///
     /// - Parameters:
     ///   - accessToken: AccessToken object to revoke
+    ///   - useRefreshToken: Whether to use refreshToken or not. `true` by default
     ///   - completion: Completion callback to notify the result of operation
     @objc
-    public func revoke(accessToken: AccessToken, completion: @escaping CompletionCallback) {
+    public func revoke(accessToken: AccessToken, useRefreshToken: Bool = true, completion: @escaping CompletionCallback) {
         // Construct parameter for the request
         var parameter:[String: String] = [:]
-        let token = accessToken.refreshToken ?? accessToken.value
+        var token = accessToken.value
+        if useRefreshToken {
+            token = accessToken.refreshToken ?? accessToken.value
+        }
         parameter[OAuth2.token] = token
         parameter[OAuth2.clientId] = self.clientId
         

--- a/FRAuth/FRAuth/Manager/TokenManager.swift
+++ b/FRAuth/FRAuth/Manager/TokenManager.swift
@@ -2,7 +2,7 @@
 //  TokenManager.swift
 //  FRAuth
 //
-//  Copyright (c) 2019-2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -364,5 +364,13 @@ struct TokenManager {
         FRSession._staticSession = nil
         FRUser._staticUser = nil
         Browser.currentBrowser = nil
+    }
+    
+    
+    /// Revoke given token
+    func revokeToken(_ token: AccessToken, completion: @escaping CompletionCallback) {
+        self.oAuth2Client.revoke(accessToken: token) { (error) in
+            completion(error)
+        }
     }
 }

--- a/FRAuth/FRAuth/Manager/TokenManager.swift
+++ b/FRAuth/FRAuth/Manager/TokenManager.swift
@@ -367,9 +367,9 @@ struct TokenManager {
     }
     
     
-    /// Revoke given token
+    /// Revoke given Access Token without using the Refresh Token
     func revokeToken(_ token: AccessToken, completion: @escaping CompletionCallback) {
-        self.oAuth2Client.revoke(accessToken: token) { (error) in
+        self.oAuth2Client.revoke(accessToken: token, useRefreshToken: false) { (error) in
             completion(error)
         }
     }

--- a/FRAuth/FRAuth/User/FRUser.swift
+++ b/FRAuth/FRAuth/User/FRUser.swift
@@ -305,6 +305,7 @@ public class FRUser: NSObject, NSSecureCoding {
         if let frAuth = FRAuth.shared, let tokenManager = frAuth.tokenManager {
             tokenManager.refresh{ (token, error) in
                 if let token = token {
+                    self.revokeOldAccessToken()
                     self.token = token
                     self.save()
                     completion(self, nil)
@@ -328,6 +329,7 @@ public class FRUser: NSObject, NSSecureCoding {
     public func refreshSync() throws -> FRUser {
         if let frAuth = FRAuth.shared, let tokenManager = frAuth.tokenManager {
             let token = try tokenManager.refreshSync()
+            self.revokeOldAccessToken()
             self.token = token
             self.save()
             return self
@@ -453,5 +455,18 @@ public class FRUser: NSObject, NSSecureCoding {
     ///
     /// - Parameter aCoder: NSCoder
     public func encode(with aCoder: NSCoder) {
+    }
+    
+    
+    /// Revoke the old(current) Access Token
+    private func revokeOldAccessToken() {
+        if let frAuth = FRAuth.shared, let tokenManager = frAuth.tokenManager, let token = self.token {
+            tokenManager.revokeToken(token) {
+                error in
+                if let error = error {
+                    FRLog.e("Error revoking the old AccessToken: \(error.localizedDescription)")
+                }
+            }
+        }
     }
 }

--- a/FRAuth/FRAuth/User/FRUser.swift
+++ b/FRAuth/FRAuth/User/FRUser.swift
@@ -303,9 +303,10 @@ public class FRUser: NSObject, NSSecureCoding {
     @objc
     public func refresh(completion:@escaping UserCallback) {
         if let frAuth = FRAuth.shared, let tokenManager = frAuth.tokenManager {
+            let oldToken = self.token
             tokenManager.refresh{ (token, error) in
                 if let token = token {
-                    self.revokeOldAccessToken()
+                    self.revokeGivenAccessToken(oldToken)
                     self.token = token
                     self.save()
                     completion(self, nil)
@@ -327,9 +328,10 @@ public class FRUser: NSObject, NSSecureCoding {
     /// - Returns: FRUser object with newly renewed OAuth2 token
     @objc
     public func refreshSync() throws -> FRUser {
+        let oldToken = self.token
         if let frAuth = FRAuth.shared, let tokenManager = frAuth.tokenManager {
             let token = try tokenManager.refreshSync()
-            self.revokeOldAccessToken()
+            self.revokeGivenAccessToken(oldToken)
             self.token = token
             self.save()
             return self
@@ -458,9 +460,9 @@ public class FRUser: NSObject, NSSecureCoding {
     }
     
     
-    /// Revoke the old(current) Access Token
-    private func revokeOldAccessToken() {
-        if let frAuth = FRAuth.shared, let tokenManager = frAuth.tokenManager, let token = self.token {
+    /// Revoke given Access Token without using the Refresh Token
+    func revokeGivenAccessToken(_ token: AccessToken?) {
+        if let frAuth = FRAuth.shared, let tokenManager = frAuth.tokenManager, let token = token {
             tokenManager.revokeToken(token) {
                 error in
                 if let error = error {

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Model/User/FRUserTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Model/User/FRUserTests.swift
@@ -768,4 +768,31 @@ class FRUserTests: FRAuthBaseTest {
             XCTFail("Refresh AccessToken failure")
         }
     }
+    
+    func test_07_01_RevokeGivenAccessToken() {
+        // Perform login first
+        self.performLogin()
+        
+        guard let user = FRUser.currentUser else {
+            XCTFail("Failed to perform user login")
+            return
+        }
+        
+        // Load mock responses for refresh token
+        self.loadMockResponses(["OAuth2_Token_Revoke_Success"])
+        
+        // Validate if FRUser.currentUser is not nil
+        XCTAssertNotNil(FRUser.currentUser)
+        XCTAssertNotNil(user.token)
+        
+        let ex = self.expectation(description: "Revoke AccessToken failure")
+        if let frAuth = FRAuth.shared, let tokenManager = frAuth.tokenManager, let token = user.token {
+            tokenManager.revokeToken(token) {
+                error in
+                XCTAssertNil(error)
+                ex.fulfill()
+            }
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+    }
 }

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/RequestInterceptor/FRRequestInterceptorTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/RequestInterceptor/FRRequestInterceptorTests.swift
@@ -2,7 +2,7 @@
 //  FRRequestInterceptorTests.swift
 //  FRAuthTests
 //
-//  Copyright (c) 2020-2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2023 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -57,8 +57,8 @@ class FRRequestInterceptorTests: FRAuthBaseTest {
         waitForExpectations(timeout: 60, handler: nil)
         XCTAssertEqual(FRRequestInterceptorTests.payload.count, 0)
         
-        XCTAssertEqual(FRRequestInterceptorTests.intercepted.count, 1)
-        let interceptorsInOrder: [String] = ["REFRESH_TOKEN"]
+        XCTAssertEqual(FRRequestInterceptorTests.intercepted.count, 2)
+        let interceptorsInOrder: [String] = ["REFRESH_TOKEN", "REVOKE_TOKEN"]
         for (index, intercepted) in FRRequestInterceptorTests.intercepted.enumerated() {
             XCTAssertEqual(interceptorsInOrder[index], intercepted)
         }


### PR DESCRIPTION

[SDKS-2571](https://bugster.forgerock.org/jira/browse/SDKS-2571)

Revoke old access_token upon force refresh. Made sure it's only revoking the access token and not the refresh token.



**The following regression test has been completed (this test has been verified with "Issue Refresh Tokens on Refreshing Access Tokens" both On and Off in AM console)**

1. Call Login - Verify that access token and refresh token has been issued

2. Call Get User Info - Verify that user info successfully retrieved using the Access Token from Step 1

3. Call Refresh Token - Verify that the new Access Token has been issued (check that it's different from the Access Token from Step 1) and that Revoke endpoint has been called with the old Access Token from Step 1

4. Call Get User Info - Verify that user info successfully retrieved using the Access Token from Step 3

5. In the Terminal call /userinfo endpoint using the Access Token from Step 1 - Verify that "invalid_token" response has been received