### PR TITLE
Sdks 2886 Fix Device Binding API access level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,18 @@
-# Unreleased
+## [4.3.0]
 #### Added
-- Update Jailbreak Detectors [SDKS-2796]
-
-# Version 4.1.1
-
-## [4.1.1]
+- AppIntegrity Callback support [SDKS-2630] [SDKS-2761]
+- New ephemeralAuthSession browser type (iOS13+) [SDKS-2707]
+- `iat` and `nbf` claims to Device Binding jws payload [SDKS-2748]
+- Custom claims to device signing verifier [SDKS-2788]
 
 #### Fixed
 - Fixed an issue where the `issuer` parameter was not properly parsed when using AM 7.2.x [SDKS-2653]
+- Updated Jailbreak Detectors [SDKS-2796]
+- Fixed an issue related to Inadequate Cache Control [SDKS-2700]
+- Fixed the issue when sfViewController setting in Centralized login had the "entersReaderIfAvailable" as true [SDKS-2746] 
+- Fix the issue with DeviceProfile Collector affecting phones with dual sim cards in iOS 16.3 and earlier [SDKS-2776]
+- Improve unit and e2e tests [SDKS-2637]
+- Fix the issue with device binding api access level [SDKS-2886]
 
 ## [4.1.0]
 #### Added

