### PR TITLE
SDKS-3963_DeviceBinding_biometry_change

### DIFF
--- a/FRDeviceBinding/FRDeviceBinding/Sources/DeviceBindingAuthenticators.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/DeviceBindingAuthenticators.swift
@@ -370,9 +370,9 @@ open class BiometricAndDeviceCredential: BiometricAuthenticator {
     /// Access Control for the authetication type
     open override func accessControl() -> SecAccessControl? {
 #if !targetEnvironment(simulator)
-        return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.userPresence, .privateKeyUsage], nil)
+        return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.biometryCurrentSet, .or, .devicePasscode, .privateKeyUsage], nil)
 #else
-        return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.userPresence], nil)
+        return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.biometryCurrentSet, .or, .devicePasscode], nil)
 #endif
     }
     


### PR DESCRIPTION
Changing the default BiometricAndFallback authenticator to respect "biometryCurrentSet, .or, .devicePasscode" in order to fail the biometric if the current set has changed

# JIRA Ticket

Please, link [jira ticket ](https://pingidentity.atlassian.net/browse/SDKS-3963) here.

# Description

Briefly describe the change and any information that would help speedup the review and testing process.

# Definition of Done Checklist:

- [ ] Acceptance criteria is met.
- [ ] All tasks listed in the user story have been completed.
- [ ] Coded to standards.
- [ ] Ensure backward compatibility.
- [ ] API reference docs is updated.
- [ ] Unit tests are written.
- [ ] Integration tests are written.
- [ ] e2e tests are written.
- [ ] Functional spec is written/updated.
- [ ] Example code snippets have been added.
- [ ] Change log updated.
- [ ] Documentation story is created and tracked.
- [ ] Tech debts and remaining tasks are tracked in separated ticket(s).