### PR TITLE
Update Recaptcha library to 18.7.0, fix tests

### DIFF
--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		A530D45D2CD13E1D009EC60C /* DeviceClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A530D45C2CD13E1D009EC60C /* DeviceClientTests.swift */; };
 		A530D4782CD1A7C7009EC60C /* CodableExtentions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A530D4752CD1A7C0009EC60C /* CodableExtentions.swift */; };
 		A53723D12AE80A5D0047B809 /* TelephonyCollectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A53723D02AE80A5D0047B809 /* TelephonyCollectorTests.swift */; };
+		A55D57BE2DC034E6000BDBCA /* FRCaptchaEnterprise.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A55D57BD2DC034E6000BDBCA /* FRCaptchaEnterprise.framework */; };
+		A55D57BF2DC034E6000BDBCA /* FRCaptchaEnterprise.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A55D57BD2DC034E6000BDBCA /* FRCaptchaEnterprise.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A5950A2A27EA205B00EDEFE4 /* SSLPinningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5950A2927EA205B00EDEFE4 /* SSLPinningTests.swift */; };
 		D512CD41240DC41E00AF520E /* FRRestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D512CD40240DC41E00AF520E /* FRRestClient.swift */; };
 		D513F17524DA6B490042228B /* AuthApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D513F17424DA6B490042228B /* AuthApiError.swift */; };
@@ -361,6 +363,20 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		A55D57C02DC034E6000BDBCA /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				A55D57BF2DC034E6000BDBCA /* FRCaptchaEnterprise.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		1B264AA62C642507002E3BD2 /* ProtectCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtectCallback.swift; sourceTree = "<group>"; };
 		1B264AA92C642F59002E3BD2 /* DerivableCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DerivableCallback.swift; sourceTree = "<group>"; };
@@ -407,6 +423,8 @@
 		A530D45C2CD13E1D009EC60C /* DeviceClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceClientTests.swift; sourceTree = "<group>"; };
 		A530D4752CD1A7C0009EC60C /* CodableExtentions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodableExtentions.swift; sourceTree = "<group>"; };
 		A53723D02AE80A5D0047B809 /* TelephonyCollectorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TelephonyCollectorTests.swift; sourceTree = "<group>"; };
+		A544D6702DBFF31200A2EE4C /* FRCaptchaEnterprise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FRCaptchaEnterprise.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		A55D57BD2DC034E6000BDBCA /* FRCaptchaEnterprise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FRCaptchaEnterprise.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5950A2927EA205B00EDEFE4 /* SSLPinningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSLPinningTests.swift; sourceTree = "<group>"; };
 		D5015FEE24996AE50025FEB6 /* MetadataCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataCallbackTests.swift; sourceTree = "<group>"; };
 		D5054B4D244680C3007FBA92 /* DeviceProfileCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceProfileCallbackTests.swift; sourceTree = "<group>"; };
@@ -690,6 +708,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A55D57BE2DC034E6000BDBCA /* FRCaptchaEnterprise.framework in Frameworks */,
 				D554630222A6DF720096C7A4 /* FRAuth.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1097,6 +1116,8 @@
 		D5554F73235A7258009FC810 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A55D57BD2DC034E6000BDBCA /* FRCaptchaEnterprise.framework */,
+				A544D6702DBFF31200A2EE4C /* FRCaptchaEnterprise.framework */,
 				D5554F74235A7259009FC810 /* UIKit.framework */,
 			);
 			name = Frameworks;
@@ -1692,6 +1713,7 @@
 				D55462FD22A6DF720096C7A4 /* Sources */,
 				D55462FE22A6DF720096C7A4 /* Frameworks */,
 				D55462FF22A6DF720096C7A4 /* Resources */,
+				A55D57C02DC034E6000BDBCA /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
@@ -2334,7 +2356,6 @@
 		D554631022A6DF720096C7A4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -2364,7 +2385,6 @@
 		D554631122A6DF720096C7A4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;

--- a/FRCaptchaEnterprise.podspec
+++ b/FRCaptchaEnterprise.podspec
@@ -34,5 +34,5 @@ Pod::Spec.new do |s|
     'FRCaptchaEnterprise' => [base_dir + '/*.xcprivacy']
   }
   s.ios.dependency 'FRAuth', '~> 4.7.0'
