### PR TITLE
Sdks 3086 privacy manifests

### DIFF
--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -27,6 +27,7 @@
 		95E180B42992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95E180B32992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift */; };
 		95EB7E4D2B8D010B00B59CD6 /* AA_09_PingOneProtectInitializeCallbackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95EB7E4C2B8D010B00B59CD6 /* AA_09_PingOneProtectInitializeCallbackTest.swift */; };
 		95EB7E532B8D5F6100B59CD6 /* AA_10_PingOneProtectEvaluateCallbackTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95EB7E522B8D5F6100B59CD6 /* AA_10_PingOneProtectEvaluateCallbackTest.swift */; };
+		A50DEC452BCDEEC10094CD73 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A50DEC442BCDEEC10094CD73 /* PrivacyInfo.xcprivacy */; };
 		A53723D12AE80A5D0047B809 /* TelephonyCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53723D02AE80A5D0047B809 /* TelephonyCollectorTests.swift */; };
 		A5950A2A27EA205B00EDEFE4 /* SSLPinningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5950A2927EA205B00EDEFE4 /* SSLPinningTests.swift */; };
 		D512CD41240DC41E00AF520E /* FRRestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D512CD40240DC41E00AF520E /* FRRestClient.swift */; };
@@ -358,6 +359,7 @@
 		95E180B32992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AA-06-DeviceSigningVerifierCallbackTest.swift"; sourceTree = "<group>"; };
 		95EB7E4C2B8D010B00B59CD6 /* AA_09_PingOneProtectInitializeCallbackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AA_09_PingOneProtectInitializeCallbackTest.swift; sourceTree = "<group>"; };
 		95EB7E522B8D5F6100B59CD6 /* AA_10_PingOneProtectEvaluateCallbackTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AA_10_PingOneProtectEvaluateCallbackTest.swift; sourceTree = "<group>"; };
+		A50DEC442BCDEEC10094CD73 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A53723D02AE80A5D0047B809 /* TelephonyCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelephonyCollectorTests.swift; sourceTree = "<group>"; };
 		A5950A2927EA205B00EDEFE4 /* SSLPinningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSLPinningTests.swift; sourceTree = "<group>"; };
 		D5015FEE24996AE50025FEB6 /* MetadataCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataCallbackTests.swift; sourceTree = "<group>"; };
@@ -974,6 +976,7 @@
 				D554632122A6EDF90096C7A4 /* FRAuth.swift */,
 				D55462FB22A6DF720096C7A4 /* FRAuth.h */,
 				D55462FC22A6DF720096C7A4 /* Info.plist */,
+				A50DEC442BCDEEC10094CD73 /* PrivacyInfo.xcprivacy */,
 			);
 			path = FRAuth;
 			sourceTree = "<group>";
@@ -1202,7 +1205,7 @@
 				959D7D97290B4B9200A1F22F /* AA-05-DeviceBindingCallbackTest.swift */,
 				95E180B32992A6F20087457D /* AA-06-DeviceSigningVerifierCallbackTest.swift */,
 				3A4B46E32AB95B3D009E7171 /* AA_07_AppIntegrityTest.swift */,
-        9536C56B2B865DD600B2DFDD /* AA_08_TextInputCallbackTest.swift */,
+				9536C56B2B865DD600B2DFDD /* AA_08_TextInputCallbackTest.swift */,
 				95EB7E4C2B8D010B00B59CD6 /* AA_09_PingOneProtectInitializeCallbackTest.swift */,
 				95EB7E522B8D5F6100B59CD6 /* AA_10_PingOneProtectEvaluateCallbackTest.swift */,
 			);
