### PR TITLE
Protect bug fixes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package (
         .package(name: "Facebook", url: "https://github.com/facebook/facebook-ios-sdk.git", .exact("16.0.1")),
         .package(name: "GoogleSignIn", url: "https://github.com/google/GoogleSignIn-iOS.git", .exact("7.0.0")),
         .package(name: "JOSESwift", url: "https://github.com/airsidemobile/JOSESwift.git", .exact("2.4.0")),
-        .package(name: "PingOneSignals", url: "https://github.com/pingidentity/pingone-signals-sdk-ios.git", .exact("5.2.0"))
+        .package(name: "PingOneSignals", url: "https://github.com/pingidentity/pingone-signals-sdk-ios.git", .exact("5.2.1"))
     ],
     targets: [
         .target(name: "cFRCore", dependencies: [], path: "FRCore/FRCore/SharedC/Sources"),

--- a/PingProtect.podspec
+++ b/PingProtect.podspec
@@ -30,5 +30,5 @@ Pod::Spec.new do |s|
   base_dir = "PingProtect/PingProtect"
   s.source_files = base_dir + '/**/*.swift', base_dir + '/**/*.c', base_dir + '/**/*.h'
   s.ios.dependency 'FRAuth', '~> 4.3.0'
-  s.ios.dependency 'PingOneSignals', :podspec => "https://assets.pingone.com/signals/ios-sdk/5.2.0/
+  s.ios.dependency 'PingOneSignals', :podspec => "https://assets.pingone.com/signals/ios-sdk/5.2.1/
 end

--- a/PingProtect.podspec
+++ b/PingProtect.podspec
@@ -30,5 +30,5 @@ Pod::Spec.new do |s|
   base_dir = "PingProtect/PingProtect"
   s.source_files = base_dir + '/**/*.swift', base_dir + '/**/*.c', base_dir + '/**/*.h'
   s.ios.dependency 'FRAuth', '~> 4.3.0'
-  s.ios.dependency 'PingOneSignals', '~> 5.2.0'
+  s.ios.dependency 'PingOneSignals', :podspec => "https://assets.pingone.com/signals/ios-sdk/5.2.0/
 end

--- a/PingProtect/PingProtect.xcodeproj/project.pbxproj
+++ b/PingProtect/PingProtect.xcodeproj/project.pbxproj
@@ -680,7 +680,7 @@
 			repositoryURL = "https://github.com/pingidentity/pingone-signals-sdk-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.0;
+				minimumVersion = 5.2.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PingProtect/PingProtect/Sources/Callbacks/PingOneProtectInitializeCallback.swift
+++ b/PingProtect/PingProtect/Sources/Callbacks/PingOneProtectInitializeCallback.swift
@@ -9,6 +9,7 @@
 //
 
 import FRAuth
+import Foundation
 
 /**
  * Callback to initialize PingOne Protect SDK


### PR DESCRIPTION
[SDKS-3078](https://bugster.forgerock.org/jira/browse/SDKS-3078)  [iOS] Protect module bug fixes

1. Add missing `import Foundation` in PingOneProtectInitializeCallback.swift
2. Fix Incorrect link for 'PingOneSignals' podspec (should be :podspec => "https://assets.pingone.com/signals/ios-sdk/5.2.1/)
3. Update Signals SDK to 5.2.1 