### PR TITLE
Fixed ApplicationPinDeviceAuthenticator lack of public init

### DIFF
--- a/FRDeviceBinding/FRDeviceBinding/Sources/ApplicationPinDeviceAuthenticator.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/ApplicationPinDeviceAuthenticator.swift
@@ -26,7 +26,7 @@ open class ApplicationPinDeviceAuthenticator: DeviceAuthenticator, CryptoAware {
     /// PinCollector for collecting the Pin
     public var pinCollector: PinCollector
     
-    init(pinCollector: PinCollector = DefaultPinCollector()) {
+    public init(pinCollector: PinCollector = DefaultPinCollector()) {
         self.pinCollector = pinCollector
     }
     


### PR DESCRIPTION
# JIRA Ticket

I don't have JIRA ticket

# Description

ApplicationPinDeviceAuthenticator doesn't have public init which makes it unavailable to use according to documentation example from here: https://backstage.forgerock.com/docs/sdks/latest/sdks/use-cases/how-to-bind-devices.html

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] Example code snippets have been added.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).