### PR TITLE
SDKS-3244 Only store PublicKeyCredentialSource when requireResidentKey is true

### DIFF
--- a/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorMakeCredentialSession.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorMakeCredentialSession.swift
@@ -360,14 +360,13 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                     
                     let credentialId = self.createNewCredentialId()
                     
-//                    //  Only store userHandle within PublicKeyCredentialSource when requireResidentKey is true
-//                    //  the client-side discoverable Public Key Credential Source should adhere requireResidentKey
-//                    var userHandle: [UInt8]? = nil
-//                    if requireResidentKey {
-//                        FRLog.v("Resident key is required; creating client-side discoverable credential source", subModule: WebAuthn.module)
-//                        userHandle = userEntity.id
-//                    }
-                    var userHandle = userEntity.id
+                    //  Only store userHandle within PublicKeyCredentialSource when requireResidentKey is true
+                    //  the client-side discoverable Public Key Credential Source should adhere requireResidentKey
+                    var userHandle: [UInt8]? = nil
+                    if requireResidentKey {
+                        FRLog.v("Resident key is required; creating client-side discoverable credential source", subModule: WebAuthn.module)
+                        userHandle = userEntity.id
+                    }
                     let credSource = PublicKeyCredentialSource(id: credentialId, rpId: rpEntity.id ?? "", userHandle: userHandle, signCount: 0, alg: keySupport.selectedAlg.rawValue, otherUI: keyName)
                                         
                     guard let publicKeyCOSE = keySupport.createKeyPair(label: credSource.keyLabel) else {

--- a/FRAuth/FRAuth/WebAuthn/Client/Operation/ClientCreateOperation.swift
+++ b/FRAuth/FRAuth/WebAuthn/Client/Operation/ClientCreateOperation.swift
@@ -221,13 +221,13 @@ class ClientCreateOperation: AuthenticatorMakeCredentialSessionDelegate {
                 }
             }
 
-//            if selection.requireResidentKey
-//                && !session.canStoreResidentKey() {
-//                let logMessage = "<CreateOperation> This authenticator can't store resident-key"
-//                WAKLogger.debug(logMessage)
-//                self.stop(by: FRWAKError.unsupported(platformError: nil, message: logMessage))
-//                return
-//            }
+            if selection.requireResidentKey
+                && !session.canStoreResidentKey() {
+                let logMessage = "<CreateOperation> This authenticator can't store resident-key"
+                WAKLogger.debug(logMessage)
+                self.stop(by: FRWAKError.unsupported(platformError: nil, message: logMessage))
+                return
+            }
 
             if selection.userVerification == .required
                 && !session.canPerformUserVerification() {

--- a/FRAuth/FRAuth/WebAuthn/FRWebAuthn.swift
+++ b/FRAuth/FRAuth/WebAuthn/FRWebAuthn.swift
@@ -49,7 +49,7 @@ public class FRWebAuthn: NSObject {
         return platformAuthenticator.deleteCredential(publicKeyCredentialSource: publicKeyCredentialSource)
     }
     
-    /// Delete the provide key from local storage and also remotely from Server. By default, if failed to delete from server, local storage
+    /// Delete the provide key from local storage and also remotely from Server if the key is discoverable. By default, if failed to delete from server, local storage
     /// will not be deleted, by providing ``forceDelete`` to true, it will also delete local keys if server call is failed.
     /// - Parameter publicKeyCredentialSource: ``PublicKeyCredentialSource`` to be deleted
     /// - Parameter forceDelete: Defaults to false, true will delete local keys even if the server key removal has failed


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3244](https://bugster.forgerock.org/jira/browse/SDKS-3244) Fix "usernameless" WebAuthn Tests

# Description

This reverts a previous change where the PublicKeyCredentialSource where stored for all WebAuthn use cases.

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] Example code snippets have been added.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).