### PR TITLE
Fix custom claims bug, add unit tests

### DIFF
--- a/FRDeviceBinding/FRDeviceBinding/Sources/ApplicationPinDeviceAuthenticator.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/ApplicationPinDeviceAuthenticator.swift
@@ -86,9 +86,10 @@ open class ApplicationPinDeviceAuthenticator: DeviceAuthenticator, CryptoAware {
     /// - Parameter userKey: user Information
     /// - Parameter challenge: challenge received from server
     /// - Parameter expiration: experation Date of jws
+    /// - Parameter customClaims: A dictionary of custom claims to be added to the jws payload
     /// - Returns: compact serialized jws
     /// - Throws: `DeviceBindingStatus` if any error occurs while signing
-    public func sign(userKey: UserKey, challenge: String, expiration: Date) throws -> String {
+    public func sign(userKey: UserKey, challenge: String, expiration: Date, customClaims: [String: Any] = [:]) throws -> String {
         guard let prompt = prompt else {
             throw DeviceBindingStatus.unsupported(errorMessage: "Cannot retrive keys, missing prompt")
         }
@@ -108,7 +109,7 @@ open class ApplicationPinDeviceAuthenticator: DeviceAuthenticator, CryptoAware {
         header.typ = DBConstants.JWS
         
         //create payload
-        var params: [String: Any] = [DBConstants.sub: userKey.userId, DBConstants.challenge: challenge, DBConstants.exp: (Int(expiration.timeIntervalSince1970)), DBConstants.iat: (Int(issueTime().timeIntervalSince1970)), DBConstants.nbf: (Int(notBeforeTime().timeIntervalSince1970))]
+        var params: [String: Any] = [DBConstants.sub: userKey.userId, DBConstants.challenge: challenge, DBConstants.exp: (Int(expiration.timeIntervalSince1970)), DBConstants.iat: (Int(issueTime().timeIntervalSince1970)), DBConstants.nbf: (Int(notBeforeTime().timeIntervalSince1970))].merging(customClaims) { (current, _) in current }
         guard let bundleIdentifier = Bundle.main.bundleIdentifier else {
             throw DeviceBindingStatus.unsupported(errorMessage: "Bundle Identifier is missing")
         }

--- a/FRDeviceBinding/FRDeviceBindingTests/ApplicationPinDeviceAuthenticatorTests.swift
+++ b/FRDeviceBinding/FRDeviceBindingTests/ApplicationPinDeviceAuthenticatorTests.swift
@@ -145,6 +145,60 @@ class ApplicationPinDeviceAuthenticatorTests: FRBaseTestCase {
         }
     }
     
+    
+    func test_05_sign_with_userKey_customClaims() throws {
+        try XCTSkipIf(self.isSimulator, "LAContext().setCredential(...) call is not supported on iOS Simulator.")
+        try XCTSkipIf(!Self.biometricTestsSupported, "This test requires PIN setup on the device")
+        let userId = "Test User Id 2"
+        let challenge = "challenge"
+        let expiration = Date().addingTimeInterval(60.0)
+        let kid = UUID().uuidString
+        let lastUpdatedDate = Date()
+        let customClaims: [String : Any] = ["deviceId": "DEVICE_ID", "isCompanyPhone": true, "lastUpdated": Int(lastUpdatedDate.timeIntervalSince1970)]
+        
+        let authenticator = ApplicationPinDeviceAuthenticator(pinCollector: PinCollectorMock())
+        authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: "description"))
+        do {
+            let keyPair = try authenticator.generateKeys()
+            let userKey = UserKey(id: CryptoKey.getKeyAlias(keyName: userId), userId: userId, userName: "username", kid: kid, authType: .applicationPin, createdAt: Date().timeIntervalSince1970)
+            let jwsString = try authenticator.sign(userKey: userKey, challenge: challenge, expiration: expiration, customClaims: customClaims)
+            
+            //verify signature
+            let jws = try JWS(compactSerialization: jwsString)
+            guard let verifier = Verifier(verifyingAlgorithm: .ES256, key: keyPair.publicKey) else {
+                XCTFail("Failed to create Verifier")
+                return
+            }
+            
+            let _ = try jws.validate(using: verifier)
+            let payload = jws.payload
+            let message = String(data: payload.data(), encoding: .utf8)!
+            XCTAssertEqual(kid, jws.header.kid)
+            XCTAssertEqual(DBConstants.JWS, jws.header.typ)
+            
+            let messageDictionary = FRTestUtils.parseStringToDictionary(message)
+            
+            XCTAssertEqual(messageDictionary[DBConstants.challenge] as? String, challenge)
+            XCTAssertEqual(messageDictionary[DBConstants.sub] as? String, userId)
+            XCTAssertEqual(messageDictionary[DBConstants.exp] as? Int, Int(expiration.timeIntervalSince1970))
+            XCTAssertEqual(messageDictionary[DBConstants.iat] as! Int, Int(Date().timeIntervalSince1970), accuracy: 10)
+            XCTAssertEqual(messageDictionary[DBConstants.nbf] as! Int, Int(Date().timeIntervalSince1970), accuracy: 10)
+            if let bundleIdentifier = Bundle.main.bundleIdentifier {
+                XCTAssertEqual(messageDictionary[DBConstants.iss] as? String, bundleIdentifier)
+            }
+            XCTAssertEqual(messageDictionary["deviceId"] as? String, "DEVICE_ID")
+            XCTAssertEqual(messageDictionary["isCompanyPhone"] as? Bool, true)
+            XCTAssertEqual(messageDictionary["lastUpdated"] as? Int, Int(lastUpdatedDate.timeIntervalSince1970))
+            
+        } catch {
+            XCTFail("Failed to verify JWS signature")
+        }
+        let cryptoKey = CryptoKey(keyId: userId)
+        cryptoKey.deleteKeys()
+    }
+    
+    
+    
     class PinCollectorMock: PinCollector {
         func collectPin(prompt: Prompt, completion: @escaping (String?) -> Void) {
             completion("1234")


### PR DESCRIPTION
During the release testing we discovered that there has been a bug related custom claims implementation. This PR fixes that bug.

- Fix a bug where ApplicationPinDeviceAuthenticator wasn't overriding  sign method with custom claims. 
- Add unit tests