### PR TITLE
SDKS-3533 Prevent duplicated notification on iOS SDK

### DIFF
--- a/FRAuthenticator/FRAuthenticator/FRAClient.swift
+++ b/FRAuthenticator/FRAuthenticator/FRAClient.swift
@@ -2,7 +2,7 @@
 //  FRAuthenticator.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020-2023 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2024 Ping Identity. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -196,6 +196,15 @@ public class FRAClient: NSObject {
     /// - Returns: PushNotification object with given identifier
     public func getNotification(identifier: String) -> PushNotification? {
         return self.authenticatorManager.getNotification(identifier: identifier)
+    }
+    
+    
+    /// Retrieves PushNotification object with given message identifier
+    /// - Parameter messageId: String value of PushNotification's message identifier
+    /// - Returns: PushNotification object with given message identifier
+    /// - Note: If the PushNotification object with given message identifier does not exist, it returns nil
+    func getNotificationByMessageId(messageId: String) -> PushNotification? {
+        return self.authenticatorManager.getNotificationByMessageId(messageId: messageId)
     }
     
     

--- a/FRAuthenticator/FRAuthenticator/Manager/AuthenticatorManager.swift
+++ b/FRAuthenticator/FRAuthenticator/Manager/AuthenticatorManager.swift
@@ -2,7 +2,7 @@
 //  AuthenticatorManager.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020-2023 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2024 Ping Identity. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -452,6 +452,14 @@ struct AuthenticatorManager {
     /// - Returns: PushNotification object with given identifier
     func getNotification(identifier: String) -> PushNotification? {
         return self.storageClient.getNotification(notificationIdentifier: identifier)
+    }
+    
+    
+    /// Retrieves PushNotification object with given PushNotification Message Identifier
+    /// - Parameter messageId: String value of PushNotification object's message identifier
+    /// - Returns: PushNotification object with given message identifier
+    func getNotificationByMessageId(messageId: String) -> PushNotification? {
+        return self.storageClient.getNotificationByMessageId(messageId: messageId)
     }
     
     

--- a/FRAuthenticator/FRAuthenticator/Push/FRAPushHandler.swift
+++ b/FRAuthenticator/FRAuthenticator/Push/FRAPushHandler.swift
@@ -99,6 +99,7 @@ public class FRAPushHandler: NSObject {
                 }
                 else {
                     FRALog.w("PushNotification object failed to be stored into StorageClient")
+                    return nil
                 }
                 
                 return notification

--- a/FRAuthenticator/FRAuthenticator/Push/FRAPushHandler.swift
+++ b/FRAuthenticator/FRAuthenticator/Push/FRAPushHandler.swift
@@ -2,7 +2,7 @@
 //  FRAPushHandler.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2024 Ping Identity. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -68,35 +68,41 @@ public class FRAPushHandler: NSObject {
         
         FRALog.v("Received valid format of remote-notification for AM Push Authentication; starts parsing it into PushNotification object")
         do {
-            // Extract JWT payload
-            FRALog.v("Starts extracting JWT payload: \(jwt)")
-            let jwtPayload = try FRCompactJWT.extractPayload(jwt: jwt)
-            FRALog.v("JWT payload is extracted: \(jwtPayload)")
-            
-            // Construct and save Notification object
-            FRALog.v("PushNotification object created - messageId:\(messageId), payload: \(jwtPayload)")
-            let notification = try PushNotification(messageId: messageId, payload: jwtPayload)
-            
-            if let mechanism = FRAClient.storage.getMechanismForUUID(uuid: notification.mechanismUUID) {
-                if try FRCompactJWT.verify(jwt: jwt, secret: mechanism.secret) == false {
-                    FRALog.e("Failed to verify given JWT in remote-notification payload; returning nil")
+            // Check if notification with given messageId already exists
+            if let notification = FRAClient.storage.getNotificationByMessageId(messageId: messageId) {
+                FRALog.v("Received remote-notification with messageId: \(messageId) already exists in StorageClient; returning the existing PushNotification object")
+                return notification
+            } else {
+                // Extract JWT payload
+                FRALog.v("Starts extracting JWT payload: \(jwt)")
+                let jwtPayload = try FRCompactJWT.extractPayload(jwt: jwt)
+                FRALog.v("JWT payload is extracted: \(jwtPayload)")
+                
+                // Construct and save Notification object
+                FRALog.v("PushNotification object created - messageId:\(messageId), payload: \(jwtPayload)")
+                let notification = try PushNotification(messageId: messageId, payload: jwtPayload)
+                
+                if let mechanism = FRAClient.storage.getMechanismForUUID(uuid: notification.mechanismUUID) {
+                    if try FRCompactJWT.verify(jwt: jwt, secret: mechanism.secret) == false {
+                        FRALog.e("Failed to verify given JWT in remote-notification payload; returning nil")
+                        return nil
+                    }
+                    FRALog.v("Verification of JWT in remote-notification payload with PushMechanism's secret")
+                }
+                else {
+                    FRALog.e("Failed to retrieve PushMechanism object from StorageClient; returning null")
                     return nil
                 }
-                FRALog.v("Verification of JWT in remote-notification payload with PushMechanism's secret")
+                
+                if FRAClient.storage.setNotification(notification: notification) {
+                    FRALog.v("PushNotification object is created and saved into StorageClient")
+                }
+                else {
+                    FRALog.w("PushNotification object failed to be stored into StorageClient")
+                }
+                
+                return notification
             }
-            else {
-                FRALog.e("Failed to retrieve PushMechanism object from StorageClient; returning null")
-                return nil
-            }
-            
-            if FRAClient.storage.setNotification(notification: notification) {
-                FRALog.v("PushNotification object is created and saved into StorageClient")
-            }
-            else {
-                FRALog.w("PushNotification object failed to be stored into StorageClient")
-            }
-            
-            return notification
         }
         catch {
             FRALog.e("An error occurred during handling incoming PushNotification: \(error.localizedDescription)")

--- a/FRAuthenticator/FRAuthenticator/Storage/KeychainServiceClient.swift
+++ b/FRAuthenticator/FRAuthenticator/Storage/KeychainServiceClient.swift
@@ -2,7 +2,7 @@
 //  KeychainServiceStorageClient.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2024 Ping Identity. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -197,6 +197,29 @@ struct KeychainServiceClient: StorageClient {
                 return nil
             }
         }
+    }
+    
+    
+    func getNotificationByMessageId(messageId: String) -> PushNotification? {
+        if let items = self.notificationStorage.allItems() {
+           for item in items {
+            if #available(iOS 11.0, *) {
+                if let notificationData = item.value as? Data,
+                   let notification = try? NSKeyedUnarchiver.unarchivedObject(ofClass: PushNotification.self, from: notificationData),
+                   notification.messageId == messageId {
+                        return notification
+                }
+            } else {
+                if let notificationData = item.value as? Data,
+                    let notification = NSKeyedUnarchiver.unarchiveObject(with: notificationData) as? PushNotification,
+                    notification.messageId == messageId {
+                        return notification
+                }
+            }
+           }
+        }
+        
+        return nil
     }
     
     

