### PR TITLE
Rename Data extension bytes property to bytesArray to avoid Xcode26 issues

### DIFF
--- a/FRAuth/FRAuth/WebAuthn/Authenticator/Internal/CredentialStore.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/Internal/CredentialStore.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Lyo Kato on 2018/11/20.
 //  Original work Copyright © 2018 Lyo Kato. All rights reserved.
-//  Modified work Copyright © 2021 ForgeRock, Inc.
+//  Modified work Copyright © 2021 - 2025 Ping Identity Corporation.
 //
 
 import Foundation
@@ -94,7 +94,7 @@ class KeychainCredentialStore : CredentialStore {
         if let items = keychainService.allItems() {
             return items.compactMap { (key, item) -> PublicKeyCredentialSource? in
                 if let itemData = item as? Data {
-                    let credentialSource = PublicKeyCredentialSource.fromCBOR(itemData.bytes)
+                    let credentialSource = PublicKeyCredentialSource.fromCBOR(itemData.bytesArray)
                     //  If PublicKeyCredentialSource has userHandle meaning that it's client-side discoverable PublicKeyCredentialSource
                     //  Only return the client-side discoverable PublicKeyCredentialSource
                     if credentialSource?.userHandle != nil {
@@ -140,7 +140,7 @@ class KeychainCredentialStore : CredentialStore {
         let handle = credentialId.toHexString()
         let keychain = self.getKeychainStore(service: self.servicePrefix + rpId).keychainStore
         if let result = keychain.getData(handle) {
-            return PublicKeyCredentialSource.fromCBOR(result.bytes)
+            return PublicKeyCredentialSource.fromCBOR(result.bytesArray)
         }
         else {
             WAKLogger.debug("[CredentialStore] failed to load data for key:\(handle)")

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/Internal/KeySupport.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/Internal/KeySupport.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Lyo Kato on 2018/11/20.
 //  Original work Copyright © 2018 Lyo Kato. All rights reserved.
-//  Modified work Copyright © 2021 ForgeRock, Inc.
+//  Modified work Copyright © 2021 - 2025 Ping Identity Corporation.
 //
 
 import Foundation
@@ -66,7 +66,7 @@ class ECDSAKeySupport : KeySupport {
     func sign(data: [UInt8], label: String) -> Optional<[UInt8]> {
         
         if let pair = self.createPair(label: label), let signature = pair.sign(data: Data(data)) {
-            return signature.bytes
+            return signature.bytesArray
         }
         else {
             WAKLogger.debug("<ECDSAKeySupport> failed to sign:")
@@ -79,7 +79,7 @@ class ECDSAKeySupport : KeySupport {
         
         if let pair = self.createPair(label: label) {
             do {
-                let publicKey = try pair.getPublicKeyDERData().bytes
+                let publicKey = try pair.getPublicKeyDERData().bytesArray
                 if publicKey.count != 91 {
                     WAKLogger.debug("<ECDSAKeySupport> length of pubKey should be 91: \(publicKey.count)")
                     return nil

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorGetAssertionSession.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorGetAssertionSession.swift
@@ -185,7 +185,7 @@ class PlatformAuthenticatorGetAssertionSession: AuthenticatorGetAssertionSession
                     
                     //  Generate AuthenticatorData based on the information
                     let extensions = SimpleOrderedDictionary<String>()
-                    let authenticatorData = AuthenticatorData(rpIdHash: rpId.sha256!.bytes, userPresent: (requireUserPresence || requireUserVerification), userVerified: requireUserVerification, signCount: newSignCount, attestedCredentialData: nil, extensions: extensions)
+                    let authenticatorData = AuthenticatorData(rpIdHash: rpId.sha256!.bytesArray, userPresent: (requireUserPresence || requireUserVerification), userVerified: requireUserVerification, signCount: newSignCount, attestedCredentialData: nil, extensions: extensions)
                     let authenticatorDataBytes = authenticatorData.toBytes()
                     
                     var data = authenticatorDataBytes

--- a/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorMakeCredentialSession.swift
+++ b/FRAuth/FRAuth/WebAuthn/Authenticator/PlatformAuthenticator/PlatformAuthenticatorMakeCredentialSession.swift
@@ -387,8 +387,8 @@ class PlatformAuthenticatorMakeCredentialSession: AuthenticatorMakeCredentialSes
                     let extensions = SimpleOrderedDictionary<String>()
                     
                     let attestedCredData = AttestedCredentialData(aaguid: UUIDHelper.zeroBytes, credentialId: credentialId, credentialPublicKey: publicKeyCOSE)
-                    let authenticatorData = AuthenticatorData(rpIdHash: rpEntity.id!.sha256!.bytes, userPresent: (requireUserPresence || requireUserVerification), userVerified: requireUserVerification, signCount: 0, attestedCredentialData: attestedCredData, extensions: extensions)
-                    
+                    let authenticatorData = AuthenticatorData(rpIdHash: rpEntity.id!.sha256!.bytesArray, userPresent: (requireUserPresence || requireUserVerification), userVerified: requireUserVerification, signCount: 0, attestedCredentialData: attestedCredData, extensions: extensions)
+
                     guard let attestation = PlatformAttestation.create(authData: authenticatorData, clientDataHash: hash, alg: keySupport.selectedAlg, keyLabel: credSource.keyLabel, attestationPreference: attestationPreference) else {
                         let logMessage = "Failed to create Attestation object"
                         FRLog.e(logMessage, subModule: WebAuthn.module)

--- a/FRAuth/FRAuth/WebAuthn/Client/Client.swift
+++ b/FRAuth/FRAuth/WebAuthn/Client/Client.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Lyo Kato on 2018/11/20.
 //  Original work Copyright © 2018 Lyo Kato. All rights reserved.
-//  Modified work Copyright © 2021-2022 ForgeRock, Inc.
+//  Modified work Copyright © 2021 - 2025 Ping Identity Corporation.
 //
 
 import Foundation
@@ -209,7 +209,7 @@ class WebAuthnClient: ClientOperationDelegate {
 
         let clientDataJSONData = try! JSONEncoder().encode(clientData)
         let clientDataJSON = String(data: clientDataJSONData, encoding: .utf8)!
-        let clientDataHash = clientDataJSONData.sha256.bytes
+        let clientDataHash = clientDataJSONData.sha256.bytesArray
 
         return (clientData, clientDataJSON, clientDataHash)
     }

--- a/FRAuth/FRAuth/WebAuthn/FRWebAuthnManager.swift
+++ b/FRAuth/FRAuth/WebAuthn/FRWebAuthnManager.swift
@@ -152,7 +152,7 @@ public class FRWebAuthnManager: NSObject, ASAuthorizationControllerPresentationC
             FRLog.i("A new passkey was registered: \(credentialRegistration)")
             // Verify the attestationObject and clientDataJSON with your service.
             // The attestationObject contains the user's new public key to store and use for subsequent sign-ins.
-            let int8Arr = credentialRegistration.rawAttestationObject?.bytes.map { Int8(bitPattern: $0) }
+            let int8Arr = credentialRegistration.rawAttestationObject?.bytesArray.map { Int8(bitPattern: $0) }
             let attestationObject = self.convertInt8ArrToStr(int8Arr!)
             
             let clientDataJSON = String(decoding: credentialRegistration.rawClientDataJSON, as: UTF8.self)
@@ -184,10 +184,10 @@ public class FRWebAuthnManager: NSObject, ASAuthorizationControllerPresentationC
             FRLog.i("A passkey was used to sign in: \(credentialAssertion)")
             // Verify the below signature and clientDataJSON with your service for the given userID.
             
-            let signatureInt8 = credentialAssertion.signature.bytes.map { Int8(bitPattern: $0) }
+            let signatureInt8 = credentialAssertion.signature.bytesArray.map { Int8(bitPattern: $0) }
             let signature = self.convertInt8ArrToStr(signatureInt8)
             let clientDataJSON = String(decoding: credentialAssertion.rawClientDataJSON, as: UTF8.self)
-            let authenticatorDataInt8 = credentialAssertion.rawAuthenticatorData.bytes.map { Int8(bitPattern: $0) }
+            let authenticatorDataInt8 = credentialAssertion.rawAuthenticatorData.bytesArray.map { Int8(bitPattern: $0) }
             let authenticatorData = self.convertInt8ArrToStr(authenticatorDataInt8)
             let credID = base64ToBase64url(base64: credentialAssertion.credentialID.base64EncodedString())
             let userIDString = String(decoding: credentialAssertion.userID, as: UTF8.self)
@@ -320,11 +320,5 @@ public class FRWebAuthnManager: NSObject, ASAuthorizationControllerPresentationC
                 self?.asAuthorizationController?.cancel()
             }
         }
-    }
-}
-
-fileprivate extension Data {
-    var bytes: [UInt8] {
-        return [UInt8](self)
     }
 }

--- a/FRCore/FRCore/Util/FRDataUtil.swift
+++ b/FRCore/FRCore/Util/FRDataUtil.swift
@@ -15,7 +15,7 @@ import CommonCrypto
 extension Data {
     
     /// Converts Data object into byte (UInt8) array
-    public var bytes: Array<UInt8> {
+    public var bytesArray: Array<UInt8> {
         return Array(self)
     }
     

--- a/FRCore/FRCore/Util/FRStringUtil.swift
+++ b/FRCore/FRCore/Util/FRStringUtil.swift
@@ -86,7 +86,7 @@ extension String {
     
     /// Converts String to bytes array
     public var bytes: Array<UInt8> {
-        return data(using: String.Encoding.utf8, allowLossyConversion: true)?.bytes ?? Array(utf8)
+        return data(using: String.Encoding.utf8, allowLossyConversion: true)?.bytesArray ?? Array(utf8)
     }
 
     


### PR DESCRIPTION
[SDKS-4299](https://pingidentity.atlassian.net/browse/SDKS-4299) [SPIKE] [iOS] Validate Legacy and Unified SDKs for Xcode 26

Rename Data extension bytes property to bytesArray to avoid Xcode26 issues