### PR TITLE
SDKS-2898 e2e test cases for the PingOne Protect module

### DIFF
--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -21,6 +21,8 @@
 		3A6D26672A1345400099D877 /* PolicyAdviceCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A6D26662A1345400099D877 /* PolicyAdviceCreator.swift */; };
 		959D7D98290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 959D7D97290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift */; };
 		95E180B42992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E180B32992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift */; };
+		95EB7E4D2B8D010B00B59CD6 /* AA_09_PingOneProtectInitializeCallbackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95EB7E4C2B8D010B00B59CD6 /* AA_09_PingOneProtectInitializeCallbackTest.swift */; };
+		95EB7E532B8D5F6100B59CD6 /* AA_10_PingOneProtectEvaluateCallbackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95EB7E522B8D5F6100B59CD6 /* AA_10_PingOneProtectEvaluateCallbackTest.swift */; };
 		A53723D12AE80A5D0047B809 /* TelephonyCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53723D02AE80A5D0047B809 /* TelephonyCollectorTests.swift */; };
 		3AB062FA2AE6224D00C4B47C /* FRAppIntegrityKeysTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB062F92AE6224D00C4B47C /* FRAppIntegrityKeysTests.swift */; };
 		A5950A2A27EA205B00EDEFE4 /* SSLPinningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5950A2927EA205B00EDEFE4 /* SSLPinningTests.swift */; };
@@ -347,6 +349,8 @@
 		3A6D26662A1345400099D877 /* PolicyAdviceCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolicyAdviceCreator.swift; sourceTree = "<group>"; };
 		959D7D97290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AA-05-DeviceBindingCallbackTest.swift"; sourceTree = "<group>"; };
 		95E180B32992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AA-06-DeviceSigningVerifierCallbackTest.swift"; sourceTree = "<group>"; };
+		95EB7E4C2B8D010B00B59CD6 /* AA_09_PingOneProtectInitializeCallbackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AA_09_PingOneProtectInitializeCallbackTest.swift; sourceTree = "<group>"; };
+		95EB7E522B8D5F6100B59CD6 /* AA_10_PingOneProtectEvaluateCallbackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AA_10_PingOneProtectEvaluateCallbackTest.swift; sourceTree = "<group>"; };
 		A53723D02AE80A5D0047B809 /* TelephonyCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelephonyCollectorTests.swift; sourceTree = "<group>"; };
 		3AB062F92AE6224D00C4B47C /* FRAppIntegrityKeysTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRAppIntegrityKeysTests.swift; sourceTree = "<group>"; };
 		A5950A2927EA205B00EDEFE4 /* SSLPinningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSLPinningTests.swift; sourceTree = "<group>"; };
@@ -1190,6 +1194,8 @@
 				959D7D97290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift */,
 				95E180B32992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift */,
 				3A4B46E32AB95B3D009E7171 /* AA_07_AppIntegrityTest.swift */,
+				95EB7E4C2B8D010B00B59CD6 /* AA_09_PingOneProtectInitializeCallbackTest.swift */,
+				95EB7E522B8D5F6100B59CD6 /* AA_10_PingOneProtectEvaluateCallbackTest.swift */,
 			);
 			path = "Callback-Live";
 			sourceTree = "<group>";
@@ -1954,6 +1960,8 @@
 				D5791BE125F87DE8004B487A /* FRUserBrowserTests.swift in Sources */,
 				D5791BE225F87DE8004B487A /* NetworkReachabilityMonitorTests.swift in Sources */,
 				D58BC38F2602A47600254654 /* IdPCallbackTests.swift in Sources */,