--- a/FRAuthenticator/FRAuthenticator/Storage/StorageClient.swift
+++ b/FRAuthenticator/FRAuthenticator/Storage/StorageClient.swift
@@ -2,7 +2,7 @@
 //  StorageClient.swift
 //  FRAuthenticator
 //
-//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2024 Ping Identity. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -48,6 +48,10 @@ public protocol StorageClient {
     /// Retrieves PushNotification object with its unique identifier
     /// - Parameter notificationIdentifier: String value of PushNotification's unique identifier
     func getNotification(notificationIdentifier: String) -> PushNotification?
+    
+    /// Retrieves PushNotification object with its unique message identifier
+    /// - Parameter messageId: String value of PushNotification's message identifier
+    func getNotificationByMessageId(messageId: String) -> PushNotification?
     
     /// Stores PushNotification object into Storage Client, and returns discardable Boolean result of operation
     /// - Parameter notification: PushNotification object to be stored

--- a/FRAuthenticator/FRAuthenticatorTests/E2ETests/FRAClient/FRAClientTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/E2ETests/FRAClient/FRAClientTests.swift
@@ -2,7 +2,7 @@
 //  FRAClientTests.swift
 //  FRAuthenticatorTests
 //
-//  Copyright (c) 2020-2023 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2024 Ping Identity. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -403,6 +403,14 @@ class FRAClientTests: FRABaseTests {
                 notifications[1].messageId = "AUTHENTICATE:0666696b-859d-4565-b069-f13c800c5e3c1589151071515"
                 notifications[2].messageId = "AUTHENTICATE:929d72b7-c3e6-4460-a7b6-8e1c950b43361589151096771"
             }
+            
+            // Get push notification by messageId
+            guard let notification1 = FRAClient.shared?.getNotificationByMessageId(messageId: "AUTHENTICATE:64e909a2-84db-4ee8-b244-f0dbbeb8b0ff1589151035455") else {
+                XCTFail("Failed to retrieve PushNotification by messageId")
+                return
+            }
+            XCTAssertEqual(notification1.messageId, "AUTHENTICATE:64e909a2-84db-4ee8-b244-f0dbbeb8b0ff1589151035455")
+            
             
             //  Remove Account object
             //  When

--- a/FRAuthenticator/FRAuthenticatorTests/TestUtils/DummyStorageClient.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/TestUtils/DummyStorageClient.swift
@@ -2,7 +2,7 @@
 //  DummyStorageClient.swift
 //  FRAuthenticatorTests
 //
-//  Copyright (c) 2020-2021 ForgeRock. All rights reserved.
+//  Copyright (c) 2020-2024 Ping Identity. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -109,6 +109,11 @@ class DummyStorageClient: StorageClient {
             return self.getNotificationResult
         }
         return self.defaultStorageClient.getNotification(notificationIdentifier: notificationIdentifier)
+    }
+    
+    
+    func getNotificationByMessageId(messageId: String) -> FRAuthenticator.PushNotification? {
+        return self.defaultStorageClient.getNotificationByMessageId(messageId: messageId)
     }
     
     


### PR DESCRIPTION
# JIRA Ticket

[SDKS-3533](https://pingidentity.atlassian.net/browse/SDKS-3533) [iOS][Authenticator] Prevent duplicated notification on iOS SDK

# Description

The iOS SDK does not verify whether a push notification with an identical identifier has already been stored, delegating this responsibility to the application developer. This PR include the following changes:
- Added a new `getNotificationByMessageId` method to the `StorageClient` and `FRAClient` 
- Updated the `FRAPushHandler` class to check whether a payload was already persisted
- Update unit tests

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] Example code snippets have been added.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).