@@ -1672,6 +1675,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A50DEC452BCDEEC10094CD73 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FRAuth/FRAuth/Device/HardwareCollector.swift
+++ b/FRAuth/FRAuth/Device/HardwareCollector.swift
@@ -31,7 +31,6 @@ public class HardwareCollector: DeviceCollector {
 //        result["activeCPU"] = pi.activeProcessorCount
 //        result["multitaskSupport"] = UIDevice.current.isMultitaskingSupported
         result["manufacturer"] = "Apple"
-        result["storage"] = Int(self.getDiskSpaceSize())
         result["memory"] = Int(self.getMemorySize())
         result["display"] = self.getScreenInfo()
         result["camera"] = self.getCameraInfo()
@@ -63,24 +62,6 @@ public class HardwareCollector: DeviceCollector {
         result["height"] = Int(UIScreen.main.bounds.height)
         result["orientation"] = UIDevice.current.orientation.isPortrait ? 1 : 0
         return result
-    }
-    
-    
-    /// Calculates current device's total disk size in MB
-    ///
-    /// - Returns: Current device's disk size in MB
-    func getDiskSpaceSize() -> Double {
-        do {
-            let fileAttributes = try FileManager.default.attributesOfFileSystem(forPath: NSHomeDirectory())
-            if var sysSize = fileAttributes[.systemSize] as? Double {
-                sysSize = (sysSize / 1024) / 1024
-                return sysSize
-            }
-            return 0.0
-        }
-        catch {
-            return 0.0
-        }
     }
     
     

--- a/FRAuth/FRAuth/Device/HardwareCollector.swift
+++ b/FRAuth/FRAuth/Device/HardwareCollector.swift
@@ -2,7 +2,7 @@
 //  HardwareCollector.swift
 //  FRAuth
 //
-//  Copyright (c) 2019-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2024 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/PrivacyInfo.xcprivacy
+++ b/FRAuth/FRAuth/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Device/FRDeviceCollectorTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Device/FRDeviceCollectorTests.swift
@@ -2,7 +2,7 @@
 //  FRDeviceCollectorTests.swift
 //  FRAuthTests
 //
-//  Copyright (c) 2019 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2024 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -81,7 +81,7 @@ class FRDeviceCollectorTests: FRAuthBaseTest {
         XCTAssertNotNil((hardware["cpu"] as? Int))
 //        XCTAssertNotNil((hardware["activeCPU"] as? Int))
         XCTAssertNotNil((hardware["memory"] as? Int))
-//        XCTAssertNotNil((hardware["storage"] as? Int))
+//        XCTAssertNotNil((hardware["storage"] as? Int)) //has been removed as Apple doesn't allow the use of this API for fingerprinting
         XCTAssertNotNil((hardware["manufacturer"] as? String))
         
         // Then, validate display section from hardware

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Device/FRDeviceCollectorTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Device/FRDeviceCollectorTests.swift
@@ -81,7 +81,7 @@ class FRDeviceCollectorTests: FRAuthBaseTest {
         XCTAssertNotNil((hardware["cpu"] as? Int))
 //        XCTAssertNotNil((hardware["activeCPU"] as? Int))
         XCTAssertNotNil((hardware["memory"] as? Int))
-        XCTAssertNotNil((hardware["storage"] as? Int))
+//        XCTAssertNotNil((hardware["storage"] as? Int))
         XCTAssertNotNil((hardware["manufacturer"] as? String))
         
         // Then, validate display section from hardware

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Network/NetworkReachabilityMonitorTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Network/NetworkReachabilityMonitorTests.swift
@@ -2,7 +2,7 @@
 //  NetworkReachabilityMonitorTests.swift
 //  FRAuthTests
 //
-//  Copyright (c) 2019-2022 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2024 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Network/NetworkReachabilityMonitorTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Network/NetworkReachabilityMonitorTests.swift
@@ -169,10 +169,14 @@ class NetworkReachabilityMonitorTests: FRAuthBaseTest {
         waitForExpectations(timeout: 60, handler: nil)
         
         // Then
+      if #available(iOS 13.0, *) {
         addTeardownBlock { [weak monitor] in
-            XCTAssertNil(monitor, "`monitor` should have been deallocated. Potential memory leak!")
-            
+          XCTAssertNil(monitor, "`monitor` should have been deallocated. Potential memory leak!")
+          
         }
+      } else {
+        // Fallback on earlier versions
+      }
     }
     
 }

--- a/FRCore/FRCore.xcodeproj/project.pbxproj
+++ b/FRCore/FRCore.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		1BA471542993472500E657DA /* FRJailbreakDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BCF4C98299343CB0068D6E8 /* FRJailbreakDetector.swift */; };
 		1BA471552993472500E657DA /* SandboxDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BCF4C91299343CB0068D6E8 /* SandboxDetector.swift */; };
 		1BA471572993472500E657DA /* SymbolicLinkDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BCF4C92299343CB0068D6E8 /* SymbolicLinkDetector.swift */; };
+		A50DEC5F2BCEC76F0094CD73 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A50DEC5E2BCEC76F0094CD73 /* PrivacyInfo.xcprivacy */; };
 		A52873D72AF1EEA3002424C0 /* URLSchemeDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52873D62AF1EEA3002424C0 /* URLSchemeDetector.swift */; };
 		A52873D92AF99A05002424C0 /* SuspiciousFilesExistenceDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52873D82AF99A05002424C0 /* SuspiciousFilesExistenceDetector.swift */; };
 		A52873DB2AFA8C2E002424C0 /* SuspiciousFilesAccessibleDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = A52873DA2AFA8C2E002424C0 /* SuspiciousFilesAccessibleDetector.swift */; };