--- a/FRDeviceBinding/FRDeviceBinding/Sources/ApplicationPinDeviceAuthenticator.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/ApplicationPinDeviceAuthenticator.swift
@@ -26,7 +26,7 @@ open class ApplicationPinDeviceAuthenticator: DeviceAuthenticator, CryptoAware {
     /// PinCollector for collecting the Pin
     public var pinCollector: PinCollector
     
-    init(pinCollector: PinCollector = DefaultPinCollector()) {
+    public init(pinCollector: PinCollector = DefaultPinCollector()) {
         self.pinCollector = pinCollector
     }
     

--- a/FRDeviceBinding/FRDeviceBinding/Sources/ApplicationPinDeviceAuthenticator.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/ApplicationPinDeviceAuthenticator.swift
@@ -16,7 +16,7 @@ import JOSESwift
 
 
 /// DeviceAuthenticator adoption for Application Pin authentication
-open class ApplicationPinDeviceAuthenticator: DeviceAuthenticator, CryptoAware {
+open class ApplicationPinDeviceAuthenticator: DefaultDeviceAuthenticator, CryptoAware {
     /// prompt  for authentication promp if applicable
     var prompt: Prompt?
     /// cryptoKey for key pair generation
@@ -31,7 +31,7 @@ open class ApplicationPinDeviceAuthenticator: DeviceAuthenticator, CryptoAware {
     }
     
     /// Generate public and private key pair
-    open func generateKeys() throws -> KeyPair {
+    open override func generateKeys() throws -> KeyPair {
         guard let appPinAuthenticator = appPinAuthenticator, let prompt = prompt else {
             throw DeviceBindingStatus.unsupported(errorMessage: "Cannot generate keys, missing appPinAuthenticator or prompt")
         }
@@ -49,18 +49,18 @@ open class ApplicationPinDeviceAuthenticator: DeviceAuthenticator, CryptoAware {
     
     
     /// Check if authentication is supported
-    open func isSupported() -> Bool {
+    open override func isSupported() -> Bool {
         return true
     }
     
     
     /// Access Control for the authetication type
-    open func accessControl() -> SecAccessControl? {
+    open override func accessControl() -> SecAccessControl? {
         return appPinAuthenticator?.accessControl()
     }
     
     
-    open func type() -> DeviceBindingAuthenticationType {
+    open override func type() -> DeviceBindingAuthenticationType {
         return .applicationPin
     }
     
@@ -71,12 +71,12 @@ open class ApplicationPinDeviceAuthenticator: DeviceAuthenticator, CryptoAware {
     }
     
     
-    open func setPrompt(_ prompt: Prompt) {
+    open override func setPrompt(_ prompt: Prompt) {
         self.prompt = prompt
     }
     
     
-    public func deleteKeys() {
+    public override func deleteKeys() {
         cryptoKey?.deleteKeys()
     }
     
@@ -89,7 +89,7 @@ open class ApplicationPinDeviceAuthenticator: DeviceAuthenticator, CryptoAware {
     /// - Parameter customClaims: A dictionary of custom claims to be added to the jws payload
     /// - Returns: compact serialized jws
     /// - Throws: `DeviceBindingStatus` if any error occurs while signing
-    public func sign(userKey: UserKey, challenge: String, expiration: Date, customClaims: [String: Any] = [:]) throws -> String {
+    public override func sign(userKey: UserKey, challenge: String, expiration: Date, customClaims: [String: Any] = [:]) throws -> String {
         guard let prompt = prompt else {
             throw DeviceBindingStatus.unsupported(errorMessage: "Cannot retrive keys, missing prompt")
         }

--- a/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/Binding.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/Binding.swift
@@ -13,7 +13,7 @@ import Foundation
 
 
 /// Device Binding protocol to provide utility methods for ``DeviceBindingCallback`` and ``DeviceSigningVerifierCallback``
-protocol Binding {
+public protocol Binding {
     
     /// Create the interface for the authentication type
     /// - Parameter type: The Device Binding Authentication Type
@@ -30,16 +30,16 @@ protocol Binding {
 
 
 extension Binding {
-    func getDeviceAuthenticator(type: DeviceBindingAuthenticationType) -> DeviceAuthenticator {
+    public func getDeviceAuthenticator(type: DeviceBindingAuthenticationType) -> DeviceAuthenticator {
         return type.getAuthType()
     }
     
     
-    func getExpiration(timeout: Int?) -> Date {
+    public func getExpiration(timeout: Int?) -> Date {
         return Date().addingTimeInterval(Double(timeout ?? 60))
     }
     
-    var deviceAuthenticatorIdentifier: (DeviceBindingAuthenticationType) -> DeviceAuthenticator {
+    public var deviceAuthenticatorIdentifier: (DeviceBindingAuthenticationType) -> DeviceAuthenticator {
         get {
             return getDeviceAuthenticator(type:)
         }

--- a/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/Binding.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/Binding.swift
@@ -27,21 +27,3 @@ public protocol Binding {
     /// Default property(method) to identify ``DeviceAuthenticator``
     var deviceAuthenticatorIdentifier: (DeviceBindingAuthenticationType) -> DeviceAuthenticator { get }
 }
-
-
-extension Binding {
-    public func getDeviceAuthenticator(type: DeviceBindingAuthenticationType) -> DeviceAuthenticator {
-        return type.getAuthType()
-    }
-    
-    
-    public func getExpiration(timeout: Int?) -> Date {
-        return Date().addingTimeInterval(Double(timeout ?? 60))
-    }
-    
-    public var deviceAuthenticatorIdentifier: (DeviceBindingAuthenticationType) -> DeviceAuthenticator {
-        get {
-            return getDeviceAuthenticator(type:)
-        }
-    }
-}

--- a/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/DeviceBindingCallback.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/DeviceBindingCallback.swift
@@ -252,4 +252,18 @@ open class DeviceBindingCallback: MultipleValuesCallback, Binding {
     public func setClientError(_ clientError: String) {
         self.inputValues[self.clientErrorKey] = clientError
     }
+    
+    open func getDeviceAuthenticator(type: DeviceBindingAuthenticationType) -> DeviceAuthenticator {
+        return type.getAuthType()
+    }
+    
+    open func getExpiration(timeout: Int?) -> Date {
+        return Date().addingTimeInterval(Double(timeout ?? 60))
+    }
+    
+    open var deviceAuthenticatorIdentifier: (DeviceBindingAuthenticationType) -> DeviceAuthenticator {
+        get {
+            return getDeviceAuthenticator(type:)
+        }
+    }
 }

--- a/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/DeviceSigningVerifierCallback.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/DeviceSigningVerifierCallback.swift
@@ -238,4 +238,18 @@ open class DeviceSigningVerifierCallback: MultipleValuesCallback, Binding {
     public func setClientError(_ clientError: String) {
         self.inputValues[self.clientErrorKey] = clientError
     }
+    
+    open func getDeviceAuthenticator(type: DeviceBindingAuthenticationType) -> DeviceAuthenticator {
+        return type.getAuthType()
+    }
+    
+    open func getExpiration(timeout: Int?) -> Date {
+        return Date().addingTimeInterval(Double(timeout ?? 60))
+    }
+    
+    open var deviceAuthenticatorIdentifier: (DeviceBindingAuthenticationType) -> DeviceAuthenticator {
+        get {
+            return getDeviceAuthenticator(type:)
+        }
+    }
 }

--- a/FRDeviceBinding/FRDeviceBinding/Sources/DeviceBindingAuthenticators.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/DeviceBindingAuthenticators.swift
@@ -248,7 +248,7 @@ open class BiometricOnly: BiometricAuthenticator, DeviceAuthenticator {
     
     
     /// Initializes BiometricOnly with the right LAPolicy
-    override init() {
+    public override init() {
         policy = .deviceOwnerAuthenticationWithBiometrics
     }
     
@@ -306,7 +306,7 @@ open class BiometricAndDeviceCredential: BiometricAuthenticator, DeviceAuthentic
     
     
     /// Initializes BiometricOnly with the rightLAPolicy
-    override init() {
+    public override init() {
         policy = .deviceOwnerAuthentication
     }
     
@@ -362,6 +362,8 @@ open class None: DeviceAuthenticator, CryptoAware {
     
     /// cryptoKey for key pair generation
     var cryptoKey: CryptoKey?
+    
+    public init() { }
     
     /// Generate public and private key pair
     open func generateKeys() throws -> KeyPair {

--- a/FRDeviceBinding/FRDeviceBindingTests/DeviceBindingCallbackTests.swift
+++ b/FRDeviceBinding/FRDeviceBindingTests/DeviceBindingCallbackTests.swift
@@ -775,161 +775,165 @@ class DeviceBindingCallbackTests: FRAuthBaseTest {
 }
 
 
-struct CustomAuthenticatorUnsupported: DeviceAuthenticator {
+class CustomAuthenticatorUnsupported: DefaultDeviceAuthenticator {
     var cryptoKey: CryptoKey
     
     init(cryptoKey: CryptoKey) {
         self.cryptoKey = cryptoKey
     }
     
-    func generateKeys() throws -> KeyPair {
+    override func generateKeys() throws -> KeyPair {
         let keyBuilderQuery = cryptoKey.keyBuilderQuery()
         return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
     }
-    func isSupported() -> Bool {
+    override func isSupported() -> Bool {
         return false
     }
     
-    func accessControl() -> SecAccessControl? {
+    override func accessControl() -> SecAccessControl? {
         return nil
     }
     
-    func type() -> DeviceBindingAuthenticationType {
+    override func type() -> DeviceBindingAuthenticationType {
         return .none
     }
     
-    func deleteKeys() {
+    override func deleteKeys() {
         cryptoKey.deleteKeys()
     }
 }
 
 
-struct CustomAuthenticatorGenerateKeysFailed: DeviceAuthenticator {
+class CustomAuthenticatorGenerateKeysFailed: DefaultDeviceAuthenticator {
     var cryptoKey: CryptoKey
     
     init(cryptoKey: CryptoKey) {
         self.cryptoKey = cryptoKey
     }
     
-    func generateKeys() throws -> KeyPair {
-        throw NSError(domain: "domain", code: 1)
-    }
-    func isSupported() -> Bool {
-        return true
-    }
-    
-    func accessControl() -> SecAccessControl? {
-        return nil
-    }
-    
-    func type() -> DeviceBindingAuthenticationType {
-        return .none
-    }
-    
-    func deleteKeys() {
-        cryptoKey.deleteKeys()
-    }
-}
-
-
-struct CustomAuthenticatorSignFailed: DeviceAuthenticator {
-    var cryptoKey: CryptoKey
-    
-    init(cryptoKey: CryptoKey) {
-        self.cryptoKey = cryptoKey
-    }
-    
-    func generateKeys() throws -> KeyPair {
-        let keyBuilderQuery = cryptoKey.keyBuilderQuery()
-        return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
-    }
-    func isSupported() -> Bool {
-        return true
-    }
-    
-    func accessControl() -> SecAccessControl? {
-        return nil
-    }
-    
-    func sign(keyPair: KeyPair, kid: String, userId: String, challenge: String, expiration: Date) throws -> String {
+    override func generateKeys() throws -> KeyPair {
         throw NSError(domain: "domain", code: 1)
     }
     
-    func type() -> DeviceBindingAuthenticationType {
+    override func isSupported() -> Bool {
+        return true
+    }
+    
+    override func accessControl() -> SecAccessControl? {
+        return nil
+    }
+    
+    override func type() -> DeviceBindingAuthenticationType {
         return .none
     }
     
-    func deleteKeys() {
+    override func deleteKeys() {
         cryptoKey.deleteKeys()
     }
 }
 
 
-struct CustomAuthenticatorAborted: DeviceAuthenticator {
+class CustomAuthenticatorSignFailed: DefaultDeviceAuthenticator {
     var cryptoKey: CryptoKey
     
     init(cryptoKey: CryptoKey) {
         self.cryptoKey = cryptoKey
     }
     
-    func generateKeys() throws -> KeyPair {
+    override func generateKeys() throws -> KeyPair {
         let keyBuilderQuery = cryptoKey.keyBuilderQuery()
         return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
     }
-    func isSupported() -> Bool {
+    
+    override func isSupported() -> Bool {
         return true
     }
     
-    func accessControl() -> SecAccessControl? {
+    override func accessControl() -> SecAccessControl? {
         return nil
     }
     
-    func sign(keyPair: KeyPair, kid: String, userId: String, challenge: String, expiration: Date) throws -> String {
+    override func sign(keyPair: KeyPair, kid: String, userId: String, challenge: String, expiration: Date) throws -> String {
+        throw NSError(domain: "domain", code: 1)
+    }
+    
+    override func type() -> DeviceBindingAuthenticationType {
+        return .none
+    }
+    
+    override func deleteKeys() {
+        cryptoKey.deleteKeys()
+    }
+}
+
+
+class CustomAuthenticatorAborted: DefaultDeviceAuthenticator {
+    var cryptoKey: CryptoKey
+    
+    init(cryptoKey: CryptoKey) {
+        self.cryptoKey = cryptoKey
+    }
+    
+    override func generateKeys() throws -> KeyPair {
+        let keyBuilderQuery = cryptoKey.keyBuilderQuery()
+        return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
+    }
+    
+    override func isSupported() -> Bool {
+        return true
+    }
+    
+    override func accessControl() -> SecAccessControl? {
+        return nil
+    }
+    
+    override func sign(keyPair: KeyPair, kid: String, userId: String, challenge: String, expiration: Date) throws -> String {
         throw JOSESwiftError.localAuthenticationFailed(errorCode: 1)
     }
     
-    func type() -> DeviceBindingAuthenticationType {
+    override func type() -> DeviceBindingAuthenticationType {
         return .none
     }
     
-    func deleteKeys() {
+    override func deleteKeys() {
         cryptoKey.deleteKeys()
     }
 }
 
 
-struct CustomDeviceAuthenticator: DeviceAuthenticator {
+class CustomDeviceAuthenticator: DefaultDeviceAuthenticator {
     var cryptoKey: CryptoKey
     
     init(cryptoKey: CryptoKey) {
         self.cryptoKey = cryptoKey
     }
     
-    func generateKeys() throws -> KeyPair {
+    override func generateKeys() throws -> KeyPair {
         let keyBuilderQuery = cryptoKey.keyBuilderQuery()
         return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
     }
-    func isSupported() -> Bool {
+    
+    override func isSupported() -> Bool {
         return true
     }
     
-    func accessControl() -> SecAccessControl? {
+    override func accessControl() -> SecAccessControl? {
         return nil
     }
     
-    func sign(keyPair: KeyPair, kid: String, userId: String, challenge: String, expiration: Date) throws -> String {
+    override func sign(keyPair: KeyPair, kid: String, userId: String, challenge: String, expiration: Date) throws -> String {
         return "CUSTOM_JWS"
     }
     
-    func sign(userKey: UserKey, challenge: String, expiration: Date, customClaims: [String: Any]) throws -> String {
+    override func sign(userKey: UserKey, challenge: String, expiration: Date, customClaims: [String: Any]) throws -> String {
         return "CUSTOM_JWS"
     }
     
-    func type() -> DeviceBindingAuthenticationType {
+    override func type() -> DeviceBindingAuthenticationType {
         return .none
     }
     
-    func deleteKeys() {
+    override func deleteKeys() {
         cryptoKey.deleteKeys()
     }
 }

--- a/FRDeviceBinding/FRDeviceBindingTests/DeviceSigningVerifierCallbackTests.swift
+++ b/FRDeviceBinding/FRDeviceBindingTests/DeviceSigningVerifierCallbackTests.swift
@@ -848,83 +848,85 @@ class DeviceSigningVerifierCallbackTests: FRAuthBaseTest {
     }
 }
 
-struct CustomDeviceAuthenticatorCustomClaimsAlwaysValid: DeviceAuthenticator {
+class CustomDeviceAuthenticatorCustomClaimsAlwaysValid: DefaultDeviceAuthenticator {
     var cryptoKey: CryptoKey
     
     init(cryptoKey: CryptoKey) {
         self.cryptoKey = cryptoKey
     }
     
-    func generateKeys() throws -> KeyPair {
+    override func generateKeys() throws -> KeyPair {
         let keyBuilderQuery = cryptoKey.keyBuilderQuery()
         return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
     }
-    func isSupported() -> Bool {
+    
+    override func isSupported() -> Bool {
         return true
     }
     
-    func accessControl() -> SecAccessControl? {
+    override func accessControl() -> SecAccessControl? {
         return nil
     }
     
-    func sign(keyPair: KeyPair, kid: String, userId: String, challenge: String, expiration: Date) throws -> String {
+    override func sign(keyPair: KeyPair, kid: String, userId: String, challenge: String, expiration: Date) throws -> String {
         return "CUSTOM_JWS"
     }
     
-    func sign(userKey: UserKey, challenge: String, expiration: Date, customClaims: [String: Any]) throws -> String {
+    override func sign(userKey: UserKey, challenge: String, expiration: Date, customClaims: [String: Any]) throws -> String {
         return "CUSTOM_JWS"
     }
     
-    func type() -> DeviceBindingAuthenticationType {
+    override func type() -> DeviceBindingAuthenticationType {
         return .none
     }
     
-    func deleteKeys() {
+    override func deleteKeys() {
         cryptoKey.deleteKeys()
     }
     
-    func validateCustomClaims(_ customClaims: [String : Any]) -> Bool {
+    override func validateCustomClaims(_ customClaims: [String : Any]) -> Bool {
         return true
     }
 }
 
 
-struct CustomDeviceAuthenticatorCustomClaimsAlwaysInvalid: DeviceAuthenticator {
+class CustomDeviceAuthenticatorCustomClaimsAlwaysInvalid: DefaultDeviceAuthenticator {
     var cryptoKey: CryptoKey
     
     init(cryptoKey: CryptoKey) {
         self.cryptoKey = cryptoKey
     }
     
-    func generateKeys() throws -> KeyPair {
+    override func generateKeys() throws -> KeyPair {
         let keyBuilderQuery = cryptoKey.keyBuilderQuery()
         return try cryptoKey.createKeyPair(builderQuery: keyBuilderQuery)
     }
-    func isSupported() -> Bool {
+    
+    override func isSupported() -> Bool {
         return true
     }
     
-    func accessControl() -> SecAccessControl? {
+    override func accessControl() -> SecAccessControl? {
         return nil
     }
     
-    func sign(keyPair: KeyPair, kid: String, userId: String, challenge: String, expiration: Date, customClaims: [String: Any]) throws -> String {
+    override func sign(keyPair: KeyPair, kid: String, userId: String, challenge: String, expiration: Date) throws -> String {
         return "CUSTOM_JWS"
     }
     
-    func sign(userKey: UserKey, challenge: String, expiration: Date, customClaims: [String: Any]) throws -> String {
+    override func sign(userKey: UserKey, challenge: String, expiration: Date, customClaims: [String: Any]) throws -> String {
         return "CUSTOM_JWS"
     }
     
-    func type() -> DeviceBindingAuthenticationType {
+    override func type() -> DeviceBindingAuthenticationType {
         return .none
     }
     
-    func deleteKeys() {
+    override func deleteKeys() {
         cryptoKey.deleteKeys()
     }
     
-    func validateCustomClaims(_ customClaims: [String : Any]) -> Bool {
+    override func validateCustomClaims(_ customClaims: [String : Any]) -> Bool {
         return false
     }
 }

--- a/SampleApps/FRExample/FRExample.xcodeproj/project.pbxproj
+++ b/SampleApps/FRExample/FRExample.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A52B848A2B339571001FBA2C /* Playground.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52B84892B339571001FBA2C /* Playground.swift */; };
+		A52B848B2B339571001FBA2C /* Playground.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52B84892B339571001FBA2C /* Playground.swift */; };
 		A5D8938529E5AA78004D21F4 /* FRDeviceBinding.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A5D1C39329E59FC30096039E /* FRDeviceBinding.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A5D8938C29E5AAA3004D21F4 /* FRDeviceBinding.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A5D1C39329E59FC30096039E /* FRDeviceBinding.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A5D8938D29E5AAD1004D21F4 /* FRDeviceBinding.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5D1C39329E59FC30096039E /* FRDeviceBinding.framework */; };
@@ -233,6 +235,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A52B84892B339571001FBA2C /* Playground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Playground.swift; sourceTree = "<group>"; };
 		A5D1C38C29E59FC30096039E /* FRDeviceBinding.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FRDeviceBinding.xcodeproj; path = ../../FRDeviceBinding/FRDeviceBinding.xcodeproj; sourceTree = "<group>"; };
 		D521A21A2303644300EDD28E /* FRExampleSSO.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FRExampleSSO.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D530423A26321BE90079EB3B /* FRCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FRCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -343,6 +346,7 @@
 				D5E080C623DA58310025EA17 /* Customization */,
 				D5FE5E5B23190A0000E04658 /* Configs */,
 				D5FE5E5E23190A0000E04658 /* Supporting Files */,
+				A52B84892B339571001FBA2C /* Playground.swift */,
 				D554632F22A6EF950096C7A4 /* AppDelegate.swift */,
 				D554633122A6EF950096C7A4 /* ViewController.swift */,
 				D554633322A6EF950096C7A4 /* Main.storyboard */,
@@ -686,6 +690,7 @@
 			files = (
 				D521A2062303644300EDD28E /* ViewController.swift in Sources */,
 				D521A2082303644300EDD28E /* AppDelegate.swift in Sources */,
+				A52B848B2B339571001FBA2C /* Playground.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -698,6 +703,7 @@
 				D53326FE2480613D002FF207 /* ForceAuthInterceptor.swift in Sources */,
 				D5CFCF7622FB8DCA0027B7A0 /* ViewController.swift in Sources */,
 				D554633022A6EF950096C7A4 /* AppDelegate.swift in Sources */,
+				A52B848A2B339571001FBA2C /* Playground.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/SampleApps/FRExample/FRExample/Playground.swift
+++ b/SampleApps/FRExample/FRExample/Playground.swift
@@ -132,11 +132,11 @@ class CustomUserKeySelector: UserKeySelector {
 
 
 class CustomNone: None {
-    func issueTime() -> Date {
+    override func issueTime() -> Date {
         return Date()
     }
     
-    func notBeforeTime() -> Date {
+    override func notBeforeTime() -> Date {
         return Date()
     }
 }
@@ -147,31 +147,23 @@ class CustomBiometricAndDeviceCredential: BiometricAndDeviceCredential {
         super.init()
     }
     
-    func issueTime() -> Date {
+    override func issueTime() -> Date {
         return Date()
     }
     
-    func notBeforeTime() -> Date {
+    override func notBeforeTime() -> Date {
         return Date()
     }
 }
 
 
 class CustomBiometricOnly: BiometricOnly {
-    override init() {
-        super.init()
+    override func issueTime() -> Date {
+        return Calendar.current.date(byAdding: .day, value: 1, to: Date())!
     }
     
-    override func isSupported() -> Bool {
-        return true
-    }
-    
-    func issueTime() -> Date {
-        return Date()
-    }
-    
-    func notBeforeTime() -> Date {
-        return Date()
+    override func notBeforeTime() -> Date {
+        return Calendar.current.date(byAdding: .day, value: 2, to: Date())!
     }
 }
 
@@ -185,11 +177,11 @@ class CustomApplicationPinDeviceAuthenticator: ApplicationPinDeviceAuthenticator
         return true
     }
     
-    func issueTime() -> Date {
+    override func issueTime() -> Date {
         return Date()
     }
     
-    func notBeforeTime() -> Date {
+    override func notBeforeTime() -> Date {
         return Date()
     }
 }

--- a/SampleApps/FRExample/FRExample/Playground.swift
+++ b/SampleApps/FRExample/FRExample/Playground.swift
@@ -1,5 +1,5 @@
-// 
-//  AccessLevelValidation.swift
+//
+//  Playground.swift
 //  FRExample
 //
 //  Copyright (c) 2023 ForgeRock. All rights reserved.
@@ -29,16 +29,16 @@ class AccessLevelValidation {
         // custom application pin UI
         deviceBindingCallback.bind(deviceAuthenticator: { type in
             switch type {
-                case .applicationPin:
-                    return ApplicationPinDeviceAuthenticator(pinCollector: CustomPinCollector())
-                default:
-                    return deviceBindingCallback.getDeviceAuthenticator(type: type)
+            case .applicationPin:
+                return ApplicationPinDeviceAuthenticator(pinCollector: CustomPinCollector())
+            default:
+                return deviceBindingCallback.getDeviceAuthenticator(type: type)
             }
         }, completion: { result in
             switch result {
-                case .success:
-                    print("Success")
-                case .failure(let error):
+            case .success:
+                print("Success")
+            case .failure(let error):
                 print(error.localizedDescription)
             }
         })
@@ -46,17 +46,16 @@ class AccessLevelValidation {
         //error handling
         deviceBindingCallback.bind() { result in
             switch result {
-                case .success:
+            case .success:
                 print("Success")
-                case .failure(let error):
-                    // Custom Error
+            case .failure(let error):
+                // Custom Error
                 if error == DeviceBindingStatus.unAuthorize {
-                        deviceBindingCallback.setClientError("CustomUnAuthorize")
-                    }
+                    deviceBindingCallback.setClientError("CustomUnAuthorize")
+                }
             }
         }
     }
-    
     
     func validateDeviceSigningVerifierCallback() {
         let deviceSigningVerifierCallback = try! DeviceSigningVerifierCallback(json: [:])
@@ -65,35 +64,34 @@ class AccessLevelValidation {
         //custom key selection UI
         deviceSigningVerifierCallback.sign(userKeySelector: CustomUserKeySelector()) { result in
             switch result {
-                case .success:
-                    print("Success")
-                case .failure(let error):
+            case .success:
+                print("Success")
+            case .failure(let error):
                 print(error.errorMessage)
             }
         }
         
         //custom claims
         deviceSigningVerifierCallback.sign(
-          customClaims: [
-            "platform": "iOS",
-            "isCompanyPhone": true,
-            "lastUpdated": Int(Date().timeIntervalSince1970)
-          ]
+            customClaims: [
+                "platform": "iOS",
+                "isCompanyPhone": true,
+                "lastUpdated": Int(Date().timeIntervalSince1970)
+            ]
         ) { result in
-              switch result
-              {
-                  case .success:
-                  print("Success")
-                  case .failure(let error):
-                      // Handle the error and proceed to the next node
-                      if error == .invalidCustomClaims {
-                          // Fix the invalid custom claims
-                          print(error.errorMessage)
-                          return
-                      }
-              }
-          }
-        
+            switch result
+            {
+            case .success:
+                print("Success")
+            case .failure(let error):
+                // Handle the error and proceed to the next node
+                if error == .invalidCustomClaims {
+                    // Fix the invalid custom claims
+                    print(error.errorMessage)
+                    return
+                }
+            }
+        }
     }
     
     func validateCustomDeviceAuthenticators() {
@@ -115,8 +113,9 @@ class AccessLevelValidation {
         
         let _ = ApplicationPinDeviceAuthenticator(pinCollector: CustomPinCollector())
     }
-    
 }
+
+
 class CustomPinCollector: PinCollector {
     func collectPin(prompt: Prompt, completion: @escaping (String?) -> Void) {
         // Implement your custom app PIN UI...
@@ -124,11 +123,13 @@ class CustomPinCollector: PinCollector {
     }
 }
 
+
 class CustomUserKeySelector: UserKeySelector {
     func selectUserKey(userKeys: [UserKey], selectionCallback: @escaping UserKeySelectorCallback) {
         selectionCallback(userKeys.first)
     }
 }
+
 
 class CustomNone: None {
     func issueTime() -> Date {
@@ -139,6 +140,7 @@ class CustomNone: None {
         return Date()
     }
 }
+
 
 class CustomBiometricAndDeviceCredential: BiometricAndDeviceCredential {
     override init() {
@@ -153,6 +155,7 @@ class CustomBiometricAndDeviceCredential: BiometricAndDeviceCredential {
         return Date()
     }
 }
+
 
 class CustomBiometricOnly: BiometricOnly {
     override init() {
@@ -172,6 +175,7 @@ class CustomBiometricOnly: BiometricOnly {
     }
 }
 
+
 class CustomApplicationPinDeviceAuthenticator: ApplicationPinDeviceAuthenticator {
     override init(pinCollector: PinCollector = DefaultPinCollector()) {
         super.init(pinCollector: pinCollector)
@@ -189,4 +193,3 @@ class CustomApplicationPinDeviceAuthenticator: ApplicationPinDeviceAuthenticator
         return Date()
     }
 }
-

--- a/SampleApps/FRExample/FRExample/Playground.swift
+++ b/SampleApps/FRExample/FRExample/Playground.swift
@@ -1,0 +1,192 @@
+// 
+//  AccessLevelValidation.swift
+//  FRExample
+//
+//  Copyright (c) 2023 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+
+import Foundation
+import FRDeviceBinding
+
+// MARK: - Validate code compilation
+
+// In this section we will define some classes and methods that will test the access level of SDK classes and methods
+// As we are using @testable import in our test classes, we are not able to properly test the open/public access level in our tests
+// Instead, by defining some code here, we make sure we have the intended access level and nothing less
+// We don't need to call this code anywhere, we want to make sure everything compiles properly
+
+class AccessLevelValidation {
+    func validateDeviceBindingCallback() {
+        let deviceBindingCallback = try! DeviceBindingCallback(json: [:])
+        
+        let _ = deviceBindingCallback.getExpiration(timeout: 60)
+        let _ = deviceBindingCallback.getDeviceAuthenticator(type: .none)
+        
+        // custom application pin UI
+        deviceBindingCallback.bind(deviceAuthenticator: { type in
+            switch type {
+                case .applicationPin:
+                    return ApplicationPinDeviceAuthenticator(pinCollector: CustomPinCollector())
+                default:
+                    return deviceBindingCallback.getDeviceAuthenticator(type: type)
+            }
+        }, completion: { result in
+            switch result {
+                case .success:
+                    print("Success")
+                case .failure(let error):
+                print(error.localizedDescription)
+            }
+        })
+        
+        //error handling
+        deviceBindingCallback.bind() { result in
+            switch result {
+                case .success:
+                print("Success")
+                case .failure(let error):
+                    // Custom Error
+                if error == DeviceBindingStatus.unAuthorize {
+                        deviceBindingCallback.setClientError("CustomUnAuthorize")
+                    }
+            }
+        }
+    }
+    
+    
+    func validateDeviceSigningVerifierCallback() {
+        let deviceSigningVerifierCallback = try! DeviceSigningVerifierCallback(json: [:])
+        
+        
+        //custom key selection UI
+        deviceSigningVerifierCallback.sign(userKeySelector: CustomUserKeySelector()) { result in
+            switch result {
+                case .success:
+                    print("Success")
+                case .failure(let error):
+                print(error.errorMessage)
+            }
+        }
+        
+        //custom claims
+        deviceSigningVerifierCallback.sign(
+          customClaims: [
+            "platform": "iOS",
+            "isCompanyPhone": true,
+            "lastUpdated": Int(Date().timeIntervalSince1970)
+          ]
+        ) { result in
+              switch result
+              {
+                  case .success:
+                  print("Success")
+                  case .failure(let error):
+                      // Handle the error and proceed to the next node
+                      if error == .invalidCustomClaims {
+                          // Fix the invalid custom claims
+                          print(error.errorMessage)
+                          return
+                      }
+              }
+          }
+        
+    }
+    
+    func validateCustomDeviceAuthenticators() {
+        let customNone = CustomNone()
+        let _ = customNone.notBeforeTime()
+        let _ = customNone.issueTime()
+        
+        let customBiometricOnly = CustomBiometricOnly()
+        let _ = try? customBiometricOnly.generateKeys()
+        let _ = customBiometricOnly.isSupported()
+        
+        let customBiometricAndDeviceCredential = CustomBiometricAndDeviceCredential()
+        let _ = customBiometricAndDeviceCredential.accessControl()
+        
+        
+        let customApplicationPinDeviceAuthenticator = CustomApplicationPinDeviceAuthenticator()
+        let _ = customApplicationPinDeviceAuthenticator.pinCollector
+        let _ = customApplicationPinDeviceAuthenticator.validateCustomClaims([:])
+        
+        let _ = ApplicationPinDeviceAuthenticator(pinCollector: CustomPinCollector())
+    }
+    
+}
+class CustomPinCollector: PinCollector {
+    func collectPin(prompt: Prompt, completion: @escaping (String?) -> Void) {
+        // Implement your custom app PIN UI...
+        completion("1234")
+    }
+}
+
+class CustomUserKeySelector: UserKeySelector {
+    func selectUserKey(userKeys: [UserKey], selectionCallback: @escaping UserKeySelectorCallback) {
+        selectionCallback(userKeys.first)
+    }
+}
+
+class CustomNone: None {
+    func issueTime() -> Date {
+        return Date()
+    }
+    
+    func notBeforeTime() -> Date {
+        return Date()
+    }
+}
+
+class CustomBiometricAndDeviceCredential: BiometricAndDeviceCredential {
+    override init() {
+        super.init()
+    }
+    
+    func issueTime() -> Date {
+        return Date()
+    }
+    
+    func notBeforeTime() -> Date {
+        return Date()
+    }
+}
+
+class CustomBiometricOnly: BiometricOnly {
+    override init() {
+        super.init()
+    }
+    
+    override func isSupported() -> Bool {
+        return true
+    }
+    
+    func issueTime() -> Date {
+        return Date()
+    }
+    
+    func notBeforeTime() -> Date {
+        return Date()
+    }
+}
+
+class CustomApplicationPinDeviceAuthenticator: ApplicationPinDeviceAuthenticator {
+    override init(pinCollector: PinCollector = DefaultPinCollector()) {
+        super.init(pinCollector: pinCollector)
+    }
+    
+    override func isSupported() -> Bool {
+        return true
+    }
+    
+    func issueTime() -> Date {
+        return Date()
+    }
+    
+    func notBeforeTime() -> Date {
+        return Date()
+    }
+}
+

--- a/SampleApps/FRExample/FRExample/ViewController.swift
+++ b/SampleApps/FRExample/FRExample/ViewController.swift
@@ -322,7 +322,7 @@ class ViewController: UIViewController, ErrorAlertShowing {
                                     signingResult = "Success"
                                 case .failure(let error):
                                     if error == .invalidCustomClaims {
-                                        self.showErrorAlert(title: "Device Binding Error", message: error.errorMessage)
+                                        self.showErrorAlert(title: "Device Signing Error", message: error.errorMessage)
                                         return
                                     }
                                     signingResult = error.errorMessage
@@ -883,7 +883,7 @@ class ViewController: UIViewController, ErrorAlertShowing {
             // Login for FRUser without UI
             self.performActionHelper(auth: frAuth, flowType: .authentication, expectedType: FRUser.self)
             break
-        case 15:
+        case 16:
             // Login for AccessToken without UI
             self.performActionHelper(auth: frAuth, flowType: .authentication, expectedType: AccessToken.self)
             break


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2886](https://bugster.forgerock.org/jira/browse/SDKS-2886)

Fix Device Binding API access level

Fix device binding inheritance issues  

# Description

1. Make Binding protocol and methods public
2. Make all **DeviceAuthenticator** subclasses init methods public
3. Add Playground.swift in the example app for validating API Access level during compilation
4. Fix typos in ViewController file.
5.  Update CHANGELOG
6. Refactor Device Binding to fix the inheritance issue caused by Swift protocol's default implementation limitations

------------
Apart from the bug that we had, where our Authenticators had internal init methods, we also found another issue while testing this fix. 
Turns out Swift protocol's default implementation has an UNEXPECTED limitation during inheritance. 

## Here is a the Issue Description:

Protocol **A** defines function **x**.
**A** has implementation of **x** in the _protocol extension_.
Class **B** conforms **A**, but _doesn't provide_ implementation for **x**.
Subclass **C** inherits from **B**, and _provides implementation_ for **x**.
Instance of **C** typed as **A** calls **x**. 

Instead of the calling the **x** defined in **C**, Swift calls **x** defined in the _protocol extension_.
```
// Defined protocol.
protocol A {
    func x() -> Int
}
extension A {
    func x() -> Int {
        return 0
    }
}

// B conforms A but doesn't provide implementation for x
class B: A {}

class C: B {
    func x() -> Int {
        return 1
    }
}

// Failure cases.
B().a() // 0
C().a() // 1
(C() as A).a() // 0 # We would expect this to be 1. 

// D conforms A and provides implementation for x
class D: A {
    func x() -> Int {
        return 1
    }
}

class E: D {
    override func x() -> Int {
        return 2
    }
}

// Success cases.
D().x() // 1
(D() as A).x() // 1
E().x() // 2
(E() as A).x() // 2
```
Here is a [blog post](https://alejandromp.com/blog/protocol-extensions-and-subclasses/) explaining it and here is the [bug](https://github.com/apple/swift/issues/42725) that is still Open on swift's  github.



The way we fixed the issue was getting rid of protocol methods default implementations in protocol extensions. 
In case of **DeviceAuthenticator** we created a **DefaultDeviceAuthenticator** _class_ that provides the default implementation for protocol methods.
In case of **Binding** we removed the default method implementations in the extension and moved them into **DeviceBindingCallback** and **DeviceSigningVerifierCallback** classes.