### PR TITLE
Fix - Cannot find type 'UIViewController' in scope

### DIFF
--- a/FRAuth/FRAuth/User/FRUser.swift
+++ b/FRAuth/FRAuth/User/FRUser.swift
@@ -11,6 +11,9 @@
 import Foundation
 import FRCore
 
+// Fix - Cannot find type 'UIViewController' in scope
+import UIKit
+
 
 /// FRUser represents authenticated user session as FRUser object
 @objc


### PR DESCRIPTION
This issue occured me when i am started build process in xcode, because in " public func logout(presentingViewController: UIViewController, browserType: BrowserType = .authSession)" UIViewController is taken, now its working fine.

<img width="265" alt="Screenshot 2024-07-29 at 5 36 18 PM" src="https://github.com/user-attachments/assets/e0f83bf0-1cdf-40b8-b39b-f3297c0f7a57">