@@ -148,6 +149,7 @@
 		1BCF4C97299343CB0068D6E8 /* JailbreakDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = JailbreakDetector.swift; sourceTree = "<group>"; };
 		1BCF4C98299343CB0068D6E8 /* FRJailbreakDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FRJailbreakDetector.swift; sourceTree = "<group>"; };
 		1BCF4C99299343CB0068D6E8 /* RestrictedDirectoriesWritableDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RestrictedDirectoriesWritableDetector.swift; sourceTree = "<group>"; };
+		A50DEC5E2BCEC76F0094CD73 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A52873D62AF1EEA3002424C0 /* URLSchemeDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSchemeDetector.swift; sourceTree = "<group>"; };
 		A52873D82AF99A05002424C0 /* SuspiciousFilesExistenceDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuspiciousFilesExistenceDetector.swift; sourceTree = "<group>"; };
 		A52873DA2AFA8C2E002424C0 /* SuspiciousFilesAccessibleDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SuspiciousFilesAccessibleDetector.swift; sourceTree = "<group>"; };
@@ -492,6 +494,7 @@
 				1BCF4C9B299343CB0068D6E8 /* Security */,
 				D5E75BCD2409B8C0005F589F /* FRCore.h */,
 				D5E75BCE2409B8C0005F589F /* Info.plist */,
+				A50DEC5E2BCEC76F0094CD73 /* PrivacyInfo.xcprivacy */,
 			);
 			path = FRCore;
 			sourceTree = "<group>";
@@ -668,6 +671,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A50DEC5F2BCEC76F0094CD73 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FRCore/FRCore/PrivacyInfo.xcprivacy
+++ b/FRCore/FRCore/PrivacyInfo.xcprivacy
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/FRDeviceBinding/FRDeviceBinding.xcodeproj/project.pbxproj
+++ b/FRDeviceBinding/FRDeviceBinding.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A50DEC542BCDFFE50094CD73 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A50DEC532BCDFFE50094CD73 /* PrivacyInfo.xcprivacy */; };
 		A589EC6D29E63C0300399B64 /* DeviceSigningVerifierCallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A589EC6B29E63C0300399B64 /* DeviceSigningVerifierCallbackTests.swift */; };
 		A589EC6E29E63C0300399B64 /* DeviceBindingCallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A589EC6C29E63C0300399B64 /* DeviceBindingCallbackTests.swift */; };
 		A589EC7729E63C7F00399B64 /* UserKeySelectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A589EC7529E63C7F00399B64 /* UserKeySelectorTests.swift */; };
@@ -91,6 +92,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A50DEC532BCDFFE50094CD73 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A589EC6B29E63C0300399B64 /* DeviceSigningVerifierCallbackTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceSigningVerifierCallbackTests.swift; sourceTree = "<group>"; };
 		A589EC6C29E63C0300399B64 /* DeviceBindingCallbackTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DeviceBindingCallbackTests.swift; sourceTree = "<group>"; };
 		A589EC7129E63C7F00399B64 /* UserDeviceKeyServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDeviceKeyServiceTests.swift; sourceTree = "<group>"; };
@@ -410,6 +412,7 @@
 			children = (
 				A5D1C39B29E5A4160096039E /* Sources */,
 				A5D1C37729E59FC20096039E /* FRDeviceBinding.h */,
+				A50DEC532BCDFFE50094CD73 /* PrivacyInfo.xcprivacy */,
 			);
 			path = FRDeviceBinding;
 			sourceTree = "<group>";
@@ -594,6 +597,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A50DEC542BCDFFE50094CD73 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FRDeviceBinding/FRDeviceBinding.xcodeproj/project.pbxproj
+++ b/FRDeviceBinding/FRDeviceBinding.xcodeproj/project.pbxproj
@@ -939,8 +939,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airsidemobile/JOSESwift";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
+				kind = upToNextMinorVersion;
+				minimumVersion = 2.4.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/FRDeviceBinding/FRDeviceBinding/PrivacyInfo.xcprivacy
+++ b/FRDeviceBinding/FRDeviceBinding/PrivacyInfo.xcprivacy
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/FRFacebookSignIn/FRFacebookSignIn.xcodeproj/project.pbxproj
+++ b/FRFacebookSignIn/FRFacebookSignIn.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A50DEC7E2BCEC8CB0094CD73 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A50DEC7D2BCEC8CB0094CD73 /* PrivacyInfo.xcprivacy */; };
 		D57F637C260137EA00BBA0B6 /* FRFacebookSignIn.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D57F6372260137E900BBA0B6 /* FRFacebookSignIn.framework */; };
 		D57F6383260137EA00BBA0B6 /* FRFacebookSignIn.h in Headers */ = {isa = PBXBuildFile; fileRef = D57F6375260137E900BBA0B6 /* FRFacebookSignIn.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		D57F63A42601387E00BBA0B6 /* FacebookSignInHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D57F63A32601387E00BBA0B6 /* FacebookSignInHandler.swift */; };
