### PR TITLE
Update FRCaptchaEnterprise and FRUI podspecs

### DIFF
--- a/FRCaptchaEnterprise.podspec
+++ b/FRCaptchaEnterprise.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.homepage         = 'https://www.forgerock.com'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = 'ForgeRock'
+  s.static_framework = true
 
   s.source           = {
       :git => 'https://github.com/ForgeRock/forgerock-ios-sdk.git',
@@ -33,5 +34,5 @@ Pod::Spec.new do |s|
     'FRCaptchaEnterprise' => [base_dir + '/*.xcprivacy']
   }
   s.ios.dependency 'FRAuth', '~> 4.6.0'
-  s.ios.dependency 'RecaptchaEnterprise', '~> 18.1.0'
+  s.ios.dependency 'RecaptchaEnterprise', '~> 18.6.0'
 end

--- a/FRUI.podspec
+++ b/FRUI.podspec
@@ -16,6 +16,7 @@ Pod::Spec.new do |s|
   s.homepage         = 'https://www.forgerock.com'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }
   s.author           = 'ForgeRock'
+  s.static_framework = true
 
   s.source           = {
       :git => 'https://github.com/ForgeRock/forgerock-ios-sdk.git',
@@ -32,6 +33,7 @@ Pod::Spec.new do |s|
   s.resource_bundles = {
     'FRUI' => [base_dir + '/*.xcprivacy']
   }
-  s.resources = [base_dir + '/**/*.xib', base_dir + '/Assets/*']
+  s.resources = [base_dir + '/**/*.xib']
   s.ios.dependency 'FRDeviceBinding', '~> 4.6.0'
+  s.ios.dependency 'FRCaptchaEnterprise', '~> 4.6.0'
 end


### PR DESCRIPTION
- Update RecaptchaEnterprise from 18.1.0 to 18.6.0
- Add s.static_framework = true in FRCaptchaEnterprise.podspec and FRUI.podspec
- Remove  base_dir + '/Assets/*' from resources in FRUI.podspec