### PR TITLE
SDKS-2653 Issuer parameter not correctly set for some URI schemes

### DIFF
--- a/FRAuthenticator/FRAuthenticator/Model/Mechanism/Push/PushQRCodeParser.swift
+++ b/FRAuthenticator/FRAuthenticator/Model/Mechanism/Push/PushQRCodeParser.swift
@@ -98,6 +98,10 @@ struct PushQRCodeParser {
               throw MechanismError.missingInformation("s, r, a, m, or c")
         }
         
+        if let issuer = params["issuer"], let decodedVal = issuer.base64Decoded() {
+            self.issuer = decodedVal
+        }
+        
         guard let regUrlData = registrationEndpoint.decodeURL(), let regUrlStr = String(data: regUrlData, encoding: .utf8), let regURL = URL(string: regUrlStr), let authUrlData = authenticationEndpoint.decodeURL(), let authUrlStr = String(data: authUrlData, encoding: .utf8), let authURL = URL(string: authUrlStr) else {
                 throw MechanismError.invalidInformation("registration and/or authentication URL")
         }

--- a/FRAuthenticator/FRAuthenticatorTests/E2ETests/AuthenticatorManager/AuthenticatorManagerTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/E2ETests/AuthenticatorManager/AuthenticatorManagerTests.swift
@@ -380,7 +380,7 @@ class AuthenticatorManagerTests: FRABaseTests {
         let storageClient = DummyStorageClient()
         let policyEvaluator = FRAPolicyEvaluator()
         let authenticatorManager = AuthenticatorManager(storageClient: storageClient, policyEvaluator: policyEvaluator)
-        let qrCode = URL(string: "pushauth://push/forgerock:pushreg3?a=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1hdXRoZW50aWNhdGU&b=519387&r=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1yZWdpc3Rlcg&s=5GuioYhLlh-xER3n5I8vrx0uuYQo3yD86aJi6KuWDsg&c=KP0XQfZ21N_jsXP_xfVQMmsmoUiWvdDPWecHdb5_INQ&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:a8970dea-3257-4be1-a37a-23eed2b692131588282723889&issuer=Rm9yZ2VSb2NrU2FuZGJveA")!
+        let qrCode = URL(string: "pushauth://push/forgerock:pushreg3?a=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1hdXRoZW50aWNhdGU&b=519387&r=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1yZWdpc3Rlcg&s=5GuioYhLlh-xER3n5I8vrx0uuYQo3yD86aJi6KuWDsg&c=KP0XQfZ21N_jsXP_xfVQMmsmoUiWvdDPWecHdb5_INQ&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:a8970dea-3257-4be1-a37a-23eed2b692131588282723889&issuer=Zm9yZ2Vyb2Nr")!
         
         let ex = self.expectation(description: "Register PushMechanism")
         authenticatorManager.storePushQRcode(uri: qrCode, onSuccess: { (mechanism) in
@@ -446,7 +446,7 @@ class AuthenticatorManagerTests: FRABaseTests {
         storageClient.setMechanismResult = false
         let policyEvaluator = FRAPolicyEvaluator()
         let authenticatorManager = AuthenticatorManager(storageClient: storageClient, policyEvaluator: policyEvaluator)
-        let qrCode = URL(string: "pushauth://push/forgerock:pushreg3?a=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1hdXRoZW50aWNhdGU&b=519387&r=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1yZWdpc3Rlcg&s=5GuioYhLlh-xER3n5I8vrx0uuYQo3yD86aJi6KuWDsg&c=KP0XQfZ21N_jsXP_xfVQMmsmoUiWvdDPWecHdb5_INQ&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:a8970dea-3257-4be1-a37a-23eed2b692131588282723889&issuer=Rm9yZ2VSb2NrU2FuZGJveA")!
+        let qrCode = URL(string: "pushauth://push/forgerock:pushreg3?a=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1hdXRoZW50aWNhdGU&b=519387&r=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1yZWdpc3Rlcg&s=5GuioYhLlh-xER3n5I8vrx0uuYQo3yD86aJi6KuWDsg&c=KP0XQfZ21N_jsXP_xfVQMmsmoUiWvdDPWecHdb5_INQ&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:a8970dea-3257-4be1-a37a-23eed2b692131588282723889&issuer=Zm9yZ2Vyb2Nr")!
         
         let ex = self.expectation(description: "Register PushMechanism")
         authenticatorManager.storePushQRcode(uri: qrCode, onSuccess: { (mechanism) in
@@ -1078,7 +1078,7 @@ class AuthenticatorManagerTests: FRABaseTests {
         }
         FRAPushHandler.shared.application(UIApplication.shared, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
 
-        let push = URL(string: "pushauth://push/forgerock:pushtestuser?a=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1hdXRoZW50aWNhdGU&b=519387&r=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1yZWdpc3Rlcg&s=-3xGWaKjfls_ZHFRnGeIvFHn--GxzjQyg1RVG_Pak1s&c=esDK4G8eYce0_Gdf4p9XGGg2cIYYoxf6CTlL_O_1aF8&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:593b6a92-f5c1-4ac0-a94a-a63e05451dd51589138620791&issuer=Rm9yZ2VSb2NrU2FuZGJveA")!
+        let push = URL(string: "pushauth://push/forgerock:pushtestuser?a=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1hdXRoZW50aWNhdGU&b=519387&r=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1yZWdpc3Rlcg&s=-3xGWaKjfls_ZHFRnGeIvFHn--GxzjQyg1RVG_Pak1s&c=esDK4G8eYce0_Gdf4p9XGGg2cIYYoxf6CTlL_O_1aF8&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:593b6a92-f5c1-4ac0-a94a-a63e05451dd51589138620791&issuer=Zm9yZ2Vyb2Nr")!
 
         //  Store first Mechanism
         let ex = self.expectation(description: "FRAClient.createMechanismFromUri")
@@ -1222,7 +1222,7 @@ class AuthenticatorManagerTests: FRABaseTests {
         }
         FRAPushHandler.shared.application(UIApplication.shared, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
 
-        let push = URL(string: "pushauth://push/forgerock:pushtestuser?a=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1hdXRoZW50aWNhdGU&b=519387&r=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1yZWdpc3Rlcg&s=-3xGWaKjfls_ZHFRnGeIvFHn--GxzjQyg1RVG_Pak1s&c=esDK4G8eYce0_Gdf4p9XGGg2cIYYoxf6CTlL_O_1aF8&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:593b6a92-f5c1-4ac0-a94a-a63e05451dd51589138620791&issuer=Rm9yZ2VSb2NrU2FuZGJveA")!
+        let push = URL(string: "pushauth://push/forgerock:pushtestuser?a=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1hdXRoZW50aWNhdGU&b=519387&r=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1yZWdpc3Rlcg&s=-3xGWaKjfls_ZHFRnGeIvFHn--GxzjQyg1RVG_Pak1s&c=esDK4G8eYce0_Gdf4p9XGGg2cIYYoxf6CTlL_O_1aF8&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:593b6a92-f5c1-4ac0-a94a-a63e05451dd51589138620791&issuer=Zm9yZ2Vyb2Nr")!
 
         //  Store first Mechanism
         let ex = self.expectation(description: "FRAClient.createMechanismFromUri")
@@ -1384,7 +1384,7 @@ class AuthenticatorManagerTests: FRABaseTests {
         }
         FRAPushHandler.shared.application(UIApplication.shared, didRegisterForRemoteNotificationsWithDeviceToken: deviceToken)
 
-        let push = URL(string: "pushauth://push/forgerock:pushtestuser?a=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1hdXRoZW50aWNhdGU&b=519387&r=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1yZWdpc3Rlcg&s=-3xGWaKjfls_ZHFRnGeIvFHn--GxzjQyg1RVG_Pak1s&c=esDK4G8eYce0_Gdf4p9XGGg2cIYYoxf6CTlL_O_1aF8&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:593b6a92-f5c1-4ac0-a94a-a63e05451dd51589138620791&issuer=Rm9yZ2VSb2NrU2FuZGJveA")!
+        let push = URL(string: "pushauth://push/forgerock:pushtestuser?a=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1hdXRoZW50aWNhdGU&b=519387&r=aHR0cDovL29wZW5hbS5leGFtcGxlLmNvbTo4MDgxL29wZW5hbS9qc29uL3B1c2gvc25zL21lc3NhZ2U_X2FjdGlvbj1yZWdpc3Rlcg&s=-3xGWaKjfls_ZHFRnGeIvFHn--GxzjQyg1RVG_Pak1s&c=esDK4G8eYce0_Gdf4p9XGGg2cIYYoxf6CTlL_O_1aF8&l=YW1sYmNvb2tpZT0wMQ&m=REGISTER:593b6a92-f5c1-4ac0-a94a-a63e05451dd51589138620791&issuer=Zm9yZ2Vyb2Nr")!
 
         //  Store first Mechanism
         let ex = self.expectation(description: "FRAClient.createMechanismFromUri")
@@ -1722,13 +1722,15 @@ class AuthenticatorManagerTests: FRABaseTests {
                          "m=REGISTER:a8970dea-3257-4be1-a37a-23eed2b692131588282723889" +
                          "digits=6&" +
                          "secret=R2PYFZRISXA5L25NVSSYK2RQ6E======&" +
-                         "period=30&")!
+                         "period=30&issuer=Zm9yZ2Vyb2Nr")!
         
         let ex = self.expectation(description: "Register PushMechanism")
         authenticatorManager.createMechanismFromUri(uri: qrCode, onSuccess: { (mechanism) in
             XCTAssertNotNil(mechanism)
             let accountFromStorage = authenticatorManager.getAccount(identifier: "forgerock-pushreg3")
             XCTAssertNotNil(accountFromStorage)
+            XCTAssertEqual(accountFromStorage?.accountName, "pushreg3")
+            XCTAssertEqual(accountFromStorage?.issuer, "forgerock")
             XCTAssertEqual(authenticatorManager.getAllAccounts().count, 1)
             XCTAssertEqual(accountFromStorage?.mechanisms.count, 2)
             ex.fulfill()
@@ -1762,7 +1764,7 @@ class AuthenticatorManagerTests: FRABaseTests {
                          "policies=eyJkdW1teSI6IHsgfSwgImR1bW15V2l0aERhdGEiOiB7ICJyZXN1bHQiIDogZmFsc2UgfX0=&" +
                          "digits=6&" +
                          "secret=R2PYFZRISXA5L25NVSSYK2RQ6E======&" +
-                         "period=30&")!
+                         "period=30&issuer=Rm9yZ2Vyb2Nr")!
         let authenticatorManager = AuthenticatorManager(storageClient: FRAClient.storage, policyEvaluator: policyEvaluator)
         
         let ex = self.expectation(description: "AuthenticatorManager.createMechanismFromUri")
@@ -1808,7 +1810,7 @@ class AuthenticatorManagerTests: FRABaseTests {
                          "policies=eyJkdW1teSI6IHsgfX0=&" +
                          "digits=6&" +
                          "secret=R2PYFZRISXA5L25NVSSYK2RQ6E======&" +
-                         "period=30&")!
+                         "period=30&issuer=Zm9yZ2Vyb2Nr")!
         
         let ex = self.expectation(description: "Register PushMechanism")
         authenticatorManager.createMechanismFromUri(uri: qrCode, onSuccess: { (mechanism) in

--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Util/PushQRCodeParserTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Util/PushQRCodeParserTests.swift
@@ -88,7 +88,7 @@ class PushQRCodeParserTests: FRABaseTests {
             XCTAssertNotNil(parser.issuer)
             XCTAssertNotNil(parser.label)
             XCTAssertEqual(parser.label, "demo")
-            XCTAssertEqual(parser.issuer, "")
+            XCTAssertEqual(parser.issuer, "Forgerock")
         }
         catch {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")
@@ -155,7 +155,7 @@ class PushQRCodeParserTests: FRABaseTests {
             
             XCTAssertEqual(parser.scheme, "mfauth")
             XCTAssertEqual(parser.type, "totp")
-            XCTAssertEqual(parser.issuer, "Test")
+            XCTAssertEqual(parser.issuer, "Forgerock")
             XCTAssertEqual(parser.label, "demo")
             XCTAssertEqual(parser.loadBalancer, "amlbcookie=01")
             XCTAssertEqual(parser.challenge, "Daf8vrc8onKu+dcptwCRS9UHmdui5u16vAdG2HMU4w0")


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2653](https://bugster.forgerock.org/jira/browse/SDKS-2653) Issuer parameter not correctly set

# Description

While registering a Push mechanism through iOS SDK, the issuer value is incorrect. It shows "forgerock", instead of the issuer value set in the 'Push registration node' property.

# Definition of Done Checklist:

- [x] Acceptance criteria is met.
- [x] All tasks listed in the user story have been completed.
- [x] Coded to standards.
- [x] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [x] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] Example code snippets have been added.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).