@@ -47,6 +48,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A50DEC7D2BCEC8CB0094CD73 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D57F6372260137E900BBA0B6 /* FRFacebookSignIn.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FRFacebookSignIn.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D57F6375260137E900BBA0B6 /* FRFacebookSignIn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FRFacebookSignIn.h; sourceTree = "<group>"; };
 		D57F6376260137E900BBA0B6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -103,6 +105,7 @@
 				D57F63A22601386B00BBA0B6 /* Sources */,
 				D57F6375260137E900BBA0B6 /* FRFacebookSignIn.h */,
 				D57F6376260137E900BBA0B6 /* Info.plist */,
+				A50DEC7D2BCEC8CB0094CD73 /* PrivacyInfo.xcprivacy */,
 			);
 			path = FRFacebookSignIn;
 			sourceTree = "<group>";
@@ -256,6 +259,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A50DEC7E2BCEC8CB0094CD73 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FRFacebookSignIn/FRFacebookSignIn.xcodeproj/project.pbxproj
+++ b/FRFacebookSignIn/FRFacebookSignIn.xcodeproj/project.pbxproj
@@ -567,8 +567,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/facebook/facebook-ios-sdk";
 			requirement = {
-				kind = exactVersion;
-				version = 16.0.1;
+				kind = upToNextMinorVersion;
+				minimumVersion = 16.0.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/FRFacebookSignIn/FRFacebookSignIn/PrivacyInfo.xcprivacy
+++ b/FRFacebookSignIn/FRFacebookSignIn/PrivacyInfo.xcprivacy
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/FRFacebookSignIn/FRFacebookSignIn/PrivacyInfo.xcprivacy
+++ b/FRFacebookSignIn/FRFacebookSignIn/PrivacyInfo.xcprivacy
@@ -2,7 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
 	<key>NSPrivacyTracking</key>
-	<false/>
+	<true/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array>
+		<string>ep1.facebook.com</string>
+	</array>
 </dict>
 </plist>

--- a/FRGoogleSignIn.podspec
+++ b/FRGoogleSignIn.podspec
@@ -32,7 +32,7 @@ Pod::Spec.new do |s|
   s.source_files = base_dir + '/**/*.swift', base_dir + '/**/*.c', base_dir + '/**/*.h'
 
   s.ios.dependency 'FRAuth', '~> 4.4.0'
-  s.ios.dependency 'GoogleSignIn', '~> 7.0.0'
+  s.ios.dependency 'GoogleSignIn', '~> 7.1.0'
   s.pod_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
   s.user_target_xcconfig = { 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'arm64' }
 end

--- a/FRGoogleSignIn/FRGoogleSignIn.xcodeproj/project.pbxproj
+++ b/FRGoogleSignIn/FRGoogleSignIn.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A50DEC4F2BCDFF8F0094CD73 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A50DEC4E2BCDFF8F0094CD73 /* PrivacyInfo.xcprivacy */; };
 		D58BC3B52603112A00254654 /* GoogleSignInHandlerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D58BC3B42603112A00254654 /* GoogleSignInHandlerTests.swift */; };
 		D5B2067626008D0900DABB9B /* FRGoogleSignIn.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D5B2066C26008D0800DABB9B /* FRGoogleSignIn.framework */; };
 		D5B2067D26008D0900DABB9B /* FRGoogleSignIn.h in Headers */ = {isa = PBXBuildFile; fileRef = D5B2066F26008D0800DABB9B /* FRGoogleSignIn.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -47,6 +48,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A50DEC4E2BCDFF8F0094CD73 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D58BC3B42603112A00254654 /* GoogleSignInHandlerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GoogleSignInHandlerTests.swift; sourceTree = "<group>"; };
 		D5B2066C26008D0800DABB9B /* FRGoogleSignIn.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FRGoogleSignIn.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D5B2066F26008D0800DABB9B /* FRGoogleSignIn.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FRGoogleSignIn.h; sourceTree = "<group>"; };
@@ -104,6 +106,7 @@
 				D5B206D026008F2E00DABB9B /* Sources */,
 				D5B2066F26008D0800DABB9B /* FRGoogleSignIn.h */,
 				D5B2067026008D0800DABB9B /* Info.plist */,
+				A50DEC4E2BCDFF8F0094CD73 /* PrivacyInfo.xcprivacy */,
 			);
 			path = FRGoogleSignIn;
 			sourceTree = "<group>";