-  s.ios.dependency 'RecaptchaEnterprise', '~> 18.6.0'
+  s.ios.dependency 'RecaptchaEnterprise', '~> 18.7.0'
 end

--- a/FRCaptchaEnterprise/FRCaptchaEnterprise.xcodeproj/project.pbxproj
+++ b/FRCaptchaEnterprise/FRCaptchaEnterprise.xcodeproj/project.pbxproj
@@ -964,7 +964,7 @@
 			repositoryURL = "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 18.6.0;
+				minimumVersion = 18.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/FRCaptchaEnterprise/FRCaptchaEnterpriseTests/ReCaptchaEnterpriseTests.swift
+++ b/FRCaptchaEnterprise/FRCaptchaEnterpriseTests/ReCaptchaEnterpriseTests.swift
@@ -155,7 +155,8 @@ final class ReCaptchaEnterpriseTests: FRAuthBaseTest {
       // Verify captured parameters
       XCTAssertEqual(mockProvider.capturedSiteKey, "siteKey")
       XCTAssertEqual(mockProvider.capturedClientTimeout, 15000)
-      XCTAssertEqual(mockProvider.capturedAction?.action, "test-action")
+      // Commenting out as action property is no longer available and there is no other way to check the quality for now
+      // XCTAssertEqual(mockProvider.capturedAction?.action, "test-action")
     }
     catch {
       XCTFail("Failed to validate captcha")
@@ -168,22 +169,23 @@ final class ReCaptchaEnterpriseTests: FRAuthBaseTest {
     let jsonStr = getJsonCallback()
     let callbackResponse = self.parseStringToDictionary(jsonStr)
     
-    mockProvider.shouldThrowErrorIntialization = RecaptchaError(domain: "com.google.recaptcha", code: .errorCodeInternalError, message: "INVALID_CAPTCHA_CLIENT")
     
+    mockProvider.shouldThrowErrorIntialization = NSError(domain: "com.google.recaptcha", code: 100, userInfo: [NSLocalizedDescriptionKey: "INVALID_CAPTCHA_CLIENT"])
     let callback = try ReCaptchaEnterpriseCallback(json: callbackResponse)
     
     do {
       
         try await callback.execute(action: "test-action", timeoutInMillis: 15000, recaptchaProvider: mockProvider)
       XCTFail("Expected error not thrown")
-    } catch let error as RecaptchaError {
-      XCTAssertEqual(error.errorCode, 100)
-      XCTAssertTrue(callback.inputValues[callback.clientErrorKey].debugDescription.contains("com.google.recaptcha error 100"))
+    } catch let error as NSError {
+        XCTAssertEqual(error.code, 100)
+        XCTAssertEqual(callback.inputValues[callback.clientErrorKey] as? String, error.localizedDescription)
     }
     
     // Verify captured parameters
     XCTAssertEqual(mockProvider.capturedSiteKey, "siteKey")
-    XCTAssertEqual(mockProvider.capturedAction?.action, nil)
+    // Commenting out as action property is no longer available and there is no other way to check the quality for now
+    //  XCTAssertEqual(mockProvider.capturedAction?.action, nil)
   }
   
   
@@ -192,23 +194,24 @@ final class ReCaptchaEnterpriseTests: FRAuthBaseTest {
     let jsonStr = getJsonCallback()
     let callbackResponse = self.parseStringToDictionary(jsonStr)
     
-    mockProvider.shouldthrowError = RecaptchaError(domain: "com.google.recaptcha", code: .errorCodeInternalError, message: "INVALID_CAPTCHA_CLIENT")
     
+    mockProvider.shouldthrowError = NSError(domain: "com.google.recaptcha", code: 100, userInfo: [NSLocalizedDescriptionKey: "INVALID_CAPTCHA_CLIENT"])
     let callback = try ReCaptchaEnterpriseCallback(json: callbackResponse)
     
     do {
       
         try await callback.execute(action: "test-action", timeoutInMillis: 15000, recaptchaProvider: mockProvider)
       XCTFail("Expected error not thrown")
-    } catch let error as RecaptchaError {
-      XCTAssertEqual(error.errorCode, 100)
-      XCTAssertTrue(callback.inputValues[callback.clientErrorKey].debugDescription.contains("com.google.recaptcha error 100"))
+    } catch let error as NSError {
+        XCTAssertEqual(error.code, 100)
+        XCTAssertEqual(callback.inputValues[callback.clientErrorKey] as? String, error.localizedDescription)
     }
     
     // Verify captured parameters
     XCTAssertEqual(mockProvider.capturedSiteKey, "siteKey")
     XCTAssertEqual(mockProvider.capturedClientTimeout, 15000)
-    XCTAssertEqual(mockProvider.capturedAction?.action, "test-action")
+    // Commenting out as action property is no longer available and there is no other way to check the quality for now
+    // XCTAssertEqual(mockProvider.capturedAction?.action, "test-action")
   }
   
   @available(iOS 13.0, *)
@@ -233,7 +236,8 @@ final class ReCaptchaEnterpriseTests: FRAuthBaseTest {
     // Verify captured parameters
     XCTAssertEqual(mockProvider.capturedSiteKey, "siteKey")
     XCTAssertEqual(mockProvider.capturedClientTimeout, 15000)
-    XCTAssertEqual(mockProvider.capturedAction?.action, "test-action")
+    // Commenting out as action property is no longer available and there is no other way to check the quality for now
+    // XCTAssertEqual(mockProvider.capturedAction?.action, "test-action")
   }
   
   
@@ -254,7 +258,8 @@ final class ReCaptchaEnterpriseTests: FRAuthBaseTest {
     // Verify captured parameters
     XCTAssertEqual(mockProvider.capturedSiteKey, "siteKey")
     XCTAssertEqual(mockProvider.capturedClientTimeout, 15000)
-    XCTAssertEqual(mockProvider.capturedAction?.action, "test-action")
+    // Commenting out as action property is no longer available and there is no other way to check the quality for now
+    // XCTAssertEqual(mockProvider.capturedAction?.action, "test-action")
   }
   
   // Test the JSONStringify function
@@ -295,8 +300,8 @@ final class ReCaptchaEnterpriseTests: FRAuthBaseTest {
 class MockRecaptchaClientProvider: RecaptchaClientProvider {
   var shouldReturnToken: String?
   
-  var shouldThrowErrorIntialization: RecaptchaError?
   
+  var shouldThrowErrorIntialization: NSError?
   var shouldthrowError: NSError?
   
   // Properties to capture the arguments passed to methods

--- a/Package.swift
+++ b/Package.swift
@@ -23,7 +23,7 @@ let package = Package (
         .package(name: "GoogleSignIn", url: "https://github.com/google/GoogleSignIn-iOS.git", .upToNextMinor(from: "7.1.0")),
         .package(name: "JOSESwift", url: "https://github.com/airsidemobile/JOSESwift.git", .upToNextMinor(from: "2.4.0")),
         .package(name: "PingOneSignals", url: "https://github.com/pingidentity/pingone-signals-sdk-ios.git", .upToNextMinor(from: "5.2.7")),
-        .package(name: "RecaptchaEnterprise", url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk.git", .upToNextMinor(from: "18.6.0"))
+        .package(name: "RecaptchaEnterprise", url: "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk.git", .upToNextMinor(from: "18.7.0"))
     ],
     targets: [
         .target(name: "cFRCore", dependencies: [], path: "FRCore/FRCore/SharedC/Sources"),

--- a/e2e/FRExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/e2e/FRExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
       "state" : {
-        "revision" : "2d12673670417654f08f5f90fdd62926dc3a2648",
-        "version" : "100.0.0"
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",
       "state" : {
-        "revision" : "e1890d87d0aa0780baa38f46bf09db3630bd0beb",
-        "version" : "18.6.0"
+        "revision" : "5ec74256124faa7e7814c574509723f49e1fccfb",
+        "version" : "18.7.0"
       }
     }
   ],


### PR DESCRIPTION
[SDKS-3927](https://pingidentity.atlassian.net/browse/SDKS-3927) [RFE][iOS]: Out of date with reCAPTCHA 18.7.0

Updated Recaptcha version to 18.7.0 from 18.6.0

Even though this didn't break anything in the **FRCaptchaEnterprise** library, it broke our tests and made them more restricted.

Notably in this version (18.7.0) they made two changes that affected our tests.
1. They removed the ability to initialize `RecaptchaError` with domain, error code and message ( `RecaptchaError(domain: "com.google.recaptcha", code: .errorCodeInternalError, message: "INVALID_CAPTCHA_CLIENT")` code no longer works )
2. They removed public access to action property from RecaptchaAction class ( `capturedAction.action` no longer works)