+				95EB7E4D2B8D010B00B59CD6 /* AA_09_PingOneProtectInitializeCallbackTest.swift in Sources */,
+				95EB7E532B8D5F6100B59CD6 /* AA_10_PingOneProtectEvaluateCallbackTest.swift in Sources */,
 				3A3E78682AB0D642007962B7 /* FRAppAttestDomainModalTests.swift in Sources */,
 				D5791BE325F87DE8004B487A /* FRBaseTest.swift in Sources */,
 			);

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA_09_PingOneProtectInitializeCallbackTest.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA_09_PingOneProtectInitializeCallbackTest.swift
@@ -1,0 +1,297 @@
+//
+//  AA_09_PingOneProtectInitializeCallbackTest.swift
+//  FRAuthTests
+//
+//  Copyright (c) 2024 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import FRAuth
+@testable import PingProtect
+
+class AA_09_PingOneProtectInitializeCallbackTest: CallbackBaseTest {
+    
+    static var USERNAME: String = "sdkuser"
+    let options = FROptions(url: "https://openam-protect2.forgeblocks.com/am",
+                            realm: "alpha",
+                            enableCookie: true,
+                            cookieName: "c1c805de4c9b333",
+                            timeout: "180",
+                            authServiceName: "TEST_PING_ONE_PROTECT_INITIALIZE",
+                            oauthThreshold: "60",
+                            oauthClientId: "iosclient",
+                            oauthRedirectUri: "http://localhost:8081",
+                            oauthScope: "openid profile email address",
+                            keychainAccessGroup: "com.bitbar.*"
+                            )
+
+    override func setUp() {
+        do {
+            try FRAuth.start(options: options)
+        }
+        catch {
+            XCTFail("Fail to start the the SDK with custom config.")
+        }
+    }
+    
+    override func tearDown() {
+        FRSession.currentSession?.logout()
+        super.tearDown()
+    }
+    
+    func test_01_protect_initialize_defaults() {
+        var currentNode: Node
+        
+        do {
+            try currentNode = startTest(nodeConfiguration: "init-default")
+        } catch AuthError.invalidCallbackResponse {
+            XCTFail("Expected a PingOne Protect Initialize node, but got nothing!")
+            return
+        } catch {
+            XCTFail("Unexpected error occured!")
+            return
+        }
+        
+        // We expect PingOneProtectInitializeCallback callback with default values here...
+        for callback in currentNode.callbacks {
+            if callback is PingOneProtectInitializeCallback, let pingOneProtectInitializeCallback = callback as? PingOneProtectInitializeCallback {
+                
+                XCTAssertNotEqual(pingOneProtectInitializeCallback.envId, "")
+                XCTAssertFalse(pingOneProtectInitializeCallback.consoleLogEnabled)
+                XCTAssertTrue(pingOneProtectInitializeCallback.deviceAttributesToIgnore.count == 0)
+                XCTAssertEqual(pingOneProtectInitializeCallback.customHost, "")
+                XCTAssertFalse(pingOneProtectInitializeCallback.lazyMetadata)
+                XCTAssertTrue(pingOneProtectInitializeCallback.behavioralDataCollection)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        var ex = self.expectation(description: "Submit PingOneProtectInitialize callback and continue...")
+            currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node!
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Provide input value for the username collector callback
+        for callback in currentNode.callbacks {
+            if callback is NameCallback, let nameCallback = callback as? NameCallback {
+                nameCallback.setValue(AA_09_PingOneProtectInitializeCallbackTest.USERNAME)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+
+        ex = self.expectation(description: "Submit username collector node")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_02_protect_initialize_custom() {
+        var currentNode: Node
+        
+        do {
+            try currentNode = startTest(nodeConfiguration: "init-custom")
+        } catch AuthError.invalidCallbackResponse {
+            XCTFail("Expected a PingOne Protect Initialize node, but got nothing!")
+            return
+        } catch {
+            XCTFail("Unexpected error occured!")
+            return
+        }
+        
+        // We expect PingOneProtectInitializeCallback callback with custom values here...
+        for callback in currentNode.callbacks {
+            if callback is PingOneProtectInitializeCallback, let pingOneProtectInitializeCallback = callback as? PingOneProtectInitializeCallback {
+                
+                XCTAssertNotEqual(pingOneProtectInitializeCallback.envId, "")
+                XCTAssertTrue(pingOneProtectInitializeCallback.consoleLogEnabled)
+                XCTAssertTrue(pingOneProtectInitializeCallback.deviceAttributesToIgnore.count == 3)
+                XCTAssertTrue(pingOneProtectInitializeCallback.deviceAttributesToIgnore.contains("Model"))
+                XCTAssertTrue(pingOneProtectInitializeCallback.deviceAttributesToIgnore.contains("Manufacturer"))
+                XCTAssertTrue(pingOneProtectInitializeCallback.deviceAttributesToIgnore.contains("Screen size"))
+                XCTAssertEqual(pingOneProtectInitializeCallback.customHost, "custom.host.com")
+                XCTAssertTrue(pingOneProtectInitializeCallback.lazyMetadata)
+                XCTAssertFalse(pingOneProtectInitializeCallback.behavioralDataCollection)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        var ex = self.expectation(description: "Submit PingOneProtectInitialize callback and continue...")
+            currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node!
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Provide input value for the username collector callback
+        for callback in currentNode.callbacks {
+            if callback is NameCallback, let nameCallback = callback as? NameCallback {
+                nameCallback.setValue(AA_09_PingOneProtectInitializeCallbackTest.USERNAME)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+
+        ex = self.expectation(description: "Submit username collector node")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_03_protect_initialize_client_error() {
+        var currentNode: Node
+        
+        do {
+            try currentNode = startTest(nodeConfiguration: "init-error")
+        } catch AuthError.invalidCallbackResponse {
+            XCTFail("Expected a PingOne Protect Initialize node, but got nothing!")
+            return
+        } catch {
+            XCTFail("Unexpected error occured!")
+            return
+        }
+        
+        // We expect PingOneProtectInitializeCallback callback with default values here...
+        for callback in currentNode.callbacks {
+            if callback is PingOneProtectInitializeCallback, let pingOneProtectInitializeCallback = callback as? PingOneProtectInitializeCallback {
+                
+                pingOneProtectInitializeCallback.setClientError("Failed to initialize")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        var ex = self.expectation(description: "Submit PingOneProtectInitialize callback and continue...")
+            currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node!
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Provide input value for the TextOutputCallback callback
+        for callback in currentNode.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Failure")
+            }
+            else if callback is ConfirmationCallback, let confirmationCallback = callback as? ConfirmationCallback {
+                confirmationCallback.value = 0
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value for the ConfirmationCallback and continue...")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node!
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Provide input value for the username collector callback
+        for callback in currentNode.callbacks {
+            if callback is NameCallback, let nameCallback = callback as? NameCallback {
+                nameCallback.setValue(AA_09_PingOneProtectInitializeCallbackTest.USERNAME)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+
+        ex = self.expectation(description: "Submit username collector node")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    /// Common steps for all test cases
+    func startTest(nodeConfiguration: String) throws -> Node  {
+        var currentNode: Node?
+        
+        var ex = self.expectation(description: "Select test configuration")
+        
+        FRSession.authenticate(authIndexValue: options.authServiceName) { (token: Token?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        /// --------------------------------
+        guard let node = currentNode else {
+            XCTFail("Failed to get Node")
+            throw AuthError.invalidCallbackResponse("Expected ChoiceCollector node, but got nothing...")
+        }
+        
+        // Provide input value for the ChoiceCollector callback
+        for callback in node.callbacks {
+            if callback is ChoiceCallback, let choiceCallback = callback as? ChoiceCallback {
+                let choiceIndex = choiceCallback.choices.firstIndex(of: nodeConfiguration)
+                choiceCallback.setValue(choiceIndex)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value to the ChoiceCollector Node")
+        currentNode?.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        guard currentNode != nil else {
+            XCTFail("Failed to get Node from the second request")
+            throw AuthError.invalidCallbackResponse("Expected at least one more node, but got nothing...")
+        }
+        return currentNode!
+    }
+}

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA_10_PingOneProtectEvaluateCallbackTest.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA_10_PingOneProtectEvaluateCallbackTest.swift
@@ -1,0 +1,449 @@
+//
+//  AA_10_PingOneProtectEvaluateCallbackTest.swift
+//  FRAuthTests
+//
+//  Copyright (c) 2024 ForgeRock. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+@testable import FRAuth
+@testable import PingProtect
+
+class AA_10_PingOneProtectEvaluateCallbackTest: CallbackBaseTest {
+    
+    static var USERNAME: String = "sdkuser"
+    let options = FROptions(url: "https://openam-protect2.forgeblocks.com/am",
+                            realm: "alpha",
+                            enableCookie: true,
+                            cookieName: "c1c805de4c9b333",
+                            timeout: "180",
+                            authServiceName: "TEST_PING_ONE_PROTECT_EVALUATE",
+                            oauthThreshold: "60",
+                            oauthClientId: "iosclient",
+                            oauthRedirectUri: "http://localhost:8081",
+                            oauthScope: "openid profile email address",
+                            keychainAccessGroup: "com.bitbar.*"
+                            )
+
+    override func setUp() {
+        do {
+            try FRAuth.start(options: options)
+        }
+        catch {
+            XCTFail("Fail to start the the SDK with custom config.")
+        }
+    }
+    
+    override func tearDown() {
+        FRSession.currentSession?.logout()
+        super.tearDown()
+    }
+    
+    func test_01_protect_evaluate_no_init() {
+        var currentNode: Node
+        
+        do {
+            try currentNode = startTest(nodeConfiguration: "evaluate-no-init")
+        } catch AuthError.invalidCallbackResponse {
+            XCTFail("Expected username  collector node, but got nothing!")
+            return
+        } catch {
+            XCTFail("Unexpected error occured!")
+            return
+        }
+        
+        // Provide username
+        for callback in currentNode.callbacks {
+            if callback is NameCallback, let nameCallback = callback as? NameCallback {
+                nameCallback.setValue(AA_10_PingOneProtectEvaluateCallbackTest.USERNAME)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+
+        var ex = self.expectation(description: "Submit username")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node!
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Handle PingOneProtectEvaluationCallback
+        for callback in currentNode.callbacks {
+            if callback is PingOneProtectEvaluationCallback, let pingOneProtectEvaluationCallback = callback as? PingOneProtectEvaluationCallback {
+                
+                var evaulationResult = ""
+                
+                // Try to getData without initializing the Signals SDK. This should result in error...
+                let ex = self.expectation(description: "PingOne Protect Evaluate")
+                pingOneProtectEvaluationCallback.getData(completion: { (result) in
+                        switch result {
+                        case .success:
+                            evaulationResult = "Success"
+                        case .failure(let error):
+                            evaulationResult = error.localizedDescription
+                        };
+                        ex.fulfill()
+                    })
+                waitForExpectations(timeout: 60, handler: nil)
+                
+                XCTAssertEqual(evaulationResult, "SDK is not initialized")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit the PingOneProtectEvaluation callback ")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node!
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Confirm that AM returns Client Error and provide input value for the TextOutputCallback callback
+        for callback in currentNode.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Client Error")
+            }
+            else if callback is ConfirmationCallback, let confirmationCallback = callback as? ConfirmationCallback {
+                confirmationCallback.value = 0
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value for the ConfirmationCallback and continue...")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_02_protect_evaluate_success() {
+        var currentNode: Node
+        
+        do {
+            try currentNode = startTest(nodeConfiguration: "evaluate-default")
+        } catch AuthError.invalidCallbackResponse {
+            XCTFail("Expected a PingOne Protect Initialize node, but got nothing!")
+            return
+        } catch {
+            XCTFail("Unexpected error occured!")
+            return
+        }
+        
+        // Handle the PingOneProtectInitializeCallback callback
+        for callback in currentNode.callbacks {
+            if callback is PingOneProtectInitializeCallback, let pingOneProtectInitializeCallback = callback as? PingOneProtectInitializeCallback {
+                
+                var initResult = ""
+                let ex = self.expectation(description: "PingOne Protect Init")
+                pingOneProtectInitializeCallback.start(completion: { (result) in
+                        switch result {
+                        case .success:
+                            initResult = "Success"
+                        case .failure(let error):
+                            initResult = error.localizedDescription
+                        };
+                        ex.fulfill()
+                    })
+                waitForExpectations(timeout: 60, handler: nil)
+                
+                XCTAssertEqual(initResult, "Success")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        var ex = self.expectation(description: "Submit PingOneProtectInitialize callback and continue...")
+            currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node!
+            ex.fulfill()
+            
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Provide username
+        for callback in currentNode.callbacks {
+            if callback is NameCallback, let nameCallback = callback as? NameCallback {
+                nameCallback.setValue(AA_10_PingOneProtectEvaluateCallbackTest.USERNAME)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+
+        ex = self.expectation(description: "Submit username collector node")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node!
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Handle PingOneProtectEvaluationCallback
+        for callback in currentNode.callbacks {
+            if callback is PingOneProtectEvaluationCallback, let pingOneProtectEvaluationCallback = callback as? PingOneProtectEvaluationCallback {
+                
+                XCTAssertTrue(pingOneProtectEvaluationCallback.pauseBehavioralData)
+                
+                var evaulationResult = ""
+                let ex = self.expectation(description: "PingOne Protect Evaluate")
+                pingOneProtectEvaluationCallback.getData(completion: { (result) in
+                        switch result {
+                        case .success:
+                            evaulationResult = "Success"
+                        case .failure(let error):
+                            evaulationResult = error.localizedDescription
+                        };
+                        ex.fulfill()
+                    })
+                waitForExpectations(timeout: 60, handler: nil)
+                
+                XCTAssertEqual(evaulationResult, "Success")
+                
+                /// Ensure that Signals data is not empty after collection
+                XCTAssertTrue(pingOneProtectEvaluationCallback.inputValues["IDToken1signals"] as! String != "")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit the PingOneProtectEvaluation callback ")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node!
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Confirm that AM returns "success"
+        for callback in currentNode.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Success")
+            }
+            else if callback is ConfirmationCallback, let confirmationCallback = callback as? ConfirmationCallback {
+                confirmationCallback.value = 0
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value for the ConfirmationCallback and continue...")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    func test_03_protect_evaluate_pause_behavioral_data_off() {
+        var currentNode: Node
+        
+        do {
+            try currentNode = startTest(nodeConfiguration: "evaluate-pause-off")
+        } catch AuthError.invalidCallbackResponse {
+            XCTFail("Expected a PingOne Protect Initialize node, but got nothing!")
+            return
+        } catch {
+            XCTFail("Unexpected error occured!")
+            return
+        }
+        
+        // Handle the PingOneProtectInitializeCallback callback
+        for callback in currentNode.callbacks {
+            if callback is PingOneProtectInitializeCallback, let pingOneProtectInitializeCallback = callback as? PingOneProtectInitializeCallback {
+                
+                var initResult = ""
+                let ex = self.expectation(description: "PingOne Protect Init")
+                pingOneProtectInitializeCallback.start(completion: { (result) in
+                        switch result {
+                        case .success:
+                            initResult = "Success"
+                        case .failure(let error):
+                            initResult = error.localizedDescription
+                        };
+                        ex.fulfill()
+                    })
+                waitForExpectations(timeout: 60, handler: nil)
+                
+                XCTAssertEqual(initResult, "Success")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        var ex = self.expectation(description: "Submit PingOneProtectInitialize callback and continue...")
+            currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node!
+            ex.fulfill()
+            
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Provide username
+        for callback in currentNode.callbacks {
+            if callback is NameCallback, let nameCallback = callback as? NameCallback {
+                nameCallback.setValue(AA_10_PingOneProtectEvaluateCallbackTest.USERNAME)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+
+        ex = self.expectation(description: "Submit username collector node")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node!
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Handle PingOneProtectEvaluationCallback
+        for callback in currentNode.callbacks {
+            if callback is PingOneProtectEvaluationCallback, let pingOneProtectEvaluationCallback = callback as? PingOneProtectEvaluationCallback {
+                
+                XCTAssertFalse(pingOneProtectEvaluationCallback.pauseBehavioralData)
+                
+                var evaulationResult = ""
+                let ex = self.expectation(description: "PingOne Protect Evaluate")
+                pingOneProtectEvaluationCallback.getData(completion: { (result) in
+                        switch result {
+                        case .success:
+                            evaulationResult = "Success"
+                        case .failure(let error):
+                            evaulationResult = error.localizedDescription
+                        };
+                        ex.fulfill()
+                    })
+                waitForExpectations(timeout: 60, handler: nil)
+                
+                XCTAssertEqual(evaulationResult, "Success")
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit the PingOneProtectEvaluation callback ")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node!
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        // Confirm that AM returns "success"
+        for callback in currentNode.callbacks {
+            if callback is TextOutputCallback, let textOutputCallback = callback as? TextOutputCallback {
+                XCTAssertEqual(textOutputCallback.message, "Success")
+            }
+            else if callback is ConfirmationCallback, let confirmationCallback = callback as? ConfirmationCallback {
+                confirmationCallback.value = 0
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value for the ConfirmationCallback and continue...")
+        currentNode.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(node)
+            XCTAssertNil(error)
+            XCTAssertNotNil(token)
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    /// Common steps for all test cases
+    func startTest(nodeConfiguration: String) throws -> Node  {
+        var currentNode: Node?
+        
+        var ex = self.expectation(description: "Select test configuration")
+        
+        FRSession.authenticate(authIndexValue: options.authServiceName) { (token: Token?, node, error) in
+            // Validate result
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        /// --------------------------------
+        guard let node = currentNode else {
+            XCTFail("Failed to get Node")
+            throw AuthError.invalidCallbackResponse("Expected ChoiceCollector node, but got nothing...")
+        }
+        
+        // Provide input value for the ChoiceCollector callback
+        for callback in node.callbacks {
+            if callback is ChoiceCallback, let choiceCallback = callback as? ChoiceCallback {
+                let choiceIndex = choiceCallback.choices.firstIndex(of: nodeConfiguration)
+                choiceCallback.setValue(choiceIndex)
+            }
+            else {
+                XCTFail("Received unexpected callback \(callback)")
+            }
+        }
+        
+        ex = self.expectation(description: "Submit value to the ChoiceCollector Node")
+        currentNode?.next { (token: AccessToken?, node, error) in
+            XCTAssertNil(token)
+            XCTAssertNil(error)
+            XCTAssertNotNil(node)
+            currentNode = node
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        guard currentNode != nil else {
+            XCTFail("Failed to get Node from the second request")
+            throw AuthError.invalidCallbackResponse("Expected at least one more node, but got nothing...")
+        }
+        return currentNode!
+    }
+}

--- a/PingProtect/PingProtect/Sources/Callbacks/PingOneProtectEvaluationCallback.swift
+++ b/PingProtect/PingProtect/Sources/Callbacks/PingOneProtectEvaluationCallback.swift
@@ -18,7 +18,7 @@ import FRAuth
 open class PingOneProtectEvaluationCallback: MultipleValuesCallback {
     
     /// The pauseBehavioralData received from server
-    public private(set) var pauseBehavioralData: Bool?
+    public private(set) var pauseBehavioralData: Bool
     
     /// Signals input key in callback response
     private var signalsKey: String
@@ -87,7 +87,7 @@ open class PingOneProtectEvaluationCallback: MultipleValuesCallback {
             if let data = data {
                 self.setSignals(data)
                 // Pause behavioral data collection if `pauseBehavioralData` is set to FALSE on the server node
-                if let pauseBehavioralData = self.pauseBehavioralData, pauseBehavioralData == true {
+                if self.pauseBehavioralData {
                     PIProtect.pauseBehavioralData()
                 }
                 completion(.success)

--- a/PingProtect/PingProtectTests/PingOneProtectEvaluationCallbackTests.swift
+++ b/PingProtect/PingProtectTests/PingOneProtectEvaluationCallbackTests.swift
@@ -73,7 +73,7 @@ final class PingOneProtectEvaluationCallbackTests: FRAuthBaseTest {
             let callback = try PingOneProtectEvaluationCallback(json: callbackResponse)
             
             XCTAssertNotNil(callback)
-            XCTAssertEqual(String(callback.pauseBehavioralData!), pauseBehavioralData)
+            XCTAssertEqual(String(callback.pauseBehavioralData), pauseBehavioralData)
             
             XCTAssertTrue(callback.inputNames.contains(signalsKey))
             XCTAssertTrue(callback.inputNames.contains(clientErrorKey))

--- a/SampleApps/FRExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/SampleApps/FRExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -53,6 +53,15 @@
         "revision" : "10ed3b6736def7c26eb87135466b1cb46ea7e37f",
         "version" : "2.4.0"
       }
+    },
+    {
+      "identity" : "pingone-signals-sdk-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pingidentity/pingone-signals-sdk-ios",
+      "state" : {
+        "revision" : "5f5d11a99746eec06f496e0302bc86673be573a2",
+        "version" : "5.2.0"
+      }
     }
   ],
   "version" : 2


### PR DESCRIPTION
# JIRA Ticket

[SDKS-2898](https://bugster.forgerock.org/jira/browse/SDKS-2898) "Test Protect SDK"

# Description
- Added e2e tests for the PingOne Protect support

These test cases require the following authentication trees present in AM:
**TEST_PING_ONE_PROTECT_INITIALIZE**:
<img width="590" alt="image" src="https://github.com/ForgeRock/forgerock-ios-sdk/assets/1580960/f544d758-ba64-4946-b40f-5bba2c294ba7">

**TEST_PING_ONE_PROTECT_EVALUATE**:
<img width="986" alt="image" src="https://github.com/ForgeRock/forgerock-ios-sdk/assets/1580960/032d12d7-8964-41c1-a25d-a9fe28a75279">