@@ -263,6 +266,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A50DEC4F2BCDFF8F0094CD73 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FRGoogleSignIn/FRGoogleSignIn.xcodeproj/project.pbxproj
+++ b/FRGoogleSignIn/FRGoogleSignIn.xcodeproj/project.pbxproj
@@ -581,8 +581,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/google/GoogleSignIn-iOS.git";
 			requirement = {
-				kind = exactVersion;
-				version = 7.1.0;
+				kind = upToNextMinorVersion;
+				minimumVersion = 7.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/FRGoogleSignIn/FRGoogleSignIn.xcodeproj/project.pbxproj
+++ b/FRGoogleSignIn/FRGoogleSignIn.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -578,7 +578,7 @@
 			repositoryURL = "https://github.com/google/GoogleSignIn-iOS.git";
 			requirement = {
 				kind = exactVersion;
-				version = 7.0.0;
+				version = 7.1.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/FRGoogleSignIn/FRGoogleSignIn/PrivacyInfo.xcprivacy
+++ b/FRGoogleSignIn/FRGoogleSignIn/PrivacyInfo.xcprivacy
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/FRProximity/FRProximity.xcodeproj/project.pbxproj
+++ b/FRProximity/FRProximity.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A50DEC4C2BCDFF700094CD73 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A50DEC4B2BCDFF700094CD73 /* PrivacyInfo.xcprivacy */; };
 		D5021009246A244200A45A51 /* DeviceCollectorNodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5021008246A244200A45A51 /* DeviceCollectorNodeTests.swift */; };
 		D502100E246A248600A45A51 /* DeviceCollectorNodeTree.png in Resources */ = {isa = PBXBuildFile; fileRef = D502100D246A248600A45A51 /* DeviceCollectorNodeTree.png */; };
 		D502101C246A304D00A45A51 /* DeviceProfileCallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D502101B246A304D00A45A51 /* DeviceProfileCallbackTests.swift */; };
@@ -127,6 +128,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A50DEC4B2BCDFF700094CD73 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D5021008246A244200A45A51 /* DeviceCollectorNodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceCollectorNodeTests.swift; sourceTree = "<group>"; };
 		D502100D246A248600A45A51 /* DeviceCollectorNodeTree.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = DeviceCollectorNodeTree.png; sourceTree = "<group>"; };
 		D502101B246A304D00A45A51 /* DeviceProfileCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceProfileCallbackTests.swift; sourceTree = "<group>"; };
@@ -294,6 +296,7 @@
 				D59FAE21234413D3005D34DA /* FRProximity.h */,
 				D59FAE22234413D3005D34DA /* Info.plist */,
 				D59FAE81234414DB005D34DA /* FRProximity.swift */,
+				A50DEC4B2BCDFF700094CD73 /* PrivacyInfo.xcprivacy */,
 			);
 			path = FRProximity;
 			sourceTree = "<group>";
@@ -636,6 +639,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A50DEC4C2BCDFF700094CD73 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FRProximity/FRProximity/PrivacyInfo.xcprivacy
+++ b/FRProximity/FRProximity/PrivacyInfo.xcprivacy
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/FRUI/FRUI.xcodeproj/project.pbxproj
+++ b/FRUI/FRUI.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A50DEC482BCDFF510094CD73 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A50DEC472BCDFF510094CD73 /* PrivacyInfo.xcprivacy */; };
 		A5C38A2329E5AFB20016B565 /* FRDeviceBinding.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A5C38A2229E5AFB20016B565 /* FRDeviceBinding.framework */; };
 		D527D03124BCDB4E00C21663 /* FRUITextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D527D03024BCDB4E00C21663 /* FRUITextView.swift */; };
 		D539C8E822DE930800BE2B3C /* TermsAndConditionsTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D539C8E622DE930800BE2B3C /* TermsAndConditionsTableViewCell.swift */; };
@@ -82,6 +83,7 @@
 
 /* Begin PBXFileReference section */
 		953E5D312A424347003BC7B3 /* FRDeviceBinding.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = FRDeviceBinding.xcodeproj; path = ../FRDeviceBinding/FRDeviceBinding.xcodeproj; sourceTree = "<group>"; };
+		A50DEC472BCDFF510094CD73 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A5C38A2229E5AFB20016B565 /* FRDeviceBinding.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FRDeviceBinding.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D527D03024BCDB4E00C21663 /* FRUITextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FRUITextView.swift; sourceTree = "<group>"; };
 		D539C8E622DE930800BE2B3C /* TermsAndConditionsTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TermsAndConditionsTableViewCell.swift; sourceTree = "<group>"; };
@@ -203,6 +205,7 @@
 				D53A91E422B1815B003DF94E /* FRUI.h */,
 				D53A91E522B1815B003DF94E /* Info.plist */,
 				D5CACF8B22B1A87700656521 /* FRUI.swift */,
