### PR TITLE
Allowing DeviceBinding `NONE` option on Simulators

### DIFF
--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA-05-DeviceBindingCallbackTest.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA-05-DeviceBindingCallbackTest.swift
@@ -206,10 +206,6 @@ class AA_05_DeviceBindingCallbackTest: CallbackBaseTest {
                         ex.fulfill()
                     })
                 waitForExpectations(timeout: 60, handler: nil)
-                if isSimulator {
-                    XCTAssertEqual(bindingResult, "DeviceBinding/Signing is not supported on the iOS Simulator")
-                    return
-                }
                 
                 XCTAssertEqual(bindingResult, "Success")
 
@@ -301,10 +297,7 @@ class AA_05_DeviceBindingCallbackTest: CallbackBaseTest {
                     })
                 waitForExpectations(timeout: 60, handler: nil)
                 
-                if isSimulator {
-                    XCTAssertEqual(bindingResult, "DeviceBinding/Signing is not supported on the iOS Simulator")
-                    return
-                }
+                
                 XCTAssertEqual(bindingResult, "Success")
 
             }

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA-06-DeviceSigningVerifierCallbackTest.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/E2ETests/Callback-Live/AA-06-DeviceSigningVerifierCallbackTest.swift
@@ -219,10 +219,7 @@ class AA_06_DeviceSigningVerifierCallbackTest: CallbackBaseTest {
                     ex.fulfill()
                 })
                 waitForExpectations(timeout: 60, handler: nil)
-                if isSimulator {
-                    XCTAssertEqual(singningResult, DeviceBindingStatus.clientNotRegistered.errorMessage)
-                    return
-                }
+                
                 XCTAssertEqual(singningResult, "Success")
             }
             else {
@@ -294,10 +291,7 @@ class AA_06_DeviceSigningVerifierCallbackTest: CallbackBaseTest {
                     ex.fulfill()
                 })
                 waitForExpectations(timeout: 60, handler: nil)
-                if isSimulator {
-                    XCTAssertEqual(singningResult, DeviceBindingStatus.clientNotRegistered.errorMessage)
-                    return
-                }
+                
                 XCTAssertEqual(singningResult, "Success")
             }
             else {
@@ -370,10 +364,7 @@ class AA_06_DeviceSigningVerifierCallbackTest: CallbackBaseTest {
                     ex.fulfill()
                 })
                 waitForExpectations(timeout: 60, handler: nil)
-                if isSimulator {
-                    XCTAssertEqual(singningResult, DeviceBindingStatus.clientNotRegistered.errorMessage)
-                    return
-                }
+                
                 XCTAssertEqual(singningResult, "Authentication Timeout")
             }
             else {
@@ -719,10 +710,7 @@ class AA_06_DeviceSigningVerifierCallbackTest: CallbackBaseTest {
                         ex.fulfill()
                     })
                 waitForExpectations(timeout: 60, handler: nil)
