### PR TITLE
Sdks 3021 OIDC signoff

### DIFF
--- a/FRAuth/FRAuth/Config/FROptions.swift
+++ b/FRAuth/FRAuth/Config/FROptions.swift
@@ -60,7 +60,7 @@ open class FROptions: NSObject, Codable {
         case oauthThreshold = "forgerock_oauth_threshold"
         case oauthClientId = "forgerock_oauth_client_id"
         case oauthRedirectUri = "forgerock_oauth_redirect_uri"
-        case oauthSignoutRedirectUri = "forgerock_oauth_signout_redirect_uri"
+        case oauthSignoutRedirectUri = "forgerock_oauth_sign_out_redirect_uri"
         case oauthScope = "forgerock_oauth_scope"
         case keychainAccessGroup = "forgerock_keychain_access_group"
         case sslPinningPublicKeyHashes = "forgerock_ssl_pinning_public_key_hashes"

--- a/FRAuth/FRAuth/Config/FROptions.swift
+++ b/FRAuth/FRAuth/Config/FROptions.swift
@@ -37,6 +37,7 @@ open class FROptions: NSObject, Codable {
     public var oauthThreshold: String?
     public var oauthClientId: String?
     public var oauthRedirectUri: String?
+    public var oauthSignoutRedirectUri: String?
     public var oauthScope: String?
     public var keychainAccessGroup: String?
     public var sslPinningPublicKeyHashes: [String]?
@@ -59,6 +60,7 @@ open class FROptions: NSObject, Codable {
         case oauthThreshold = "forgerock_oauth_threshold"
         case oauthClientId = "forgerock_oauth_client_id"
         case oauthRedirectUri = "forgerock_oauth_redirect_uri"
+        case oauthSignoutRedirectUri = "forgerock_oauth_signout_redirect_uri"
         case oauthScope = "forgerock_oauth_scope"
         case keychainAccessGroup = "forgerock_keychain_access_group"
         case sslPinningPublicKeyHashes = "forgerock_ssl_pinning_public_key_hashes"
@@ -84,6 +86,7 @@ open class FROptions: NSObject, Codable {
     ///   - oauthThreshold: OAuth Client timeout threshold
     ///   - oauthClientId: OAuth Client name
     ///   - oauthRedirectUri: OAuth Client redirectURI
+    ///   - oauthSignoutRedirectUri: OAuth Client signout redirectURI
     ///   - oauthScope: OAuth Client scopes
     ///   - keychainAccessGroup: Keychain access group for shared keychain
     ///   - sslPinningPublicKeyHashes: SSL Pinning hashes
@@ -105,6 +108,7 @@ open class FROptions: NSObject, Codable {
                 oauthThreshold: String? = nil,
                 oauthClientId: String? = nil,
                 oauthRedirectUri: String? = nil,
+                oauthSignoutRedirectUri: String? = nil,
                 oauthScope: String? = nil,
                 keychainAccessGroup: String? = nil,
                 sslPinningPublicKeyHashes: [String]? = nil) {
@@ -125,6 +129,7 @@ open class FROptions: NSObject, Codable {
         self.oauthClientId = oauthClientId
         self.oauthThreshold = oauthThreshold
         self.oauthRedirectUri = oauthRedirectUri
+        self.oauthSignoutRedirectUri = oauthSignoutRedirectUri
         self.oauthScope = oauthScope
         self.keychainAccessGroup = keychainAccessGroup
         self.sslPinningPublicKeyHashes = sslPinningPublicKeyHashes
@@ -154,6 +159,7 @@ open class FROptions: NSObject, Codable {
         self.oauthClientId = config[FROptions.CodingKeys.oauthClientId.rawValue] as? String
         self.oauthThreshold = config[FROptions.CodingKeys.oauthThreshold.rawValue] as? String
         self.oauthRedirectUri = config[FROptions.CodingKeys.oauthRedirectUri.rawValue] as? String
+        self.oauthSignoutRedirectUri = config[FROptions.CodingKeys.oauthSignoutRedirectUri.rawValue] as? String
         self.oauthScope = config[FROptions.CodingKeys.oauthScope.rawValue] as? String
         self.keychainAccessGroup = config[FROptions.CodingKeys.keychainAccessGroup.rawValue] as? String
         self.sslPinningPublicKeyHashes = config[FROptions.CodingKeys.sslPinningPublicKeyHashes.rawValue] as? [String]
@@ -231,6 +237,7 @@ open class FROptions: NSObject, Codable {
                 lhs.oauthClientId == rhs.oauthClientId &&
                 lhs.oauthScope == rhs.oauthScope &&
                 lhs.oauthRedirectUri == rhs.oauthRedirectUri &&
+                lhs.oauthSignoutRedirectUri == rhs.oauthSignoutRedirectUri &&
                 lhs.keychainAccessGroup == rhs.keychainAccessGroup)
     }
 }

--- a/FRAuth/FRAuth/Config/OAuth2Client.swift
+++ b/FRAuth/FRAuth/Config/OAuth2Client.swift
@@ -24,7 +24,7 @@ public class OAuth2Client: NSObject, Codable {
     /// OAuth2 redirect_uri for the client
     let redirectUri: URL
     /// OAuth2 signout_redirect_uri for the client
-    let signoutRredirectUri: URL?
+    let signoutRedirectUri: URL?
     /// ServerConfig which OAuth2 client will communicate to
     let serverConfig: ServerConfig
     /// Threshold to refresh access_token in advance
@@ -39,15 +39,15 @@ public class OAuth2Client: NSObject, Codable {
     ///   - clientId: client_id of the client
     ///   - scope: set of scope(s) separated by space to request for the client; requesting scope set must be registered in the OAuth2 client
     ///   - redirectUri: redirect_uri in URL object as registered in the client
-    ///   - signoutRredirectUri: optional signout_redirect_uri in URL object as registered in the client
+    ///   - signoutRedirectUri: optional signout_redirect_uri in URL object as registered in the client
     ///   - serverConfig: ServerConfig that OAuth2 Client will communicate to
     ///   - threshold: threshold in seconds to refresh access_token before it actually expires
     @objc
-  public init (clientId: String, scope: String, redirectUri: URL, signoutRredirectUri: URL? = nil, serverConfig: ServerConfig, threshold: Int = 60) {
+  public init (clientId: String, scope: String, redirectUri: URL, signoutRedirectUri: URL? = nil, serverConfig: ServerConfig, threshold: Int = 60) {
 
         self.clientId = clientId
         self.redirectUri = redirectUri
-        self.signoutRredirectUri = signoutRredirectUri
+        self.signoutRedirectUri = signoutRedirectUri
         self.scope = scope
         self.serverConfig = serverConfig
         self.threshold = threshold
@@ -470,7 +470,9 @@ public class OAuth2Client: NSObject, Codable {
     func buildEndSessionRequestForExternalAgent(idToken: String?) -> Request {
       //  Construct parameter for the request
       var parameter: [String: String] = [:]
-      parameter[OAuth2.postLogoutRedirectUri] = self.signoutRredirectUri!.absoluteString
+      if let signoutRedirectUri = self.signoutRedirectUri {
+        parameter[OAuth2.postLogoutRedirectUri] = signoutRedirectUri.absoluteString
+      }
       if let idToken, !idToken.isEmpty {
         parameter[OAuth2.idTokenHint] = idToken
       }

--- a/FRAuth/FRAuth/Constants/OAuth2.swift
+++ b/FRAuth/FRAuth/Constants/OAuth2.swift
@@ -2,7 +2,7 @@
 //  OAuth2.swift
 //  FRAuth
 //
-//  Copyright (c) 2019-2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2024 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -13,7 +13,8 @@ struct OAuth2 {
     static let clientId = "client_id"
     static let scope = "scope"
     static let redirecUri = "redirect_uri"
-    
+    static let postLogoutRedirectUri = "post_logout_redirect_uri"
+
     static let csrf = "csrf"
     static let decision = "decision"
     

--- a/FRAuth/FRAuth/FRAuth.swift
+++ b/FRAuth/FRAuth/FRAuth.swift
@@ -2,7 +2,7 @@
 //  FRAuth.swift
 //  FRAuth
 //
-//  Copyright (c) 2019-2023 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2024 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -224,7 +224,9 @@ public final class FRAuth: NSObject {
         if let thresholdConfigStr = config[FROptions.CodingKeys.oauthThreshold.rawValue] as? String, let timeOutConfigInt = Int(thresholdConfigStr) {
             threshold = timeOutConfigInt
         }
-        
+
+        let signoutRedirectUri = URL(string: config[FROptions.CodingKeys.oauthSignoutRedirectUri.rawValue] as? String ?? "")
+
         let serverConfig = configBuilder.build()
         FRLog.v("ServerConfig created: \(serverConfig)")
         var oAuth2Client: OAuth2Client?
@@ -235,7 +237,7 @@ public final class FRAuth: NSObject {
         redirectUri.absoluteString.isValidUrl,
         let scope = config[FROptions.CodingKeys.oauthScope.rawValue] as? String
         {
-            oAuth2Client = OAuth2Client(clientId: clientId, scope: scope, redirectUri: redirectUri, serverConfig: serverConfig, threshold: threshold)
+            oAuth2Client = OAuth2Client(clientId: clientId, scope: scope, redirectUri: redirectUri, signoutRredirectUri: signoutRedirectUri, serverConfig: serverConfig, threshold: threshold)
             FRLog.v("OAuth2Client created: \(String(describing: oAuth2Client))")
         }
         else {

--- a/FRAuth/FRAuth/FRAuth.swift
+++ b/FRAuth/FRAuth/FRAuth.swift
@@ -237,7 +237,7 @@ public final class FRAuth: NSObject {
         redirectUri.absoluteString.isValidUrl,
         let scope = config[FROptions.CodingKeys.oauthScope.rawValue] as? String
         {
-            oAuth2Client = OAuth2Client(clientId: clientId, scope: scope, redirectUri: redirectUri, signoutRredirectUri: signoutRedirectUri, serverConfig: serverConfig, threshold: threshold)
+            oAuth2Client = OAuth2Client(clientId: clientId, scope: scope, redirectUri: redirectUri, signoutRedirectUri: signoutRedirectUri, serverConfig: serverConfig, threshold: threshold)
             FRLog.v("OAuth2Client created: \(String(describing: oAuth2Client))")
         }
         else {

--- a/FRAuth/FRAuth/User/Browser.swift
+++ b/FRAuth/FRAuth/User/Browser.swift
@@ -171,8 +171,8 @@ import SafariServices
     public func logout(completion: @escaping UserCallback) {
       browserMode = .logout
 
-      //perform browser logout only if signoutRredirectUri is provided
-      guard self.oAuth2Client.signoutRredirectUri != nil else {
+      //perform browser logout only if signoutRedirectUri is provided
+      guard self.oAuth2Client.signoutRedirectUri != nil else {
         completion(nil, nil)
         self.cleanUp()
         return
@@ -387,7 +387,7 @@ import SafariServices
     ///   - completion: Completion callback to nofiy the result
     /// - Returns: Boolean indicator whether or not launching external user-agent was successful
     func logoutWithASWebSession(url: URL, prefersEphemeralWebBrowserSession: Bool, completion: @escaping UserCallback) -> Bool {
-      let asWebAuthSession = ASWebAuthenticationSession(url: url, callbackURLScheme: self.oAuth2Client.signoutRredirectUri!.scheme) { (url, error) in
+      let asWebAuthSession = ASWebAuthenticationSession(url: url, callbackURLScheme: self.oAuth2Client.signoutRedirectUri?.scheme) { (url, error) in
 
         if let error = error {
           FRLog.e("Failed to complete authorization using ASWebAuthenticationSession: \(error.localizedDescription)")

--- a/FRAuth/FRAuth/User/FRUser.swift
+++ b/FRAuth/FRAuth/User/FRUser.swift
@@ -2,7 +2,7 @@
 //  FRUser.swift
 //  FRAuth
 //
-//  Copyright (c) 2019-2023 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2024 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRAuth/FRAuth/User/FRUser.swift
+++ b/FRAuth/FRAuth/User/FRUser.swift
@@ -219,7 +219,24 @@ public class FRUser: NSObject, NSSecureCoding {
         // Clear Browser instance if there is anything running
         Browser.currentBrowser = nil
     }
-    
+
+    /// Logs-out currently authenticated user session. If `oauth2Clint.signoutRredirectUri` is not nil, will logout the user in the browser as well
+    ///
+    /// - Parameters:
+    ///   - presentingViewController: ViewController to present the logout broser view from
+    ///   - browserType: An external user-agent type; default to Authentication Service. This must match the browser type used during login
+    public func logout(presentingViewController: UIViewController, browserType: BrowserType = .authSession) {
+      FRUser.browser()?
+        .set(presentingViewController: presentingViewController)
+        .set(browserType: browserType)
+        .build().logout { (_, error) in
+          if let error {
+            FRLog.e("Browser logout error: \(String(describing: error))")
+          }
+          self.logout()
+        }
+    }
+
     
     //  MARK: - AccessToken
     

--- a/FRAuth/FRAuth/User/FRUser.swift
+++ b/FRAuth/FRAuth/User/FRUser.swift
@@ -220,7 +220,7 @@ public class FRUser: NSObject, NSSecureCoding {
         Browser.currentBrowser = nil
     }
 
-    /// Logs-out currently authenticated user session. If `oauth2Clint.signoutRredirectUri` is not nil, will logout the user in the browser as well
+    /// Logs-out currently authenticated user session. If `oauth2Clint.signoutRedirectUri` is not nil, will logout the user in the browser as well
     ///
     /// - Parameters:
     ///   - presentingViewController: ViewController to present the logout broser view from

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Browser/BrowserTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Browser/BrowserTests.swift
@@ -1,298 +1,391 @@
-////
-////  BrowserTests.swift
-////  FRAuthTests
-////
-////  Copyright (c) 2020 ForgeRock. All rights reserved.
-////
-////  This software may be modified and distributed under the terms
-////  of the MIT license. See the LICENSE file for details.
-////
 //
-//import XCTest
-//@testable import FRAuth
+//  BrowserTests.swift
+//  FRAuthTests
 //
-//class BrowserTests: FRAuthBaseTest {
+//  Copyright (c) 2020-2024 ForgeRock. All rights reserved.
 //
-//    override func setUp() {
-//        self.configFileName = "Config"
-//        super.setUp()
-//    }
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
 //
-//    func test_01_browser_init() {
-//
+
+import XCTest
+@testable import FRAuth
+
+class BrowserTests: FRAuthBaseTest {
+
+    override func setUp() {
+        self.configFileName = "Config"
+        super.setUp()
+    }
+
+    func test_01_browser_init() {
+
+        //  Start SDK
+        self.startSDK()
+
+        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
+            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
+            return
+        }
+
+        let vc = UIViewController()
+        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
+
+        XCTAssertNil(Browser.currentBrowser)
+        XCTAssertNotNil(browser)
+        XCTAssertEqual(browser.browserType, .sfViewController)
+        XCTAssertEqual(browser.presentingViewController, vc)
+        XCTAssertEqual(browser.customParam.count, 0)
+        XCTAssertFalse(browser.isInProgress)
+        XCTAssertNil(browser.currentSession)
+        XCTAssertNil(browser.completionCallback)
+    }
+
+
+    func test_02_browser_login_already_authenticated() {
+
+        //  Start SDK
+        self.startSDK()
+
+        //  Perform Login
+        self.performLogin()
+        XCTAssertNotNil(FRUser.currentUser?.token)
+
+        //  Construct Browser
+        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
+            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
+            return
+        }
+
+        //  Given with already authenticated session
+        let vc = UIViewController()
+        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
+
+        //  When
+        let ex = self.expectation(description: "Browser Login")
+        browser.login { (user, error) in
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+
+            if let authError = error as? AuthError {
+                switch authError {
+                case .userAlreadyAuthenticated:
+                    break
+                default:
+                    XCTFail("While expecting AuthError.userAlreadyAuthenticated; failed with different error \(authError.localizedDescription)")
+                    break
+                }
+            }
+
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+    }
+
+
+    func test_03_browser_login_already_in_progress_from_another_instance() {
+
+        //  Start SDK
+        self.startSDK()
+
+        //  Construct Browser
+        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
+            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
+            return
+        }
+
+        //  Given that another Browser instance is constructed and running
+        let firstBrowser = FRUser.browser()?.build()
+        XCTAssertNotNil(Browser.currentBrowser)
+        firstBrowser?.login(completion: { (user, error) in
+        })
+
+        let vc = UIViewController()
+        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
+        XCTAssertEqual(firstBrowser, Browser.currentBrowser)
+
+        //  When
+        let ex = self.expectation(description: "Browser Login")
+        browser.login { (user, error) in
+            XCTAssertTrue(Browser.currentBrowser?.isInProgress ?? false)
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+
+            if let browserError = error as? BrowserError {
+                switch browserError {
+                case .externalUserAgentAuthenticationInProgress:
+                    break
+                default:
+                    XCTFail("While expecting BrowserError.externalUserAgentAuthenticationInProgress; failed with different error \(browserError.localizedDescription)")
+                    break
+                }
+            }
+            else {
+                XCTFail("While expecting BrowserError.externalUserAgentAuthenticationInProgress; failed with different error \(error?.localizedDescription ?? "")")
+            }
+
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+    }
+
+
+    func test_04_same_browser_login_already_in_progress() {
+
+        //  Start SDK
+        self.startSDK()
+
+        //  Construct Browser
+        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
+            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
+            return
+        }
+
+        //  Given with already login process initiated
+        let vc = UIViewController()
+        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
+        browser.login { (user, error) in
+        }
+
+        //  When
+        let ex = self.expectation(description: "Browser Login")
+        browser.login { (user, error) in
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+
+            if let browserError = error as? BrowserError {
+                switch browserError {
+                case .externalUserAgentAuthenticationInProgress:
+                    break
+                default:
+                    XCTFail("While expecting BrowserError.externalUserAgentAuthenticationInProgress; failed with different error \(browserError.localizedDescription)")
+                    break
+                }
+            }
+            else {
+                XCTFail("While expecting BrowserError.externalUserAgentAuthenticationInProgress; failed with different error \(error?.localizedDescription ?? "")")
+            }
+
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+    }
+
+
+    func test_05_login_safari_vc_validate_auth_code() {
+
+        //  Start SDK
+        self.startSDK()
+
+        // Set mock responses
+        self.loadMockResponses(["OAuth2_Token_Success"])
+
+        //  Construct Browser
+        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
+            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
+            return
+        }
+
+        //  Given with SFSafariViewController type of Browser object
+
+        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+        var topVC = keyWindow?.rootViewController
+        while let presentedViewController = topVC?.presentedViewController {
+            topVC = presentedViewController
+        }
+
+        guard let vc = topVC else {
+            XCTFail("Failed to retrieve top most ViewController")
+            return
+        }
+
+        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
+        Browser.currentBrowser = browser
+
+        let ex = self.expectation(description: "Browser Login")
+        browser.login { (user, error) in
+            XCTAssertNotNil(user)
+            XCTAssertNil(error)
+            ex.fulfill()
+        }
+        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
+        waitForExpectations(timeout: 60, handler: nil)
+
+        XCTAssertNotNil(FRUser.currentUser)
+        XCTAssertNotNil(FRUser.currentUser?.token)
+    }
+
+
+    func test_06_login_safari_vc_validate_auth_code_no_auth_code() {
+
+        //  Start SDK
+        self.startSDK()
+
+        //  Construct Browser
+        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
+            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
+            return
+        }
+
+        //  Given with SFSafariViewController type of Browser object
+
+        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+        var topVC = keyWindow?.rootViewController
+        while let presentedViewController = topVC?.presentedViewController {
+            topVC = presentedViewController
+        }
+
+        guard let vc = topVC else {
+            XCTFail("Failed to retrieve top most ViewController")
+            return
+        }
+
+        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
+        Browser.currentBrowser = browser
+
+        let ex = self.expectation(description: "Browser Login")
+        browser.login { (user, error) in
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+
+            if let oauth2Error = error as? OAuth2Error {
+                switch oauth2Error {
+                case .unknown:
+                    break
+                default:
+                    XCTFail("While expecting OAuth2Error.unknown; failed with different error \(oauth2Error.localizedDescription)")
+                    break
+                }
+            }
+            else {
+                XCTFail("While expecting OAuth2Error.unknown; failed with different error \(error?.localizedDescription ?? "")")
+            }
+
+            ex.fulfill()
+        }
+        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login")!)
+        waitForExpectations(timeout: 60, handler: nil)
+    }
+
+
+    func test_07_login_safari_vc_cancelled() {
+
+        //  Start SDK
+        self.startSDK()
+
+        //  Construct Browser
+        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
+            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
+            return
+        }
+
+        //  Given with SFSafariViewController type of Browser object
+
+        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+        var topVC = keyWindow?.rootViewController
+        while let presentedViewController = topVC?.presentedViewController {
+            topVC = presentedViewController
+        }
+
+        guard let vc = topVC else {
+            XCTFail("Failed to retrieve top most ViewController")
+            return
+        }
+
+        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
+        Browser.currentBrowser = browser
+
+        let ex = self.expectation(description: "Browser Login")
+        browser.login { (user, error) in
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+
+            if let browserError = error as? BrowserError {
+                switch browserError {
+                case .externalUserAgentCancelled:
+                    break
+                default:
+                    XCTFail("While expecting BrowserError.externalUserAgentCancelled; failed with different error \(browserError.localizedDescription)")
+                    break
+                }
+            }
+            else {
+                XCTFail("While expecting BrowserError.externalUserAgentCancelled; failed with different error \(error?.localizedDescription ?? "")")
+            }
+
+            ex.fulfill()
+        }
+        browser.cancel()
+        waitForExpectations(timeout: 60, handler: nil)
+    }
+
+
+    func test_08_login_auth_session_cancelled() {
+
+        //  Start SDK
+        self.startSDK()
+
+        //  Construct Browser
+        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
+            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
+            return
+        }
+
+        //  Given with Authentication Framework type of Browser object
+
+        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+        var topVC = keyWindow?.rootViewController
+        while let presentedViewController = topVC?.presentedViewController {
+            topVC = presentedViewController
+        }
+
+        guard let vc = topVC else {
+            XCTFail("Failed to retrieve top most ViewController")
+            return
+        }
+
+        let browser = Browser(.authSession, oAuth2Client, keychainManager, vc)
+        Browser.currentBrowser = browser
+
+        let ex = self.expectation(description: "Browser Login")
+        browser.login { (user, error) in
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+
+            if let browserError = error as? BrowserError {
+                switch browserError {
+                case .externalUserAgentCancelled:
+                    break
+                default:
+                    XCTFail("While expecting BrowserError.externalUserAgentCancelled; failed with different error \(browserError.localizedDescription)")
+                    break
+                }
+            }
+            else {
+                XCTFail("While expecting BrowserError.externalUserAgentCancelled; failed with different error \(error?.localizedDescription ?? "")")
+            }
+
+            ex.fulfill()
+        }
+        browser.cancel()
+        waitForExpectations(timeout: 60, handler: nil)
+    }
+
+
+    func test_09_login_native_browser_cancelled() {
+
+        //  TODO: - Temporarily disable this test due to UI issue
 //        //  Start SDK
 //        self.startSDK()
-//
-//        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
-//            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
-//            return
-//        }
-//
-//        let vc = UIViewController()
-//        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
-//
-//        XCTAssertNil(Browser.currentBrowser)
-//        XCTAssertNotNil(browser)
-//        XCTAssertEqual(browser.browserType, .sfViewController)
-//        XCTAssertEqual(browser.presentingViewController, vc)
-//        XCTAssertEqual(browser.customParam.count, 0)
-//        XCTAssertFalse(browser.isInProgress)
-//        XCTAssertNil(browser.currentSession)
-//        XCTAssertNil(browser.completionCallback)
-//    }
-//
-//
-//    func test_02_browser_login_already_authenticated() {
-//
-//        //  Start SDK
-//        self.startSDK()
-//
-//        //  Perform Login
-//        self.performLogin()
-//        XCTAssertNotNil(FRUser.currentUser?.token)
 //
 //        //  Construct Browser
-//        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
-//            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
-//            return
-//        }
-//
-//        //  Given with already authenticated session
-//        let vc = UIViewController()
-//        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
-//
-//        //  When
-//        let ex = self.expectation(description: "Browser Login")
-//        browser.login { (user, error) in
-//            XCTAssertNil(user)
-//            XCTAssertNotNil(error)
-//
-//            if let authError = error as? AuthError {
-//                switch authError {
-//                case .userAlreadyAuthenticated:
-//                    break
-//                default:
-//                    XCTFail("While expecting AuthError.userAlreadyAuthenticated; failed with different error \(authError.localizedDescription)")
-//                    break
-//                }
-//            }
-//
-//            ex.fulfill()
-//        }
-//        waitForExpectations(timeout: 60, handler: nil)
-//    }
-//
-//
-//    func test_03_browser_login_already_in_progress_from_another_instance() {
-//
-//        //  Start SDK
-//        self.startSDK()
-//
-//        //  Construct Browser
-//        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
-//            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
-//            return
-//        }
-//
-//        //  Given that another Browser instance is constructed and running
-//        let firstBrowser = FRUser.browser()?.build()
-//        XCTAssertNotNil(Browser.currentBrowser)
-//        firstBrowser?.login(completion: { (user, error) in
-//        })
-//
-//        let vc = UIViewController()
-//        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
-//        XCTAssertEqual(firstBrowser, Browser.currentBrowser)
-//
-//        //  When
-//        let ex = self.expectation(description: "Browser Login")
-//        browser.login { (user, error) in
-//            XCTAssertTrue(Browser.currentBrowser?.isInProgress ?? false)
-//            XCTAssertNil(user)
-//            XCTAssertNotNil(error)
-//
-//            if let browserError = error as? BrowserError {
-//                switch browserError {
-//                case .externalUserAgentAuthenticationInProgress:
-//                    break
-//                default:
-//                    XCTFail("While expecting BrowserError.externalUserAgentAuthenticationInProgress; failed with different error \(browserError.localizedDescription)")
-//                    break
-//                }
-//            }
-//            else {
-//                XCTFail("While expecting BrowserError.externalUserAgentAuthenticationInProgress; failed with different error \(error?.localizedDescription ?? "")")
-//            }
-//
-//            ex.fulfill()
-//        }
-//        waitForExpectations(timeout: 60, handler: nil)
-//    }
-//
-//
-//    func test_04_same_browser_login_already_in_progress() {
-//
-//        //  Start SDK
-//        self.startSDK()
-//
-//        //  Construct Browser
-//        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
-//            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
-//            return
-//        }
-//
-//        //  Given with already login process initiated
-//        let vc = UIViewController()
-//        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
-//        browser.login { (user, error) in
-//        }
-//
-//        //  When
-//        let ex = self.expectation(description: "Browser Login")
-//        browser.login { (user, error) in
-//            XCTAssertNil(user)
-//            XCTAssertNotNil(error)
-//
-//            if let browserError = error as? BrowserError {
-//                switch browserError {
-//                case .externalUserAgentAuthenticationInProgress:
-//                    break
-//                default:
-//                    XCTFail("While expecting BrowserError.externalUserAgentAuthenticationInProgress; failed with different error \(browserError.localizedDescription)")
-//                    break
-//                }
-//            }
-//            else {
-//                XCTFail("While expecting BrowserError.externalUserAgentAuthenticationInProgress; failed with different error \(error?.localizedDescription ?? "")")
-//            }
-//
-//            ex.fulfill()
-//        }
-//        waitForExpectations(timeout: 60, handler: nil)
-//    }
-//
-//
-//    func test_05_login_safari_vc_validate_auth_code() {
-//
-//        //  Start SDK
-//        self.startSDK()
-//
-//        // Set mock responses
-//        self.loadMockResponses(["OAuth2_Token_Success"])
-//
-//        //  Construct Browser
-//        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
-//            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
+//        guard let oAuth2Client = self.config.oAuth2Client, let sessionManager = self.config.sessionManager else {
+//            XCTFail("Failed to retrieve OAuth2Client, and/or SessionManager instance after SDK init")
 //            return
 //        }
 //
 //        //  Given with SFSafariViewController type of Browser object
-//
-//        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-//        var topVC = keyWindow?.rootViewController
-//        while let presentedViewController = topVC?.presentedViewController {
-//            topVC = presentedViewController
-//        }
-//
-//        guard let vc = topVC else {
-//            XCTFail("Failed to retrieve top most ViewController")
-//            return
-//        }
-//
-//        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
-//        Browser.currentBrowser = browser
-//
-//        let ex = self.expectation(description: "Browser Login")
-//        browser.login { (user, error) in
-//            XCTAssertNotNil(user)
-//            XCTAssertNil(error)
-//            ex.fulfill()
-//        }
-//        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
-//        waitForExpectations(timeout: 60, handler: nil)
-//
-//        XCTAssertNotNil(FRUser.currentUser)
-//        XCTAssertNotNil(FRUser.currentUser?.token)
-//    }
-//
-//
-//    func test_06_login_safari_vc_validate_auth_code_no_auth_code() {
-//
-//        //  Start SDK
-//        self.startSDK()
-//
-//        //  Construct Browser
-//        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
-//            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
-//            return
-//        }
-//
-//        //  Given with SFSafariViewController type of Browser object
-//
-//        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-//        var topVC = keyWindow?.rootViewController
-//        while let presentedViewController = topVC?.presentedViewController {
-//            topVC = presentedViewController
-//        }
-//
-//        guard let vc = topVC else {
-//            XCTFail("Failed to retrieve top most ViewController")
-//            return
-//        }
-//
-//        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
-//        Browser.currentBrowser = browser
-//
-//        let ex = self.expectation(description: "Browser Login")
-//        browser.login { (user, error) in
-//            XCTAssertNil(user)
-//            XCTAssertNotNil(error)
-//
-//            if let oauth2Error = error as? OAuth2Error {
-//                switch oauth2Error {
-//                case .unknown:
-//                    break
-//                default:
-//                    XCTFail("While expecting OAuth2Error.unknown; failed with different error \(oauth2Error.localizedDescription)")
-//                    break
-//                }
-//            }
-//            else {
-//                XCTFail("While expecting OAuth2Error.unknown; failed with different error \(error?.localizedDescription ?? "")")
-//            }
-//
-//            ex.fulfill()
-//        }
-//        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login")!)
-//        waitForExpectations(timeout: 60, handler: nil)
-//    }
-//
-//
-//    func test_07_login_safari_vc_cancelled() {
-//
-//        //  Start SDK
-//        self.startSDK()
-//
-//        //  Construct Browser
-//        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
-//            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
-//            return
-//        }
-//
-//        //  Given with SFSafariViewController type of Browser object
-//
-//        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-//        var topVC = keyWindow?.rootViewController
-//        while let presentedViewController = topVC?.presentedViewController {
-//            topVC = presentedViewController
-//        }
-//
-//        guard let vc = topVC else {
-//            XCTFail("Failed to retrieve top most ViewController")
-//            return
-//        }
-//
-//        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, vc)
+//        let browser = Browser(.nativeBrowserApp, oAuth2Client, sessionManager, UIViewController())
 //        Browser.currentBrowser = browser
 //
 //        let ex = self.expectation(description: "Browser Login")
@@ -317,188 +410,122 @@
 //        }
 //        browser.cancel()
 //        waitForExpectations(timeout: 60, handler: nil)
-//    }
-//
-//
-//    func test_08_login_auth_session_cancelled() {
-//
-//        //  Start SDK
-//        self.startSDK()
-//
-//        //  Construct Browser
-//        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
-//            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
-//            return
-//        }
-//
-//        //  Given with Authentication Framework type of Browser object
-//
-//        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-//        var topVC = keyWindow?.rootViewController
-//        while let presentedViewController = topVC?.presentedViewController {
-//            topVC = presentedViewController
-//        }
-//
-//        guard let vc = topVC else {
-//            XCTFail("Failed to retrieve top most ViewController")
-//            return
-//        }
-//
-//        let browser = Browser(.authSession, oAuth2Client, keychainManager, vc)
-//        Browser.currentBrowser = browser
-//
-//        let ex = self.expectation(description: "Browser Login")
-//        browser.login { (user, error) in
-//            XCTAssertNil(user)
-//            XCTAssertNotNil(error)
-//
-//            if let browserError = error as? BrowserError {
-//                switch browserError {
-//                case .externalUserAgentCancelled:
-//                    break
-//                default:
-//                    XCTFail("While expecting BrowserError.externalUserAgentCancelled; failed with different error \(browserError.localizedDescription)")
-//                    break
-//                }
-//            }
-//            else {
-//                XCTFail("While expecting BrowserError.externalUserAgentCancelled; failed with different error \(error?.localizedDescription ?? "")")
-//            }
-//
-//            ex.fulfill()
-//        }
-//        browser.cancel()
-//        waitForExpectations(timeout: 60, handler: nil)
-//    }
-//
-//
-//    func test_09_login_native_browser_cancelled() {
-//
-//        //  TODO: - Temporarily disable this test due to UI issue
-////        //  Start SDK
-////        self.startSDK()
-////
-////        //  Construct Browser
-////        guard let oAuth2Client = self.config.oAuth2Client, let sessionManager = self.config.sessionManager else {
-////            XCTFail("Failed to retrieve OAuth2Client, and/or SessionManager instance after SDK init")
-////            return
-////        }
-////
-////        //  Given with SFSafariViewController type of Browser object
-////        let browser = Browser(.nativeBrowserApp, oAuth2Client, sessionManager, UIViewController())
-////        Browser.currentBrowser = browser
-////
-////        let ex = self.expectation(description: "Browser Login")
-////        browser.login { (user, error) in
-////            XCTAssertNil(user)
-////            XCTAssertNotNil(error)
-////
-////            if let browserError = error as? BrowserError {
-////                switch browserError {
-////                case .externalUserAgentCancelled:
-////                    break
-////                default:
-////                    XCTFail("While expecting BrowserError.externalUserAgentCancelled; failed with different error \(browserError.localizedDescription)")
-////                    break
-////                }
-////            }
-////            else {
-////                XCTFail("While expecting BrowserError.externalUserAgentCancelled; failed with different error \(error?.localizedDescription ?? "")")
-////            }
-////
-////            ex.fulfill()
-////        }
-////        browser.cancel()
-////        waitForExpectations(timeout: 60, handler: nil)
-//    }
-//
-//
-//    func test_10_cancel_while_not_in_progress() {
-//
-//        //  Start SDK
-//        self.startSDK()
-//
-//        //  Construct Browser
-//        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
-//            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
-//            return
-//        }
-//
-//        //  Given with SFSafariViewController type of Browser object
-//        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, UIViewController())
-//
-//        //  Try
-//        browser.cancel()
-//
-//        //  Then, try cancel while in progress
-//        let ex = self.expectation(description: "Browser Login")
-//        browser.login { (user, error) in
-//            XCTAssertNil(user)
-//            XCTAssertNotNil(error)
-//
-//            if let browserError = error as? BrowserError {
-//                switch browserError {
-//                case .externalUserAgentCancelled:
-//                    break
-//                default:
-//                    XCTFail("While expecting BrowserError.externalUserAgentCancelled; failed with different error \(browserError.localizedDescription)")
-//                    break
-//                }
-//            }
-//            else {
-//                XCTFail("While expecting BrowserError.externalUserAgentCancelled; failed with different error \(error?.localizedDescription ?? "")")
-//            }
-//
-//            ex.fulfill()
-//        }
-//        browser.cancel()
-//        waitForExpectations(timeout: 60, handler: nil)
-//    }
-//
-//
-//    func test_11_build_authorize_request() {
-//
-//        //  Start SDK
-//        self.startSDK()
-//
-//        //  Construct Browser
-//        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
-//            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
-//            return
-//        }
-//
-//        //  Givne
-//        let browser = BrowserBuilder(oAuth2Client, keychainManager).set(browserType: .authSession).setCustomParam(key: "key1", value: "value1").setCustomParam(key: "prompt", value: "login").build()
-//        let authorizeURL = browser.buildAuthorizeRequestURL()
-//
-//        //  Then
-//        XCTAssertNotNil(authorizeURL)
-//        XCTAssertNotNil(authorizeURL?.absoluteString)
-//        //  Validate custom URL query params
-//        XCTAssertNotNil(authorizeURL?.valueOf("key1"))
-//        XCTAssertEqual(authorizeURL?.valueOf("key1"), "value1")
-//        XCTAssertNotNil(authorizeURL?.valueOf("prompt"))
-//        XCTAssertEqual(authorizeURL?.valueOf("prompt"), "login")
-//        //  Validate PKCE
-//        XCTAssertNotNil(authorizeURL?.valueOf("state"))
-//        XCTAssertEqual(authorizeURL?.valueOf("state"), browser.pkce.state)
-//        XCTAssertNotNil(authorizeURL?.valueOf("code_challenge"))
-//        XCTAssertEqual(authorizeURL?.valueOf("code_challenge"), browser.pkce.codeChallenge)
-//        XCTAssertNotNil(authorizeURL?.valueOf("code_challenge_method"))
-//        XCTAssertEqual(authorizeURL?.valueOf("code_challenge_method"), browser.pkce.codeChallengeMethod)
-//        //  Validate OAuth2 client information
-//        XCTAssertNotNil(authorizeURL?.valueOf("redirect_uri"))
-//        XCTAssertEqual(authorizeURL?.valueOf("redirect_uri"), oAuth2Client.redirectUri.absoluteString)
-//        XCTAssertNotNil(authorizeURL?.valueOf("client_id"))
-//        XCTAssertEqual(authorizeURL?.valueOf("client_id"), oAuth2Client.clientId)
-//        XCTAssertNotNil(authorizeURL?.valueOf("scope"))
-//        XCTAssertEqual(authorizeURL?.valueOf("scope"), oAuth2Client.scope)
-//        XCTAssertNotNil(authorizeURL?.valueOf("response_type"))
-//        XCTAssertEqual(authorizeURL?.valueOf("response_type"), "code")
-//    }
-//
-//
-//    func test_12_should_manual_cleanup() {
-//        self.shouldCleanup = true
-//    }
-//}
+    }
+
+
+    func test_10_cancel_while_not_in_progress() {
+
+        //  Start SDK
+        self.startSDK()
+
+        //  Construct Browser
+        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
+            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
+            return
+        }
+
+        //  Given with SFSafariViewController type of Browser object
+        let browser = Browser(.sfViewController, oAuth2Client, keychainManager, UIViewController())
+
+        //  Try
+        browser.cancel()
+
+        //  Then, try cancel while in progress
+        let ex = self.expectation(description: "Browser Login")
+        browser.login { (user, error) in
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+
+            if let browserError = error as? BrowserError {
+                switch browserError {
+                case .externalUserAgentCancelled:
+                    break
+                default:
+                    XCTFail("While expecting BrowserError.externalUserAgentCancelled; failed with different error \(browserError.localizedDescription)")
+                    break
+                }
+            }
+            else {
+                XCTFail("While expecting BrowserError.externalUserAgentCancelled; failed with different error \(error?.localizedDescription ?? "")")
+            }
+
+            ex.fulfill()
+        }
+        browser.cancel()
+        waitForExpectations(timeout: 60, handler: nil)
+    }
+
+
+    func test_11_build_authorize_request() {
+
+        //  Start SDK
+        self.startSDK()
+
+        //  Construct Browser
+        guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
+            XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
+            return
+        }
+
+        //  Givne
+        let browser = BrowserBuilder(oAuth2Client, keychainManager).set(browserType: .authSession).setCustomParam(key: "key1", value: "value1").setCustomParam(key: "prompt", value: "login").build()
+        let authorizeURL = browser.buildAuthorizeRequestURL()
+
+        //  Then
+        XCTAssertNotNil(authorizeURL)
+        XCTAssertNotNil(authorizeURL?.absoluteString)
+        //  Validate custom URL query params
+        XCTAssertNotNil(authorizeURL?.valueOf("key1"))
+        XCTAssertEqual(authorizeURL?.valueOf("key1"), "value1")
+        XCTAssertNotNil(authorizeURL?.valueOf("prompt"))
+        XCTAssertEqual(authorizeURL?.valueOf("prompt"), "login")
+        //  Validate PKCE
+        XCTAssertNotNil(authorizeURL?.valueOf("state"))
+        XCTAssertEqual(authorizeURL?.valueOf("state"), browser.pkce.state)
+        XCTAssertNotNil(authorizeURL?.valueOf("code_challenge"))
+        XCTAssertEqual(authorizeURL?.valueOf("code_challenge"), browser.pkce.codeChallenge)
+        XCTAssertNotNil(authorizeURL?.valueOf("code_challenge_method"))
+        XCTAssertEqual(authorizeURL?.valueOf("code_challenge_method"), browser.pkce.codeChallengeMethod)
+        //  Validate OAuth2 client information
+        XCTAssertNotNil(authorizeURL?.valueOf("redirect_uri"))
+        XCTAssertEqual(authorizeURL?.valueOf("redirect_uri"), oAuth2Client.redirectUri.absoluteString)
+        XCTAssertNotNil(authorizeURL?.valueOf("client_id"))
+        XCTAssertEqual(authorizeURL?.valueOf("client_id"), oAuth2Client.clientId)
+        XCTAssertNotNil(authorizeURL?.valueOf("scope"))
+        XCTAssertEqual(authorizeURL?.valueOf("scope"), oAuth2Client.scope)
+        XCTAssertNotNil(authorizeURL?.valueOf("response_type"))
+        XCTAssertEqual(authorizeURL?.valueOf("response_type"), "code")
+    }
+
+
+    func test_12_should_manual_cleanup() {
+        self.shouldCleanup = true
+    }
+
+  func test_13_build_end_session_request() {
+
+      //  Start SDK
+      self.startSDK()
+
+      //  Construct Browser
+      guard let oAuth2Client = self.config.oAuth2Client, let keychainManager = self.config.keychainManager else {
+          XCTFail("Failed to retrieve OAuth2Client, and/or KeychainManager instance after SDK init")
+          return
+      }
+
+      //  Givne
+      let browser = BrowserBuilder(oAuth2Client, keychainManager).set(browserType: .authSession).build()
+    let authorizeURL = browser.buildEndSessionRequestURL(idToken: "idToken")
+
+      //  Then
+      XCTAssertNotNil(authorizeURL)
+      XCTAssertNotNil(authorizeURL?.absoluteString)
+      //  Validate Id Token Hint
+      XCTAssertNotNil(authorizeURL?.valueOf("id_token_hint"))
+      XCTAssertEqual(authorizeURL?.valueOf("id_token_hint"), "idToken")
+      //  Validate OAuth2 client information
+      XCTAssertNotNil(authorizeURL?.valueOf("post_logout_redirect_uri"))
+      XCTAssertEqual(authorizeURL?.valueOf("post_logout_redirect_uri"), oAuth2Client.signoutRredirectUri?.absoluteString)
+
+  }
+}

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Browser/BrowserTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Browser/BrowserTests.swift
@@ -527,7 +527,7 @@ class BrowserTests: FRAuthBaseTest {
       XCTAssertEqual(authorizeURL?.valueOf("id_token_hint"), "idToken")
       //  Validate OAuth2 client information
       XCTAssertNotNil(authorizeURL?.valueOf("post_logout_redirect_uri"))
-      XCTAssertEqual(authorizeURL?.valueOf("post_logout_redirect_uri"), oAuth2Client.signoutRredirectUri?.absoluteString)
+      XCTAssertEqual(authorizeURL?.valueOf("post_logout_redirect_uri"), oAuth2Client.signoutRedirectUri?.absoluteString)
 
   }
 }

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Browser/BrowserTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Browser/BrowserTests.swift
@@ -83,6 +83,7 @@ class BrowserTests: FRAuthBaseTest {
     }
 
 
+    @available(iOS 13, *)
     func test_03_browser_login_already_in_progress_from_another_instance() {
 
         //  Start SDK
@@ -95,7 +96,7 @@ class BrowserTests: FRAuthBaseTest {
         }
 
         //  Given that another Browser instance is constructed and running
-        let firstBrowser = FRUser.browser()?.build()
+        let firstBrowser = FRUser.browser()?.set(browserType: .ephemeralAuthSession).build()
         XCTAssertNotNil(Browser.currentBrowser)
         firstBrowser?.login(completion: { (user, error) in
         })
@@ -320,6 +321,7 @@ class BrowserTests: FRAuthBaseTest {
     }
 
 
+    @available(iOS 13, *)
     func test_08_login_auth_session_cancelled() {
 
         //  Start SDK
@@ -344,7 +346,7 @@ class BrowserTests: FRAuthBaseTest {
             return
         }
 
-        let browser = Browser(.authSession, oAuth2Client, keychainManager, vc)
+        let browser = Browser(.ephemeralAuthSession, oAuth2Client, keychainManager, vc)
         Browser.currentBrowser = browser
 
         let ex = self.expectation(description: "Browser Login")
@@ -515,7 +517,7 @@ class BrowserTests: FRAuthBaseTest {
 
       //  Givne
       let browser = BrowserBuilder(oAuth2Client, keychainManager).set(browserType: .authSession).build()
-    let authorizeURL = browser.buildEndSessionRequestURL(idToken: "idToken")
+      let authorizeURL = browser.buildEndSessionRequestURL(idToken: "idToken")
 
       //  Then
       XCTAssertNotNil(authorizeURL)

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FRAuth/FRAuthTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FRAuth/FRAuthTests.swift
@@ -589,7 +589,7 @@ class FRAuthTests: FRAuthBaseTest {
 
       // Given
       var config = self.readConfigFile(fileName: "FRAuthConfig")
-      config["forgerock_oauth_signout_redirect_uri"] = "invalid url"
+      config["forgerock_oauth_sign_out_redirect_uri"] = "invalid url"
 
       var initError: Error?
 
@@ -612,7 +612,7 @@ class FRAuthTests: FRAuthBaseTest {
 
       // Given
       initError = nil
-      config.removeValue(forKey: "forgerock_oauth_signout_redirect_uri")
+      config.removeValue(forKey: "forgerock_oauth_sign_out_redirect_uri")
 
       // Then
       do {

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FRAuth/FRAuthTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FRAuth/FRAuthTests.swift
@@ -583,4 +583,52 @@ class FRAuthTests: FRAuthBaseTest {
     XCTAssertNotNil(frAuth.oAuth2Client)
     XCTAssertNotNil(frAuth.tokenManager)
   }
+
+
+  func testFRStartWithMissingOrInvalidSignoutRedirectURL() {
+
+      // Given
+      var config = self.readConfigFile(fileName: "FRAuthConfig")
+      config["forgerock_oauth_signout_redirect_uri"] = "invalid url"
+
+      var initError: Error?
+
+      // Then
+      do {
+          try FRAuth.initPrivate(config: config)
+      }
+      catch {
+          initError = error
+      }
+
+      // It should
+      guard let frAtuh = FRAuth.shared else {
+          XCTFail("FRAuth shared instance is returned nil")
+          return
+      }
+      XCTAssertNotNil(frAtuh.oAuth2Client)
+      XCTAssertNotNil(frAtuh.tokenManager)
+      XCTAssertNil(initError)
+
+      // Given
+      initError = nil
+      config.removeValue(forKey: "forgerock_oauth_signout_redirect_uri")
+
+      // Then
+      do {
+          try FRAuth.initPrivate(config: config)
+      }
+      catch {
+          initError = error
+      }
+
+      // It should
+      guard let frAtuhWithNoUri = FRAuth.shared else {
+          XCTFail("FRAuth shared instance is returned nil")
+          return
+      }
+      XCTAssertNotNil(frAtuhWithNoUri.oAuth2Client)
+      XCTAssertNotNil(frAtuhWithNoUri.tokenManager)
+      XCTAssertNil(initError)
+  }
 }

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FROptions/FROptionsTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FROptions/FROptionsTests.swift
@@ -89,8 +89,8 @@ class FROptionsTests: FRAuthBaseTest {
     
     func testDynamicConfigComplete() {
         do {
-            let options = FROptions(url: "https://openam-forgerock-sdks/", realm: "alpha", enableCookie: true, cookieName: "CookieName", timeout: "35", authenticateEndpoint: "json/authenticate", authorizeEndpoint: "json/authorize", tokenEndpoint: "json/accessToken", revokeEndpoint: "json/revoke", userinfoEndpoint: "json/userinfo", sessionEndpoint: "json/session", authServiceName: "LoginTest", registrationServiceName: "RegisterTest", oauthThreshold: "62", oauthClientId: "iOSClient", oauthRedirectUri: "frauth://com.forgerock.ios.frexample", oauthScope: "openid profile email address", keychainAccessGroup: "com.bitbar.*", sslPinningPublicKeyHashes: ["hash1", "hash2"])
-            
+            let options = FROptions(url: "https://openam-forgerock-sdks/", realm: "alpha", enableCookie: true, cookieName: "CookieName", timeout: "35", authenticateEndpoint: "json/authenticate", authorizeEndpoint: "json/authorize", tokenEndpoint: "json/accessToken", revokeEndpoint: "json/revoke", userinfoEndpoint: "json/userinfo", sessionEndpoint: "json/session", authServiceName: "LoginTest", registrationServiceName: "RegisterTest", oauthThreshold: "62", oauthClientId: "iOSClient", oauthRedirectUri: "frauth://com.forgerock.ios.frexample", oauthSignoutRedirectUri: "frauth://com.forgerock.ios.frexample.signout", oauthScope: "openid profile email address", keychainAccessGroup: "com.bitbar.*", sslPinningPublicKeyHashes: ["hash1", "hash2"])
+
             
             self.dictionaryMatches(options: options)
             
@@ -113,6 +113,7 @@ class FROptionsTests: FRAuthBaseTest {
             XCTAssertTrue(options.oauthThreshold == "62")
             XCTAssertTrue(options.oauthClientId == "iOSClient")
             XCTAssertTrue(options.oauthRedirectUri == "frauth://com.forgerock.ios.frexample")
+            XCTAssertTrue(options.oauthSignoutRedirectUri == "frauth://com.forgerock.ios.frexample.signout")
             XCTAssertTrue(options.oauthScope == "openid profile email address")
             XCTAssertTrue(options.keychainAccessGroup == "com.bitbar.*")
             XCTAssertTrue(options.sslPinningPublicKeyHashes?[0] == "hash1")
@@ -262,6 +263,7 @@ class FROptionsTests: FRAuthBaseTest {
         XCTAssertTrue(options.oauthThreshold == optionsDict?["forgerock_oauth_threshold"] as? String)
         XCTAssertTrue(options.oauthClientId == optionsDict?["forgerock_oauth_client_id"] as? String)
         XCTAssertTrue(options.oauthRedirectUri == optionsDict?["forgerock_oauth_redirect_uri"] as? String)
+        XCTAssertTrue(options.oauthSignoutRedirectUri == optionsDict?["forgerock_oauth_signout_redirect_uri"] as? String)
         XCTAssertTrue(options.oauthScope == optionsDict?["forgerock_oauth_scope"] as? String)
         XCTAssertTrue(options.keychainAccessGroup == optionsDict?["forgerock_keychain_access_group"] as? String)
         XCTAssertTrue(options.sslPinningPublicKeyHashes == optionsDict?["forgerock_ssl_pinning_public_key_hashes"] as? [String])
@@ -296,6 +298,7 @@ class FROptionsTests: FRAuthBaseTest {
         XCTAssertEqual(frAuth?.serverConfig.timeout , Double(updatedOptions.timeout))
         XCTAssertEqual(frAuth?.oAuth2Client?.scope , updatedOptions.oauthScope)
         XCTAssertEqual(frAuth?.oAuth2Client?.redirectUri.absoluteString , updatedOptions.oauthRedirectUri)
+        XCTAssertEqual(frAuth?.oAuth2Client?.signoutRredirectUri?.absoluteString , updatedOptions.oauthSignoutRedirectUri)
         XCTAssertEqual(frAuth?.oAuth2Client?.clientId , updatedOptions.oauthClientId)
         XCTAssertEqual(frAuth?.oAuth2Client?.threshold , Int(updatedOptions.oauthThreshold ?? "60"))
         XCTAssertNotNil(frAuth?.tokenManager)
@@ -329,6 +332,7 @@ class FROptionsTests: FRAuthBaseTest {
     let config =
     ["forgerock_oauth_client_id":"test_client_id",
      "forgerock_oauth_redirect_uri": "org.forgerock.demo://oauth2redirect",
+     "forgerock_oauth_signout_redirect_uri": "org.forgerock.demo2://oauth2redirect",
      "forgerock_oauth_scope" : "openid profile email address",
      "forgerock_authorize_endpoint": "test",
      "forgerock_token_endpoint": "test",
@@ -341,6 +345,7 @@ class FROptionsTests: FRAuthBaseTest {
     options = try await options.discover(discoveryURL: validURL)
     XCTAssertEqual(options.oauthClientId, "test_client_id")
     XCTAssertEqual(options.oauthRedirectUri, "org.forgerock.demo://oauth2redirect")
+    XCTAssertEqual(options.oauthSignoutRedirectUri, "org.forgerock.demo2://oauth2redirect")
     XCTAssertEqual(options.oauthScope, "openid profile email address")
     XCTAssertEqual(options.url, FRTestURL.oidcConfigUrl)
     XCTAssertEqual(options.authorizeEndpoint, FRTestURL.oidcConfigUrl +  "/oauth/authorize")

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FROptions/FROptionsTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FROptions/FROptionsTests.swift
@@ -298,7 +298,7 @@ class FROptionsTests: FRAuthBaseTest {
         XCTAssertEqual(frAuth?.serverConfig.timeout , Double(updatedOptions.timeout))
         XCTAssertEqual(frAuth?.oAuth2Client?.scope , updatedOptions.oauthScope)
         XCTAssertEqual(frAuth?.oAuth2Client?.redirectUri.absoluteString , updatedOptions.oauthRedirectUri)
-        XCTAssertEqual(frAuth?.oAuth2Client?.signoutRredirectUri?.absoluteString , updatedOptions.oauthSignoutRedirectUri)
+        XCTAssertEqual(frAuth?.oAuth2Client?.signoutRedirectUri?.absoluteString , updatedOptions.oauthSignoutRedirectUri)
         XCTAssertEqual(frAuth?.oAuth2Client?.clientId , updatedOptions.oauthClientId)
         XCTAssertEqual(frAuth?.oAuth2Client?.threshold , Int(updatedOptions.oauthThreshold ?? "60"))
         XCTAssertNotNil(frAuth?.tokenManager)

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FROptions/FROptionsTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/FROptions/FROptionsTests.swift
@@ -263,7 +263,7 @@ class FROptionsTests: FRAuthBaseTest {
         XCTAssertTrue(options.oauthThreshold == optionsDict?["forgerock_oauth_threshold"] as? String)
         XCTAssertTrue(options.oauthClientId == optionsDict?["forgerock_oauth_client_id"] as? String)
         XCTAssertTrue(options.oauthRedirectUri == optionsDict?["forgerock_oauth_redirect_uri"] as? String)
-        XCTAssertTrue(options.oauthSignoutRedirectUri == optionsDict?["forgerock_oauth_signout_redirect_uri"] as? String)
+        XCTAssertTrue(options.oauthSignoutRedirectUri == optionsDict?["forgerock_oauth_sign_out_redirect_uri"] as? String)
         XCTAssertTrue(options.oauthScope == optionsDict?["forgerock_oauth_scope"] as? String)
         XCTAssertTrue(options.keychainAccessGroup == optionsDict?["forgerock_keychain_access_group"] as? String)
         XCTAssertTrue(options.sslPinningPublicKeyHashes == optionsDict?["forgerock_ssl_pinning_public_key_hashes"] as? [String])
@@ -332,7 +332,7 @@ class FROptionsTests: FRAuthBaseTest {
     let config =
     ["forgerock_oauth_client_id":"test_client_id",
      "forgerock_oauth_redirect_uri": "org.forgerock.demo://oauth2redirect",
-     "forgerock_oauth_signout_redirect_uri": "org.forgerock.demo2://oauth2redirect",
+     "forgerock_oauth_sign_out_redirect_uri": "org.forgerock.demo2://oauth2redirect",
      "forgerock_oauth_scope" : "openid profile email address",
      "forgerock_authorize_endpoint": "test",
      "forgerock_token_endpoint": "test",

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Model/User/FRUserBrowserTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Model/User/FRUserBrowserTests.swift
@@ -1,250 +1,137 @@
-//// 
-////  FRUserBrowserTests.swift
-////  FRAuthTests
-////
-////  Copyright (c) 2020 ForgeRock. All rights reserved.
-////
-////  This software may be modified and distributed under the terms
-////  of the MIT license. See the LICENSE file for details.
-////
+// 
+//  FRUserBrowserTests.swift
+//  FRAuthTests
 //
+//  Copyright (c) 2020-2024 ForgeRock. All rights reserved.
 //
-//import XCTest
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
 //
-//class FRUserBrowserTests: FRBaseTest {
-//    
-//    override func setUp() {
-//        self.configFileName = "Config"
-//        super.setUp()
-//    }
-//    
-//    
-//    func test_01_fruser_browser_init() {
-//        FRAuth.shared = nil
-//        
-//        //  Given no SDK init
-//        let builder = FRUser.browser()
-//        XCTAssertNil(builder)
-//        
-//        //  When
-//        self.startSDK()
-//        
-//        //  Then
-//        let builder2 = FRUser.browser()
-//        XCTAssertNotNil(builder2)
-//        
-//        //  Can also
-//        let builder3 = FRUser.browser()
-//        XCTAssertNotNil(builder3)
-//        
-//        //  If
-//        let browser = builder2?.build()
-//        
-//        //  Then
-//        let builder4 = FRUser.browser()
-//        XCTAssertNil(builder4)
-//        XCTAssertNotNil(Browser.currentBrowser)
-//        XCTAssertEqual(Browser.currentBrowser, browser)
-//    }
-//    
-//    
-//    func test_02_fruser_browser_login_and_logout_success() {
-//        
+
+
+import XCTest
+@testable import FRAuth
+
+class FRUserBrowserTests: FRAuthBaseTest {
+
+    override func setUp() {
+        self.configFileName = "Config"
+        super.setUp()
+    }
+    
+    
+    func test_01_fruser_browser_init() {
+        FRAuth.shared = nil
+        
+        //  Given no SDK init
+        let builder = FRUser.browser()
+        XCTAssertNil(builder)
+        
+        //  When
+        self.startSDK()
+        
+        //  Then
+        let builder2 = FRUser.browser()
+        XCTAssertNotNil(builder2)
+        
+        //  Can also
+        let builder3 = FRUser.browser()
+        XCTAssertNotNil(builder3)
+        
+        //  If
+        let browser = builder2?.build()
+        
+        //  Then
+        let builder4 = FRUser.browser()
+        XCTAssertNil(builder4)
+        XCTAssertNotNil(Browser.currentBrowser)
+        XCTAssertEqual(Browser.currentBrowser, browser)
+    }
+    
+    
+  @available(iOS 13, *)
+  func test_02_fruser_browser_login_and_logout_success() {
+        
+        //  SDK init
+        self.startSDK()
+        
+        // Set mock responses
+        self.loadMockResponses(["OAuth2_Token_Success",
+                                "AM_Session_Logout_Success",
+                                "OAuth2_Token_Revoke_Success",
+                                "OAuth2_EndSession_Success"])
+        
+        let ex = self.expectation(description: "Browser Login")
+        let _ = FRUser.browser()?.set(browserType: .ephemeralAuthSession).build().login(completion: { (user, error) in
+            XCTAssertNil(error)
+            XCTAssertNotNil(user)
+            ex.fulfill()
+        })
+        //  Inject authorization_code to mimic browser authentication
+        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+        XCTAssertNil(Browser.currentBrowser)
+        
+        FRUser.currentUser?.logout()
+        
+        // Sleep for 5 seconds to wait for async logout requests go through
+        sleep(5)
+        
+        XCTAssertNil(FRUser.currentUser)
+        XCTAssertNil(Browser.currentBrowser)
+    }
+    
+    
+  @available(iOS 13, *)
+  func test_03_fruser_browser_login_and_logout_end_session_failure() {
+        
+        //  SDK init
+        self.startSDK()
+        
+        // Set mock responses
+        self.loadMockResponses(["OAuth2_Token_Success",
+                                "OAuth2_Token_Revoke_Success",
+                                "OAuth2_EndSession_Failure"])
+        
+        let ex = self.expectation(description: "Browser Login")
+        let _ = FRUser.browser()?.set(browserType: .ephemeralAuthSession).build().login(completion: { (user, error) in
+            XCTAssertNotNil(user)
+            XCTAssertNil(error)
+            ex.fulfill()
+        })
+        //  Inject authorization_code to mimic browser authentication
+        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+        XCTAssertNil(Browser.currentBrowser)
+        
+        FRUser.currentUser?.logout()
+        
+        // Sleep for 5 seconds to wait for async logout requests go through
+        sleep(5)
+        
+        XCTAssertNil(FRUser.currentUser)
+        XCTAssertNil(Browser.currentBrowser)
+    }
+    
+    
+    func test_04_consecutive_browser_login_with_different_browser_type() {
+        
+        //  TODO: - Temporarily disable this test due to UI issue
 //        //  SDK init
 //        self.startSDK()
-//        
+//
 //        // Set mock responses
 //        self.loadMockResponses(["OAuth2_Token_Success",
-//                                "AM_Session_Logout_Success",
-//                                "OAuth2_Token_Revoke_Success",
-//                                "OAuth2_EndSession_Success"])
-//        
-//        let ex = self.expectation(description: "Browser Login")
-//        let _ = FRUser.browser()?.set(browserType: .authSession).build().login(completion: { (user, error) in
-//            XCTAssertNil(error)
-//            XCTAssertNotNil(user)
-//            ex.fulfill()
-//        })
-//        //  Inject authorization_code to mimic browser authentication
-//        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
-//        waitForExpectations(timeout: 60, handler: nil)
-//        
-//        XCTAssertNotNil(FRUser.currentUser)
-//        XCTAssertNil(Browser.currentBrowser)
-//        
-//        FRUser.currentUser?.logout()
-//        
-//        // Sleep for 5 seconds to wait for async logout requests go through
-//        sleep(5)
-//        
-//        XCTAssertNil(FRUser.currentUser)
-//        XCTAssertNil(Browser.currentBrowser)
-//    }
-//    
-//    
-//    func test_03_fruser_browser_login_and_logout_end_session_failure() {
-//        
-//        //  SDK init
-//        self.startSDK()
-//        
-//        // Set mock responses
-//        self.loadMockResponses(["OAuth2_Token_Success",
-//                                "OAuth2_Token_Revoke_Success",
-//                                "OAuth2_EndSession_Failure"])
-//        
-//        let ex = self.expectation(description: "Browser Login")
-//        let _ = FRUser.browser()?.set(browserType: .authSession).build().login(completion: { (user, error) in
-//            XCTAssertNotNil(user)
-//            XCTAssertNil(error)
-//            ex.fulfill()
-//        })
-//        //  Inject authorization_code to mimic browser authentication
-//        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
-//        waitForExpectations(timeout: 60, handler: nil)
-//        
-//        XCTAssertNotNil(FRUser.currentUser)
-//        XCTAssertNil(Browser.currentBrowser)
-//        
-//        FRUser.currentUser?.logout()
-//        
-//        // Sleep for 5 seconds to wait for async logout requests go through
-//        sleep(5)
-//        
-//        XCTAssertNil(FRUser.currentUser)
-//        XCTAssertNil(Browser.currentBrowser)
-//    }
-//    
-//    
-//    func test_04_consecutive_browser_login_with_different_browser_type() {
-//        
-//        //  TODO: - Temporarily disable this test due to UI issue
-////        //  SDK init
-////        self.startSDK()
-////
-////        // Set mock responses
-////        self.loadMockResponses(["OAuth2_Token_Success",
-////                                "OAuth2_Token_Revoke_Success",
-////                                "OAuth2_EndSession_Success",
-////                                "OAuth2_Token_Success"])
-////
-////        var ex = self.expectation(description: "Browser Login")
-////        let _ = FRUser.browser()?.set(browserType: .authSession).build().login(completion: { (user, error) in
-////            XCTAssertNotNil(user)
-////            XCTAssertNil(error)
-////            ex.fulfill()
-////        })
-////        //  Inject authorization_code to mimic browser authentication
-////        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
-////        waitForExpectations(timeout: 60, handler: nil)
-////
-////        XCTAssertNotNil(FRUser.currentUser)
-////        XCTAssertNil(Browser.currentBrowser)
-////
-////        FRUser.currentUser?.logout()
-////
-////        // Sleep for 5 seconds to wait for async logout requests go through
-////        sleep(5)
-////
-////        XCTAssertNil(FRUser.currentUser)
-////        XCTAssertNil(Browser.currentBrowser)
-////
-////        ex = self.expectation(description: "Browser Login")
-////        let _ = FRUser.browser()?.set(browserType: .sfViewController).build().login(completion: { (user, error) in
-////            XCTAssertNotNil(user)
-////            XCTAssertNil(error)
-////            ex.fulfill()
-////        })
-////        //  Inject authorization_code to mimic browser authentication
-////        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
-////        waitForExpectations(timeout: 60, handler: nil)
-////
-////        XCTAssertNotNil(FRUser.currentUser)
-////        XCTAssertNil(Browser.currentBrowser)
-//    }
-//    
-//    
-//    func test_05_native_login_and_following_browser_login() {
-//        
-//        //  SDK init
-//        self.startSDK()
-//        
-//        //  Perform native Login
-//        self.performUsernamePasswordLogin()
-//        
-//        //  Validate
-//        XCTAssertNotNil(FRUser.currentUser)
-//        
-//        
-//        // Set mock responses
-//        self.loadMockResponses(["AM_Session_Logout_Success",
 //                                "OAuth2_Token_Revoke_Success",
 //                                "OAuth2_EndSession_Success",
-//                                "OAuth2_Token_Success",
-//                                "OAuth2_Token_Revoke_Success",
-//                                "OAuth2_EndSession_Success"])
-//        
-//        //  Then
-//        FRUser.currentUser?.logout()
-//        sleep(5)
-//        XCTAssertNil(FRUser.currentUser)
-//        
-//        //  Get top VC
-//        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-//        var topVC = keyWindow?.rootViewController
-//        while let presentedViewController = topVC?.presentedViewController {
-//            topVC = presentedViewController
-//        }
-//        guard let vc = topVC else {
-//            XCTFail("Failed to retrieve top most ViewController")
-//            return
-//        }
-//        
-//        //  Continue with Browser
-//        let ex = self.expectation(description: "Browser Login")
-//        let _ = FRUser.browser()?.set(browserType: .sfViewController).set(presentingViewController: vc).build().login(completion: { (user, error) in
-//            XCTAssertNotNil(user)
-//            XCTAssertNil(error)
-//            ex.fulfill()
-//        })
-//        //  Inject authorization_code to mimic browser authentication
-//        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
-//        waitForExpectations(timeout: 60, handler: nil)
-//        
-//        XCTAssertNotNil(FRUser.currentUser)
-//        XCTAssertNil(Browser.currentBrowser)
-//        
-//        //  Then
-//        FRUser.currentUser?.logout()
-//        sleep(5)
-//        XCTAssertNil(FRUser.currentUser)
-//    }
+//                                "OAuth2_Token_Success"])
 //
-//    
-//    func test_06_browser_login_and_following_native_login() {
-//        
-//        //  SDK init
-//        self.startSDK()
-//        
-//        
-//        // Set mock responses
-//        self.loadMockResponses(["OAuth2_Token_Success",
-//                                "OAuth2_Token_Revoke_Success",
-//                                "OAuth2_EndSession_Success"])
-//        
-//        //  Get top VC
-//        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
-//        var topVC = keyWindow?.rootViewController
-//        while let presentedViewController = topVC?.presentedViewController {
-//            topVC = presentedViewController
-//        }
-//        guard let vc = topVC else {
-//            XCTFail("Failed to retrieve top most ViewController")
-//            return
-//        }
-//        
-//        //  Start with Browser
-//        let ex = self.expectation(description: "Browser Login")
-//        let _ = FRUser.browser()?.set(browserType: .sfViewController).set(presentingViewController: vc).build().login(completion: { (user, error) in
+//        var ex = self.expectation(description: "Browser Login")
+//        let _ = FRUser.browser()?.set(browserType: .authSession).build().login(completion: { (user, error) in
 //            XCTAssertNotNil(user)
 //            XCTAssertNil(error)
 //            ex.fulfill()
@@ -252,23 +139,197 @@
 //        //  Inject authorization_code to mimic browser authentication
 //        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
 //        waitForExpectations(timeout: 60, handler: nil)
-//        
+//
 //        XCTAssertNotNil(FRUser.currentUser)
 //        XCTAssertNil(Browser.currentBrowser)
-//        
-//        //  Then
+//
 //        FRUser.currentUser?.logout()
+//
+//        // Sleep for 5 seconds to wait for async logout requests go through
 //        sleep(5)
+//
 //        XCTAssertNil(FRUser.currentUser)
-//        
-//        //  Continue with native
-//        self.performUsernamePasswordLogin()
-//        
+//        XCTAssertNil(Browser.currentBrowser)
+//
+//        ex = self.expectation(description: "Browser Login")
+//        let _ = FRUser.browser()?.set(browserType: .sfViewController).build().login(completion: { (user, error) in
+//            XCTAssertNotNil(user)
+//            XCTAssertNil(error)
+//            ex.fulfill()
+//        })
+//        //  Inject authorization_code to mimic browser authentication
+//        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
+//        waitForExpectations(timeout: 60, handler: nil)
+//
 //        XCTAssertNotNil(FRUser.currentUser)
-//    }
-//    
-//    
-//    func test_07_should_manual_cleanup() {
-//        self.shouldCleanup = true
-//    }
-//}
+//        XCTAssertNil(Browser.currentBrowser)
+    }
+    
+    
+    func test_05_native_login_and_following_browser_login() {
+        
+        //  SDK init
+        self.startSDK()
+        
+        //  Perform native Login
+        self.performLogin()
+        
+        //  Validate
+        XCTAssertNotNil(FRUser.currentUser)
+        
+        
+        // Set mock responses
+        self.loadMockResponses(["AM_Session_Logout_Success",
+                                "OAuth2_Token_Revoke_Success"])
+
+        //  Then
+        FRUser.currentUser?.logout()
+        sleep(5)
+        XCTAssertNil(FRUser.currentUser)
+
+      self.loadMockResponses(["OAuth2_Token_Success",
+                              "OAuth2_Token_Revoke_Success",
+                              "OAuth2_EndSession_Success"])
+
+        //  Get top VC
+        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+        var topVC = keyWindow?.rootViewController
+        while let presentedViewController = topVC?.presentedViewController {
+            topVC = presentedViewController
+        }
+        guard let vc = topVC else {
+            XCTFail("Failed to retrieve top most ViewController")
+            return
+        }
+        
+        //  Continue with Browser
+        let ex = self.expectation(description: "Browser Login")
+        let _ = FRUser.browser()?.set(browserType: .sfViewController).set(presentingViewController: vc).build().login(completion: { (user, error) in
+            XCTAssertNotNil(user)
+            XCTAssertNil(error)
+            ex.fulfill()
+        })
+        //  Inject authorization_code to mimic browser authentication
+        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+        XCTAssertNil(Browser.currentBrowser)
+        
+        //  Then
+        FRUser.currentUser?.logout()
+        sleep(5)
+        XCTAssertNil(FRUser.currentUser)
+    }
+
+    
+    func test_06_browser_login_and_following_native_login() {
+        
+        //  SDK init
+        self.startSDK()
+        
+        
+        // Set mock responses
+        self.loadMockResponses(["OAuth2_Token_Success",
+                                "OAuth2_Token_Revoke_Success",
+                                "OAuth2_EndSession_Success"])
+        
+        //  Get top VC
+        let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+        var topVC = keyWindow?.rootViewController
+        while let presentedViewController = topVC?.presentedViewController {
+            topVC = presentedViewController
+        }
+        guard let vc = topVC else {
+            XCTFail("Failed to retrieve top most ViewController")
+            return
+        }
+        
+        //  Start with Browser
+        let ex = self.expectation(description: "Browser Login")
+        let _ = FRUser.browser()?.set(browserType: .sfViewController).set(presentingViewController: vc).build().login(completion: { (user, error) in
+            XCTAssertNotNil(user)
+            XCTAssertNil(error)
+            ex.fulfill()
+        })
+        //  Inject authorization_code to mimic browser authentication
+        let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
+        waitForExpectations(timeout: 60, handler: nil)
+        
+        XCTAssertNotNil(FRUser.currentUser)
+        XCTAssertNil(Browser.currentBrowser)
+        
+        //  Then
+        FRUser.currentUser?.logout()
+        sleep(5)
+        XCTAssertNil(FRUser.currentUser)
+        
+        //  Continue with native
+        self.performLogin()
+        
+        XCTAssertNotNil(FRUser.currentUser)
+    }
+    
+    
+    func test_07_should_manual_cleanup() {
+        self.shouldCleanup = true
+    }
+
+
+  func test_08_browser_login_and_browser_logout() {
+
+      //  SDK init
+      self.startSDK()
+
+      //-----LOGIN-----
+      // Set mock responses
+      self.loadMockResponses(["OAuth2_Token_Success"])
+
+      //  Get top VC
+      let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first
+      var topVC = keyWindow?.rootViewController
+      while let presentedViewController = topVC?.presentedViewController {
+          topVC = presentedViewController
+      }
+      guard let vc = topVC else {
+          XCTFail("Failed to retrieve top most ViewController")
+          return
+      }
+
+      //  Start with Browser
+      let ex = self.expectation(description: "Browser Login")
+      let _ = FRUser.browser()?.set(browserType: .sfViewController).set(presentingViewController: vc).build().login(completion: { (user, error) in
+          XCTAssertNotNil(user)
+          XCTAssertNil(error)
+          ex.fulfill()
+      })
+      //  Inject authorization_code to mimic browser authentication
+      let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios/login?code=testcode")!)
+      waitForExpectations(timeout: 60, handler: nil)
+
+      XCTAssertNotNil(FRUser.currentUser)
+      XCTAssertNil(Browser.currentBrowser)
+
+    sleep(5)
+
+    //-----LOGOUT-----
+    // Set mock responses
+    self.loadMockResponses(["OAuth2_Token_Revoke_Success",
+                            "OAuth2_EndSession_Success"])
+
+    guard let vc = topVC else {
+        XCTFail("Failed to retrieve top most ViewController")
+        return
+    }
+
+    let _ = FRUser.currentUser?.logout(presentingViewController: vc, browserType: .sfViewController)
+    //  Inject authorization_code to mimic browser authentication
+    let _ = Browser.validateBrowserLogin(url: URL(string: "frauth://com.forgerock.ios")!)
+
+    // Sleep for 5 seconds to wait for async logout requests go through
+    sleep(5)
+
+    XCTAssertNil(FRUser.currentUser)
+    XCTAssertNil(Browser.currentBrowser)
+  }
+}

--- a/FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config.json
+++ b/FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config.json
@@ -38,6 +38,7 @@
     },
     "forgerock_oauth_client_id": "iosclient",
     "forgerock_oauth_redirect_uri": "http://localhost:8081",
+    "forgerock_oauth_signout_redirect_uri": "http://localhost:8081",
     "forgerock_oauth_scope": "openid profile email address",
     "forgerock_oauth_url": "http://openam.example.com:8081/openam",
     "forgerock_oauth_threshold": 60,

--- a/FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config.json
+++ b/FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config.json
@@ -38,7 +38,7 @@
     },
     "forgerock_oauth_client_id": "iosclient",
     "forgerock_oauth_redirect_uri": "http://localhost:8081",
-    "forgerock_oauth_signout_redirect_uri": "http://localhost:8081",
+    "forgerock_oauth_sign_out_redirect_uri": "http://localhost:8081",
     "forgerock_oauth_scope": "openid profile email address",
     "forgerock_oauth_url": "http://openam.example.com:8081/openam",
     "forgerock_oauth_threshold": 60,

--- a/FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config.swift
+++ b/FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config.swift
@@ -99,7 +99,7 @@ class Config: NSObject {
                         let signoutRedirectUri = URL(string: config["forgerock_oauth_sign_out_redirect_uri"] as? String ?? "")
 
                         let serverConfig = ServerConfigBuilder(url: url, realm: realm).set(timeout: timeout).set(enableCookie: enableCookie).set(cookieName: cookieName).build()
-                        let oAuth2Client = OAuth2Client(clientId: oauthClientId, scope: scope, redirectUri: redirectUri, signoutRredirectUri: signoutRedirectUri, serverConfig: serverConfig, threshold: threshold)
+                        let oAuth2Client = OAuth2Client(clientId: oauthClientId, scope: scope, redirectUri: redirectUri, signoutRedirectUri: signoutRedirectUri, serverConfig: serverConfig, threshold: threshold)
                         self.serverConfig = serverConfig
                         self.oAuth2Client = oAuth2Client
                         

--- a/FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config.swift
+++ b/FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config.swift
@@ -96,7 +96,7 @@ class Config: NSObject {
                         let enableCookie = config["forgerock_enable_cookie"] as? Bool ?? true
                         let cookieName = config["forgerock_cookie_name"] as? String ?? "iPlanetDirectoryPro"
 
-                        let signoutRedirectUri = URL(string: config["forgerock_oauth_signout_redirect_uri"] as? String ?? "")
+                        let signoutRedirectUri = URL(string: config["forgerock_oauth_sign_out_redirect_uri"] as? String ?? "")
 
                         let serverConfig = ServerConfigBuilder(url: url, realm: realm).set(timeout: timeout).set(enableCookie: enableCookie).set(cookieName: cookieName).build()
                         let oAuth2Client = OAuth2Client(clientId: oauthClientId, scope: scope, redirectUri: redirectUri, signoutRredirectUri: signoutRedirectUri, serverConfig: serverConfig, threshold: threshold)

--- a/FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config.swift
+++ b/FRTestHost/FRTestHost/SharedTestFiles/TestConfig/Config.swift
@@ -2,7 +2,7 @@
 //  Config.swift
 //  FRAuthTests
 //
-//  Copyright (c) 2019-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2024 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -95,9 +95,11 @@ class Config: NSObject {
                         
                         let enableCookie = config["forgerock_enable_cookie"] as? Bool ?? true
                         let cookieName = config["forgerock_cookie_name"] as? String ?? "iPlanetDirectoryPro"
-                        
+
+                        let signoutRedirectUri = URL(string: config["forgerock_oauth_signout_redirect_uri"] as? String ?? "")
+
                         let serverConfig = ServerConfigBuilder(url: url, realm: realm).set(timeout: timeout).set(enableCookie: enableCookie).set(cookieName: cookieName).build()
-                        let oAuth2Client = OAuth2Client(clientId: oauthClientId, scope: scope, redirectUri: redirectUri, serverConfig: serverConfig, threshold: threshold)
+                        let oAuth2Client = OAuth2Client(clientId: oauthClientId, scope: scope, redirectUri: redirectUri, signoutRredirectUri: signoutRedirectUri, serverConfig: serverConfig, threshold: threshold)
                         self.serverConfig = serverConfig
                         self.oAuth2Client = oAuth2Client
                         

--- a/SampleApps/FRExample/FRExample/ViewController.swift
+++ b/SampleApps/FRExample/FRExample/ViewController.swift
@@ -233,7 +233,7 @@ class ViewController: UIViewController, ErrorAlertShowing {
               let config =
               ["forgerock_oauth_client_id": "CLIENT_ID_PLACEHOLDER",
                "forgerock_oauth_redirect_uri": "org.forgerock.demo://oauth2redirect",
-               "forgerock_oauth_signout_redirect_uri": "org.forgerock.demo://oauth2redirect",
+               "forgerock_oauth_sign_out_redirect_uri": "org.forgerock.demo://oauth2redirect",
                "forgerock_oauth_scope": "openid profile email address revoke",
               /* "forgerock_ssl_pinning_public_key_hashes": ["SSL_PINNING_HASH_PLACEHOLDER"]*/]
 

--- a/SampleApps/FRExample/FRExample/ViewController.swift
+++ b/SampleApps/FRExample/FRExample/ViewController.swift
@@ -35,6 +35,7 @@ class ViewController: UIViewController, ErrorAlertShowing {
     var urlSession: URLSession = URLSession.shared
     var loadingView: FRLoadingView = FRLoadingView(size: CGSize(width: 120, height: 120), showDropShadow: true, showDimmedBackground: true, loadingText: "Loading...")
     let useDiscoveryURL = false
+    let centralizedLoginBrowserType: BrowserType = .authSession
 
     // MARK: - UIViewController Lifecycle
     
@@ -232,8 +233,9 @@ class ViewController: UIViewController, ErrorAlertShowing {
               let config =
               ["forgerock_oauth_client_id": "CLIENT_ID_PLACEHOLDER",
                "forgerock_oauth_redirect_uri": "org.forgerock.demo://oauth2redirect",
-               "forgerock_oauth_scope" : "openid profile email address revoke",
-               "forgerock_ssl_pinning_public_key_hashes": ["SSL_PINNING_HASH_PLACEHOLDER"]]
+               "forgerock_oauth_signout_redirect_uri": "org.forgerock.demo://oauth2redirect",
+               "forgerock_oauth_scope": "openid profile email address revoke",
+              /* "forgerock_ssl_pinning_public_key_hashes": ["SSL_PINNING_HASH_PLACEHOLDER"]*/]
 
               let discoveryURL = "DISCOVERY_URL_PLACEHOLDER"
 
@@ -699,7 +701,7 @@ class ViewController: UIViewController, ErrorAlertShowing {
     func performCentralizedLogin() {
         FRUser.browser()?
             .set(presentingViewController: self)
-            .set(browserType: .authSession)
+            .set(browserType: centralizedLoginBrowserType)
             .setCustomParam(key: "custom", value: "value")
             .build().login { (user, error) in
                 self.displayLog("User: \(String(describing: user)) || Error: \(String(describing: error))")
@@ -739,7 +741,7 @@ class ViewController: UIViewController, ErrorAlertShowing {
         }
         
         // If FRUser.currentUser exists, perform logout
-        user.logout()
+        user.logout(presentingViewController: self, browserType: centralizedLoginBrowserType)
         self.displayLog("Logout completed")
     }
     


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3021](https://bugster.forgerock.org/jira/browse/SDKS-3021)

# Description

[iOS] Centralize Oidc Signoff with PingOne

1. A new logout method has been added to FRUser. It takes presentingViewController and browserType arguments
2. If oauthSignoutRedirectUri is provided in the config/options, the sdk will perform browser logout
3. Works with all browser types. Same browser type need to be used for browser login and logout
4. Might add more Browser login/logout tests