+				A50DEC472BCDFF510094CD73 /* PrivacyInfo.xcprivacy */,
 			);
 			path = FRUI;
 			sourceTree = "<group>";
@@ -453,6 +456,7 @@
 				D592481623285AAF0027031A /* TextOutputCallbackTableViewCell.xib in Resources */,
 				D53A922C22B1869C003DF94E /* AuthStepViewController.xib in Resources */,
 				D5F8F9F424B7DC8300EC9AEB /* BooleanAttributeInputCallbackTableViewCell.xib in Resources */,
+				A50DEC482BCDFF510094CD73 /* PrivacyInfo.xcprivacy in Resources */,
 				D539C8E922DE930800BE2B3C /* TermsAndConditionsTableViewCell.xib in Resources */,
 				D53A922922B1869C003DF94E /* PasswordCallbackTableViewCell.xib in Resources */,
 				D53A922B22B1869C003DF94E /* NameCallbackTableViewCell.xib in Resources */,

--- a/FRUI/FRUI/PrivacyInfo.xcprivacy
+++ b/FRUI/FRUI/PrivacyInfo.xcprivacy
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/openid/AppAuth-iOS.git",
         "state": {
           "branch": null,
-          "revision": "0eadcdec4ddb121865f3d66917549194afce1f2b",
-          "version": "1.6.1"
+          "revision": "8c0b028aedf617d6d780d448dc836f7048166d0f",
+          "version": "1.7.4"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/facebook/facebook-ios-sdk.git",
         "state": {
           "branch": null,
-          "revision": "82dec0403c32d7b1d93529dcabb9fcb18f0825cc",
-          "version": "9.1.0"
+          "revision": "5c7367dadcbe504702c041621dc09752bf2cd747",
+          "version": "16.0.1"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/google/GoogleSignIn-iOS.git",
         "state": {
           "branch": null,
-          "revision": "60ca2bfd218ccb194a746a79b41d9d50eb7e3af0",
-          "version": "6.1.0"
+          "revision": "a7965d134c5d3567026c523e0a8a583f73b62b0d",
+          "version": "7.1.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/google/gtm-session-fetcher.git",
         "state": {
           "branch": null,
-          "revision": "4e9bbf2808b8fee444e84a48f5f3c12641987d3e",
-          "version": "1.7.2"
+          "revision": "bc8972686f8797713af26b8eb24e85e2a6b972a3",
+          "version": "3.4.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/google/GTMAppAuth.git",
         "state": {
           "branch": null,
-          "revision": "6dee0cde8a1b223737a5159e55e6b4ec16bbbdd9",
-          "version": "1.3.1"
+          "revision": "5d7d66f647400952b1758b230e019b07c0b4b22a",
+          "version": "4.1.1"
         }
       },
       {
@@ -53,6 +53,15 @@
           "branch": null,
           "revision": "10ed3b6736def7c26eb87135466b1cb46ea7e37f",
           "version": "2.4.0"
+        }
+      },
+      {
+        "package": "PingOneSignals",
+        "repositoryURL": "https://github.com/pingidentity/pingone-signals-sdk-ios.git",
+        "state": {
+          "branch": null,
+          "revision": "07bc27b6485a0d741ca4055f46d743ac0680c974",
+          "version": "5.2.2"
         }
       }
     ]

--- a/Package.resolved
+++ b/Package.resolved
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/pingidentity/pingone-signals-sdk-ios.git",
         "state": {
           "branch": null,
-          "revision": "07bc27b6485a0d741ca4055f46d743ac0680c974",
-          "version": "5.2.2"
+          "revision": "88951ad71c37853fb86cee0bf48cf447ded5b268",
+          "version": "5.2.3"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,7 @@ let package = Package (
     ],
     dependencies: [
         .package(name: "Facebook", url: "https://github.com/facebook/facebook-ios-sdk.git", .exact("16.0.1")),
-        .package(name: "GoogleSignIn", url: "https://github.com/google/GoogleSignIn-iOS.git", .exact("7.0.0")),
+        .package(name: "GoogleSignIn", url: "https://github.com/google/GoogleSignIn-iOS.git", .exact("7.1.0")),
         .package(name: "JOSESwift", url: "https://github.com/airsidemobile/JOSESwift.git", .exact("2.4.0")),
         .package(name: "PingOneSignals", url: "https://github.com/pingidentity/pingone-signals-sdk-ios.git", .exact("5.2.1"))
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package (
         .package(name: "Facebook", url: "https://github.com/facebook/facebook-ios-sdk.git", .exact("16.0.1")),
         .package(name: "GoogleSignIn", url: "https://github.com/google/GoogleSignIn-iOS.git", .exact("7.1.0")),
         .package(name: "JOSESwift", url: "https://github.com/airsidemobile/JOSESwift.git", .exact("2.4.0")),
-        .package(name: "PingOneSignals", url: "https://github.com/pingidentity/pingone-signals-sdk-ios.git", .exact("5.2.2"))
+        .package(name: "PingOneSignals", url: "https://github.com/pingidentity/pingone-signals-sdk-ios.git", .exact("5.2.3"))
     ],
     targets: [
         .target(name: "cFRCore", dependencies: [], path: "FRCore/FRCore/SharedC/Sources"),

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package (
         .package(name: "Facebook", url: "https://github.com/facebook/facebook-ios-sdk.git", .exact("16.0.1")),
         .package(name: "GoogleSignIn", url: "https://github.com/google/GoogleSignIn-iOS.git", .exact("7.1.0")),
         .package(name: "JOSESwift", url: "https://github.com/airsidemobile/JOSESwift.git", .exact("2.4.0")),
-        .package(name: "PingOneSignals", url: "https://github.com/pingidentity/pingone-signals-sdk-ios.git", .exact("5.2.1"))
+        .package(name: "PingOneSignals", url: "https://github.com/pingidentity/pingone-signals-sdk-ios.git", .exact("5.2.2"))
     ],
     targets: [
         .target(name: "cFRCore", dependencies: [], path: "FRCore/FRCore/SharedC/Sources"),

--- a/Package.swift
+++ b/Package.swift
@@ -18,10 +18,10 @@ let package = Package (
         .library(name: "PingProtect", targets: ["PingProtect"])
     ],
     dependencies: [
-        .package(name: "Facebook", url: "https://github.com/facebook/facebook-ios-sdk.git", .exact("16.0.1")),
-        .package(name: "GoogleSignIn", url: "https://github.com/google/GoogleSignIn-iOS.git", .exact("7.1.0")),
-        .package(name: "JOSESwift", url: "https://github.com/airsidemobile/JOSESwift.git", .exact("2.4.0")),
-        .package(name: "PingOneSignals", url: "https://github.com/pingidentity/pingone-signals-sdk-ios.git", .exact("5.2.3"))
+        .package(name: "Facebook", url: "https://github.com/facebook/facebook-ios-sdk.git", .upToNextMinor(from: "16.0.1")),
+        .package(name: "GoogleSignIn", url: "https://github.com/google/GoogleSignIn-iOS.git", .upToNextMinor(from: ("7.1.0")),
+        .package(name: "JOSESwift", url: "https://github.com/airsidemobile/JOSESwift.git", .upToNextMinor(from: ("2.4.0")),
+        .package(name: "PingOneSignals", url: "https://github.com/pingidentity/pingone-signals-sdk-ios.git", .upToNextMinor(from: ("5.2.3"))
     ],
     targets: [
         .target(name: "cFRCore", dependencies: [], path: "FRCore/FRCore/SharedC/Sources"),

--- a/PingProtect.podspec
+++ b/PingProtect.podspec
@@ -31,5 +31,5 @@ Pod::Spec.new do |s|
   base_dir = "PingProtect/PingProtect"
   s.source_files = base_dir + '/**/*.swift', base_dir + '/**/*.c', base_dir + '/**/*.h'
   s.ios.dependency 'FRAuth', '~> 4.4.0'
-  s.ios.dependency 'PingOneSignals', '~> 5.2.2'
+  s.ios.dependency 'PingOneSignals', '~> 5.2.3'
 end

--- a/PingProtect.podspec
+++ b/PingProtect.podspec
@@ -31,5 +31,5 @@ Pod::Spec.new do |s|
   base_dir = "PingProtect/PingProtect"
   s.source_files = base_dir + '/**/*.swift', base_dir + '/**/*.c', base_dir + '/**/*.h'
   s.ios.dependency 'FRAuth', '~> 4.4.0'
-  s.ios.dependency 'PingOneSignals', '~> 5.2.1'
+  s.ios.dependency 'PingOneSignals', '~> 5.2.2'
 end

--- a/PingProtect/PingProtect.xcodeproj/project.pbxproj
+++ b/PingProtect/PingProtect.xcodeproj/project.pbxproj
@@ -683,8 +683,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pingidentity/pingone-signals-sdk-ios";
 			requirement = {
-				kind = exactVersion;
-				version = 5.2.2;
+				kind = upToNextMinorVersion;
+				minimumVersion = 5.2.3;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PingProtect/PingProtect.xcodeproj/project.pbxproj
+++ b/PingProtect/PingProtect.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A50DEC572BCE00130094CD73 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = A50DEC562BCE00130094CD73 /* PrivacyInfo.xcprivacy */; };
 		A52761162B60209000F8BDF7 /* PingProtect.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A527610D2B60209000F8BDF7 /* PingProtect.framework */; };
 		A527611B2B60209000F8BDF7 /* PIInitParamsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A527611A2B60209000F8BDF7 /* PIInitParamsTests.swift */; };
 		A527611C2B60209000F8BDF7 /* PingProtect.h in Headers */ = {isa = PBXBuildFile; fileRef = A52761102B60209000F8BDF7 /* PingProtect.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -74,6 +75,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A50DEC562BCE00130094CD73 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		A527610D2B60209000F8BDF7 /* PingProtect.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = PingProtect.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A52761102B60209000F8BDF7 /* PingProtect.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PingProtect.h; sourceTree = "<group>"; };
 		A52761152B60209000F8BDF7 /* PingProtectTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = PingProtectTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -142,6 +144,7 @@
 			children = (
 				A52761402B602D3D00F8BDF7 /* Sources */,
 				A52761102B60209000F8BDF7 /* PingProtect.h */,
+				A50DEC562BCE00130094CD73 /* PrivacyInfo.xcprivacy */,
 			);
 			path = PingProtect;
 			sourceTree = "<group>";
@@ -352,6 +355,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A50DEC572BCE00130094CD73 /* PrivacyInfo.xcprivacy in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PingProtect/PingProtect.xcodeproj/project.pbxproj
+++ b/PingProtect/PingProtect.xcodeproj/project.pbxproj
@@ -683,8 +683,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/pingidentity/pingone-signals-sdk-ios";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.1;
+				kind = exactVersion;
+				version = 5.2.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/PingProtect/PingProtect/PrivacyInfo.xcprivacy
+++ b/PingProtect/PingProtect/PrivacyInfo.xcprivacy
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>

--- a/PingProtect/PingProtect/PrivacyInfo.xcprivacy
+++ b/PingProtect/PingProtect/PrivacyInfo.xcprivacy
@@ -2,35 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>NSPrivacyTracking</key>
-    <false/>
-    <key>NSPrivacyAccessedAPITypes</key>
-    <array>
-      <dict>
-        <key>NSPrivacyAccessedAPITypeReasons</key>
-        <array>
-          <string>35F9.1</string>
-        </array>
-        <key>NSPrivacyAccessedAPIType</key>
-        <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
-      </dict>
-      <dict>
-        <key>NSPrivacyAccessedAPIType</key>
-        <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
-        <key>NSPrivacyAccessedAPITypeReasons</key>
-        <array>
-          <string>85F4.1</string>
-        </array>
-      </dict>
-      <dict>
-        <key>NSPrivacyAccessedAPIType</key>
-        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
-        <key>NSPrivacyAccessedAPITypeReasons</key>
-        <array>
-          <string>CA92.1</string>
-        </array>
-      </dict>
-    </array>
-
+	<key>NSPrivacyTracking</key>
+	<false/>
 </dict>
 </plist>

--- a/PingProtect/PingProtect/PrivacyInfo.xcprivacy
+++ b/PingProtect/PingProtect/PrivacyInfo.xcprivacy
@@ -2,7 +2,35 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSPrivacyTracking</key>
-	<false/>
+  <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array>
+      <dict>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>35F9.1</string>
+        </array>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategorySystemBootTime</string>
+      </dict>
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryDiskSpace</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>85F4.1</string>
+        </array>
+      </dict>
+      <dict>
+        <key>NSPrivacyAccessedAPIType</key>
+        <string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+        <key>NSPrivacyAccessedAPITypeReasons</key>
+        <array>
+          <string>CA92.1</string>
+        </array>
+      </dict>
+    </array>
+
 </dict>
 </plist>


### PR DESCRIPTION
[SDKS-3086](https://bugster.forgerock.org/jira/browse/SDKS-3086)

[iOS] Add Privacy Manifests to SDK

1. Update Google SDK to 7.1.0
2. Remove storage(diskSpace) from HardwareCollector
3. Add Privacy Manifests to all modules
4. Update Signals SDK to 5.2.3
5. Update FRFacebookSignIn Privacy Manifest to reflect Facebook iOS SDK privacy manifest
6. Change SPM dependency versions from exactVersion to upToNextMinorVersion