### PR TITLE
Fix the issue when session would get revoked twice during browser logout

### DIFF
--- a/FRAuth/FRAuth/User/FRUser.swift
+++ b/FRAuth/FRAuth/User/FRUser.swift
@@ -194,8 +194,9 @@ public class FRUser: NSObject, NSSecureCoding {
                 else {
                     FRLog.v("Invalidating OAuth2 token(s) successful")
                 }
-                
-                if let idToken = tokens.idToken, ssoTokenInvalidated == false {
+                if let oAuth2Client = frAuth.oAuth2Client, oAuth2Client.signoutRedirectUri != nil {
+                    FRLog.v("Skipping invalidating session using id_token since the session has already been invalidated in the browser")
+                } else if let idToken = tokens.idToken, ssoTokenInvalidated == false {
                     FRLog.v("Invalidating session using id_token")
                     // End Session if id_token exists
                     frAuth.tokenManager?.endSession(idToken: idToken, completion: { (error) in

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Model/User/FRUserBrowserTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Model/User/FRUserBrowserTests.swift
@@ -231,8 +231,7 @@ class FRUserBrowserTests: FRAuthBaseTest {
         
         // Set mock responses
         self.loadMockResponses(["OAuth2_Token_Success",
-                                "OAuth2_Token_Revoke_Success",
-                                "OAuth2_EndSession_Success"])
+                                "OAuth2_Token_Revoke_Success"])
         
         //  Get top VC
         let keyWindow = UIApplication.shared.windows.filter {$0.isKeyWindow}.first


### PR DESCRIPTION
[SDKS-3301](https://bugster.forgerock.org/jira/browse/SDKS-3301)

[iOS] FRUser.logout(...) should not invoke endSession when oauthSignoutRedirectUri is present in the configuration