### PR TITLE
SDKS-4182 New Push device token not stored correctly

### DIFF
--- a/FRAuthenticator/FRAuthenticatorTests/UnitTests/Push/FRAPushHandlerTests.swift
+++ b/FRAuthenticator/FRAuthenticatorTests/UnitTests/Push/FRAPushHandlerTests.swift
@@ -281,7 +281,7 @@ class FRAPushHandlerTests: FRABaseTests {
 
             XCTAssertEqual(jwtPayload["mechanismUid"] as? String, mechanism.mechanismUUID)
             XCTAssertEqual(jwtPayload["deviceName"] as? String, UIDevice.current.name)
-            XCTAssertEqual(jwtPayload["deviceId"] as? String, FRAPushHandler.shared.deviceToken)
+            XCTAssertEqual(jwtPayload["deviceId"] as? String, deviceTokenStr)
             XCTAssertEqual(jwtPayload["deviceType"] as? String, "ios")
             XCTAssertEqual(jwtPayload["communicationType"] as? String, "apns")
 


### PR DESCRIPTION
# JIRA Ticket

[SDKS-4182](https://pingidentity.atlassian.net/browse/SDKS-4182) New Push device token not stored correctly

# Description

This change fix an issue with manual device token updates. While automatic updates correctly refreshed the device token, the `updateDeviceToken(mechanism: PushMechanism, deviceToken:)` method, when used for manual updates, incorrectly sent the previous token. This was due to the method assuming the token was already stored, rather than utilizing the one provided in the parameter.

# Definition of Done Checklist:

- [x] Coded to standards.
- [x] Ensure backward compatibility.
- [x] API reference docs is created or updated, if applicable.
- [x] Unit tests are written or updated.
- [ ] Integration tests are written, if applicable.