### PR TITLE
SDKS-3226_TextOutputCallbacks-Type4-Ignore

### DIFF
--- a/FRAuth/FRAuth/Authentication/Node.swift
+++ b/FRAuth/FRAuth/Authentication/Node.swift
@@ -322,8 +322,8 @@ public class Node: NSObject {
         var callbacks: [Any] = []
         
         for callback:Callback in self.callbacks {
-            if let textOutPutCallback = callback as? TextOutputCallback, (textOutPutCallback.messageType == .unknown) {
-                FRLog.i("TextOutputCallback of unknown type (scipted TextOutputCallback) is skipped from the response")
+            if let textOutputCallback = callback as? TextOutputCallback, (textOutputCallback.messageType == .unknown) {
+                FRLog.i("TextOutputCallback of unknown type (scripted TextOutputCallback) is skipped from the response")
             } else {
                 callbacks.append(callback.buildResponse())
             }

--- a/FRAuth/FRAuth/Authentication/Node.swift
+++ b/FRAuth/FRAuth/Authentication/Node.swift
@@ -322,7 +322,11 @@ public class Node: NSObject {
         var callbacks: [Any] = []
         
         for callback:Callback in self.callbacks {
-            callbacks.append(callback.buildResponse())
+            if let textOutPutCallback = callback as? TextOutputCallback, (textOutPutCallback.messageType == .unknown) {
+                FRLog.i("TextOutputCallback of unknown type (scipted TextOutputCallback) is skipped from the response")
+            } else {
+                callbacks.append(callback.buildResponse())
+            }
         }
         
         payload[OpenAM.callbacks] = callbacks

--- a/FRAuth/FRAuth/Authentication/Node.swift
+++ b/FRAuth/FRAuth/Authentication/Node.swift
@@ -2,7 +2,7 @@
 //  Node.swift
 //  FRAuth
 //
-//  Copyright (c) 2019-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2019-2024 ForgeRock. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.


### PR DESCRIPTION
Simple fix for ignoring the ScriptedTextOutputCallbacks from the response. The callbacks can still be used on the Journey, but won't be returned on the response built by the SDK when submitting back.

# JIRA Ticket

[Please, link jira ticket here.](https://bugster.forgerock.org/jira/browse/SDKS-3226)

# Description

Briefly describe the change and any information that would help speedup the review and testing process.

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] Example code snippets have been added.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).