-                if isSimulator {
-                    XCTAssertEqual(bindingResult, "DeviceBinding/Signing is not supported on the iOS Simulator")
-                    return
-                }
+                
                 XCTAssertEqual(bindingResult, "Success")
             }
             else {

--- a/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/DeviceBindingCallback.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/DeviceBindingCallback.swift
@@ -1,4 +1,4 @@
-// 
+//
 //  DeviceBindingCallback.swift
 //  FRDeviceBinding
 //
@@ -170,11 +170,14 @@ open class DeviceBindingCallback: MultipleValuesCallback, Binding {
                           deviceRepository: DeviceBindingRepository = LocalDeviceBindingRepository(),
                           prompt: Prompt? = nil,
                           _ completion: @escaping DeviceBindingResultCallback) {
+        if deviceBindingAuthenticationType != .none {
 #if targetEnvironment(simulator)
-        // DeviceBinding/Signing is not supported on the iOS Simulator
-        handleException(status: .unsupported(errorMessage: "DeviceBinding/Signing is not supported on the iOS Simulator"), completion: completion)
-        return
+            // DeviceBinding/Signing other than `.NONE` type is not supported on the iOS Simulator
+            handleException(status: .unsupported(errorMessage: "DeviceBinding/Signing is not supported on the iOS Simulator"), completion: completion)
+            return
 #endif
+        }
+        
         let authInterface = authInterface ?? getDeviceAuthenticator(type: deviceBindingAuthenticationType)
         authInterface.initialize(userId: userId, prompt: prompt ?? Prompt(title: title, subtitle: subtitle, description: promptDescription))
         let deviceId = deviceId ?? FRDevice.currentDevice?.identifier.getIdentifier()

--- a/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/DeviceSigningVerifierCallback.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/DeviceSigningVerifierCallback.swift
@@ -180,11 +180,15 @@ open class DeviceSigningVerifierCallback: MultipleValuesCallback, Binding {
                                customClaims: [String: Any] = [:],
                                prompt: Prompt? = nil,
                                _ completion: @escaping DeviceSigningResultCallback) {
+        
+        if userKey.authType != .none {
 #if targetEnvironment(simulator)
-        // DeviceBinding/Signing is not supported on the iOS Simulator
-        handleException(status: .unsupported(errorMessage: "DeviceBinding/Signing is not supported on the iOS Simulator"), completion: completion)
-        return
+            // DeviceBinding/Signing other than `.NONE` type is not supported on the iOS Simulator
+            handleException(status: .unsupported(errorMessage: "DeviceBinding/Signing is not supported on the iOS Simulator"), completion: completion)
+            return
 #endif
+        }
+        
         authInterface.initialize(userId: userKey.userId, prompt: prompt ?? Prompt(title: title, subtitle: subtitle, description: promptDescription))
         guard authInterface.isSupported() else {
             handleException(status: .unsupported(errorMessage: nil), completion: completion)

--- a/FRDeviceBinding/FRDeviceBindingTests/DeviceBindingCallbackTests.swift
+++ b/FRDeviceBinding/FRDeviceBindingTests/DeviceBindingCallbackTests.swift
@@ -625,10 +625,7 @@ class DeviceBindingCallbackTests: FRAuthBaseTest {
                 case .success:
                     XCTFail("Callback Execute succeeded instead of timeout")
                 case .failure(let error):
-                    if self.isSimulator {
-                        XCTAssertEqual(error.errorMessage, "DeviceBinding/Signing is not supported on the iOS Simulator")
-                        return
-                    }
+                    
                     XCTAssertEqual(error.clientError, DeviceBindingStatus.timeout.clientError)
                     XCTAssertTrue(callback.inputValues.count == 1)
                 }

--- a/FRDeviceBinding/FRDeviceBindingTests/DeviceSigningVerifierCallbackTests.swift
+++ b/FRDeviceBinding/FRDeviceBindingTests/DeviceSigningVerifierCallbackTests.swift
@@ -538,11 +538,7 @@ class DeviceSigningVerifierCallbackTests: FRAuthBaseTest {
                 case .success:
                     XCTAssertTrue(callback.inputValues.count == 1)
                 case .failure(let error):
-                    if self.isSimulator {
-                        XCTAssertEqual(error.errorMessage, "DeviceBinding/Signing is not supported on the iOS Simulator")
-                    } else {
-                        XCTFail("Callback Execute failed: \(error.errorMessage)")
-                    }
+                    XCTFail("Callback Execute failed: \(error.errorMessage)")
                 }
             }
         }
@@ -578,12 +574,8 @@ class DeviceSigningVerifierCallbackTests: FRAuthBaseTest {
                 case .success:
                     XCTFail("Callback Execute succeeded instead of timeout")
                 case .failure(let error):
-                    if self.isSimulator {
-                        XCTAssertEqual(error.errorMessage, "DeviceBinding/Signing is not supported on the iOS Simulator")
-                    } else {
-                        XCTAssertEqual(error.clientError, DeviceBindingStatus.timeout.clientError)
-                        XCTAssertTrue(callback.inputValues.count == 1)
-                    }
+                    XCTAssertEqual(error.clientError, DeviceBindingStatus.timeout.clientError)
+                    XCTAssertTrue(callback.inputValues.count == 1)
                 }
             }
         }
@@ -670,11 +662,7 @@ class DeviceSigningVerifierCallbackTests: FRAuthBaseTest {
                 case .success:
                     XCTAssertTrue(callback.inputValues.count == 1)
                 case .failure(let error):
-                    if self.isSimulator {
-                        XCTAssertEqual(error.errorMessage, "DeviceBinding/Signing is not supported on the iOS Simulator")
-                    } else {
-                        XCTFail("Callback Execute failed: \(error.errorMessage)")
-                    }
+                    XCTFail("Callback Execute failed: \(error.errorMessage)")
                 }
             }
         }
@@ -713,12 +701,8 @@ class DeviceSigningVerifierCallbackTests: FRAuthBaseTest {
                 case .success:
                     XCTFail("Callback bind succeeded instead of unsupported (invalid custom cliams)")
                 case .failure(let error):
-                    if self.isSimulator {
-                        XCTAssertEqual(error.errorMessage, "DeviceBinding/Signing is not supported on the iOS Simulator")
-                    } else {
-                        XCTAssertEqual(error.clientError, DeviceBindingStatus.invalidCustomClaims.clientError)
-                        XCTAssertTrue(callback.inputValues.count == 1)
-                    }
+                    XCTAssertEqual(error.clientError, DeviceBindingStatus.invalidCustomClaims.clientError)
+                    XCTAssertTrue(callback.inputValues.count == 1)
                 }
             }
         }
@@ -860,12 +844,8 @@ class DeviceSigningVerifierCallbackTests: FRAuthBaseTest {
                     XCTFail("Callback bind succeeded instead of unsupported (invalid custom cliams)")
                 case .failure(let error):
                     // even though we don't overrid any of the existing claims, it fails as validateCustomClaims method always returns false
-                    if self.isSimulator {
-                        XCTAssertEqual(error.errorMessage, "DeviceBinding/Signing is not supported on the iOS Simulator")
-                    } else {
-                        XCTAssertEqual(error, DeviceBindingStatus.invalidCustomClaims)
-                        XCTAssertTrue(callback.inputValues.count == 1)
-                    }
+                    XCTAssertEqual(error, DeviceBindingStatus.invalidCustomClaims)
+                    XCTAssertTrue(callback.inputValues.count == 1)
                 }
                 expectation.fulfill()
             }


### PR DESCRIPTION
Allowing DeviceBinding `NONE` option on Simulators

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] Example code snippets have been added.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).