### PR TITLE
Updated Auth service and Node to not revoke existing OAuth2.0 token due to a session missmatch when an existing session does not apply (central login case)

### DIFF
--- a/FRAuth/FRAuth/Authentication/AuthService.swift
+++ b/FRAuth/FRAuth/Authentication/AuthService.swift
@@ -252,6 +252,10 @@ public class AuthService: NSObject {
                                 }
                             }
                             keychainManager.setSSOToken(ssoToken: token)
+                        } else {
+                            if (try? keychainManager.getAccessToken()) == nil {
+                                keychainManager.setSSOToken(ssoToken: token)
+                            }
                         }
                     }
                     

--- a/FRAuth/FRAuth/Authentication/AuthService.swift
+++ b/FRAuth/FRAuth/Authentication/AuthService.swift
@@ -232,24 +232,27 @@ public class AuthService: NSObject {
                     let token = Token(tokenId)
                     if let keychainManager = self.keychainManager {
                         let currentSessionToken = keychainManager.getSSOToken()
-                        if let _ = try? keychainManager.getAccessToken(), token.value != currentSessionToken?.value {
-                            FRLog.w("SDK identified existing Session Token (\(currentSessionToken?.value ?? "nil")) and received Session Token (\(token.value))'s mismatch; to avoid misled information, SDK automatically revokes OAuth2 token set issued with existing Session Token.")
-                            if let tokenManager = self.tokenManager {
-                                tokenManager.revokeAndEndSession { (error) in
-                                    FRLog.i("OAuth2 token set was revoked due to mismatch of Session Tokens; \(error?.localizedDescription ?? "")")
+                        if currentSessionToken != nil {
+                            //If the `currentSessionToken` is nil, it means the user did a Centralized Login flow to authenticate initially. Ignore the new token and just return.
+                            if let _ = try? keychainManager.getAccessToken(), token.value != currentSessionToken?.value {
+                                FRLog.w("SDK identified existing Session Token (\(currentSessionToken?.value ?? "nil")) and received Session Token (\(token.value))'s mismatch; to avoid misled information, SDK automatically revokes OAuth2 token set issued with existing Session Token.")
+                                if let tokenManager = self.tokenManager {
+                                    tokenManager.revokeAndEndSession { (error) in
+                                        FRLog.i("OAuth2 token set was revoked due to mismatch of Session Tokens; \(error?.localizedDescription ?? "")")
+                                    }
+                                }
+                                else {
+                                    FRLog.i("TokenManager is not found; OAuth2 token set was removed from the storage")
+                                    do {
+                                        try keychainManager.setAccessToken(token: nil)
+                                    }
+                                    catch {
+                                        FRLog.e("Unexpected error while removing AccessToken: \(error.localizedDescription)")
+                                    }
                                 }
                             }
-                            else {
-                                FRLog.i("TokenManager is not found; OAuth2 token set was removed from the storage")
-                                do {
-                                    try keychainManager.setAccessToken(token: nil)
-                                }
-                                catch {
-                                    FRLog.e("Unexpected error while removing AccessToken: \(error.localizedDescription)")
-                                }
-                            }
+                            keychainManager.setSSOToken(ssoToken: token)
                         }
-                        keychainManager.setSSOToken(ssoToken: token)
                     }
                     
                     completion(token, nil, nil)

--- a/FRAuth/FRAuth/Authentication/Node.swift
+++ b/FRAuth/FRAuth/Authentication/Node.swift
@@ -294,6 +294,10 @@ public class Node: NSObject {
                                 }
                             }
                             keychainManager.setSSOToken(ssoToken: token)
+                        } else {
+                            if (try? keychainManager.getAccessToken()) == nil {
+                                keychainManager.setSSOToken(ssoToken: token)
+                            }
                         }
                     }
                     


### PR DESCRIPTION
Updated Auth service and Node to not revoke existing OAuth2.0 token due to a session missmatch when an existing session does not apply (central login case)

# Description

When apps perform Centralized Login, the SDK does not hold an SSO token in storage. Therefore when trying an FRSession.authenticate calls from the SDK subsequently, despite succeeding the SDK will revoke all OAuth2.0 tokens and end the session. 
There are use cases that developers might use Centralized Login for authentication and Self Service or Transactional Auth in an embedded flow. In these cases, the SDK should continue to hold the OAuth2.0 tokens and not invalidate the existing session 

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] Example code snippets have been added.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).