### PR TITLE
Fix UserInfo and Address decoding

### DIFF
--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -55,6 +55,8 @@
 		A55D57BE2DC034E6000BDBCA /* FRCaptchaEnterprise.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = A55D57BD2DC034E6000BDBCA /* FRCaptchaEnterprise.framework */; };
 		A55D57BF2DC034E6000BDBCA /* FRCaptchaEnterprise.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = A55D57BD2DC034E6000BDBCA /* FRCaptchaEnterprise.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A5950A2A27EA205B00EDEFE4 /* SSLPinningTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5950A2927EA205B00EDEFE4 /* SSLPinningTests.swift */; };
+		A5A855572E5CFE54001C5349 /* UserInfoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A855562E5CFE49001C5349 /* UserInfoTests.swift */; };
+		A5A855592E5CFEBB001C5349 /* AddressTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5A855582E5CFEB3001C5349 /* AddressTests.swift */; };
 		D512CD41240DC41E00AF520E /* FRRestClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D512CD40240DC41E00AF520E /* FRRestClient.swift */; };
 		D513F17524DA6B490042228B /* AuthApiError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D513F17424DA6B490042228B /* AuthApiError.swift */; };
 		D533270B24806665002FF207 /* TokenManagementPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D533270A24806665002FF207 /* TokenManagementPolicy.swift */; };
@@ -426,6 +428,8 @@
 		A544D6702DBFF31200A2EE4C /* FRCaptchaEnterprise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FRCaptchaEnterprise.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A55D57BD2DC034E6000BDBCA /* FRCaptchaEnterprise.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = FRCaptchaEnterprise.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5950A2927EA205B00EDEFE4 /* SSLPinningTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSLPinningTests.swift; sourceTree = "<group>"; };
+		A5A855562E5CFE49001C5349 /* UserInfoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserInfoTests.swift; sourceTree = "<group>"; };
+		A5A855582E5CFEB3001C5349 /* AddressTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddressTests.swift; sourceTree = "<group>"; };
 		D5015FEE24996AE50025FEB6 /* MetadataCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataCallbackTests.swift; sourceTree = "<group>"; };
 		D5054B4D244680C3007FBA92 /* DeviceProfileCallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeviceProfileCallbackTests.swift; sourceTree = "<group>"; };
 		D5094CD923DF7F850041D5C1 /* CookieTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CookieTests.swift; sourceTree = "<group>"; };
@@ -796,6 +800,15 @@
 			path = "SSL Pinning";
 			sourceTree = "<group>";
 		};
+		A5A855542E5CFE42001C5349 /* User */ = {
+			isa = PBXGroup;
+			children = (
+				A5A855562E5CFE49001C5349 /* UserInfoTests.swift */,
+				A5A855582E5CFEB3001C5349 /* AddressTests.swift */,
+			);
+			path = User;
+			sourceTree = "<group>";
+		};
 		D5094CD823DF7F590041D5C1 /* Cookie */ = {
 			isa = PBXGroup;
 			children = (
@@ -819,6 +832,7 @@
 		D52D1637231484D60095905A /* FRAuth */ = {
 			isa = PBXGroup;
 			children = (
+				A5A855542E5CFE42001C5349 /* User */,
 				A530D47B2CD27534009EC60C /* SelfService */,
 				3A3E78662AB0D602007962B7 /* AppIntegrity */,
 				EC0BA2F72863323A00F8326E /* FROptions */,
@@ -2089,6 +2103,7 @@
 				D5791BC425F87DE8004B487A /* TextOutputCallbackTests.swift in Sources */,
 				D58BC3A52602FB8000254654 /* IdPClientTests.swift in Sources */,
 				D5791BC525F87DE8004B487A /* PollingWaitCallbackTests.swift in Sources */,
+				A5A855592E5CFEBB001C5349 /* AddressTests.swift in Sources */,
 				D5791BC625F87DE8004B487A /* ConfirmationCallbackTests.swift in Sources */,
 				D5791BC725F87DE8004B487A /* DeviceProfileCallbackTests.swift in Sources */,
 				D53A806F26278A5C0093B1CA /* WebAuthnRegistrationCallbackTests.swift in Sources */,
@@ -2131,6 +2146,7 @@
 				D5791BE225F87DE8004B487A /* NetworkReachabilityMonitorTests.swift in Sources */,
 				D58BC38F2602A47600254654 /* IdPCallbackTests.swift in Sources */,
 				95EB7E4D2B8D010B00B59CD6 /* AA_09_PingOneProtectInitializeCallbackTest.swift in Sources */,
+				A5A855572E5CFE54001C5349 /* UserInfoTests.swift in Sources */,
 				95EB7E532B8D5F6100B59CD6 /* AA_10_PingOneProtectEvaluateCallbackTest.swift in Sources */,
 				3A3E78682AB0D642007962B7 /* FRAppAttestDomainModalTests.swift in Sources */,
 				D5791BE325F87DE8004B487A /* FRBaseTest.swift in Sources */,

--- a/FRAuth/FRAuth/User/Address.swift
+++ b/FRAuth/FRAuth/User/Address.swift
@@ -97,10 +97,11 @@ public class Address: NSObject, NSSecureCoding {
     ///
     /// - Parameter aDecoder: NSCoder
     convenience required public init?(coder aDecoder: NSCoder) {
-        if let address = aDecoder.decodeObject(forKey: "address") as? [String: Any] {
-            self.init(address)
+        guard let address = aDecoder.decodeObject(of: [NSDictionary.self, NSString.self, NSNumber.self, NSDate.self, NSURL.self, NSNull.self],
+                                                  forKey: "address") as? [String: Any] else {
+            return nil
         }
-        return nil
+        self.init(address)
     }
     
     

--- a/FRAuth/FRAuth/User/UserInfo.swift
+++ b/FRAuth/FRAuth/User/UserInfo.swift
@@ -185,7 +185,8 @@ public class UserInfo: NSObject, NSSecureCoding {
     ///
     /// - Parameter aDecoder: NSCoder
     convenience required public init?(coder aDecoder: NSCoder) {
-        guard let userInfo = aDecoder.decodeObject(forKey: "userInfo") as? [String: Any] else {
+        guard let userInfo = aDecoder.decodeObject(of: [NSDictionary.self, NSString.self, NSNumber.self, NSDate.self, NSURL.self, NSNull.self],
+                                                   forKey: "userInfo") as? [String: Any] else {
             return nil
         }
         self.init(userInfo)

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/User/AddressTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/User/AddressTests.swift
@@ -1,0 +1,83 @@
+// 
+//  AddressTests.swift
+//  FRAuth
+//
+//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+import XCTest
+import Foundation
+@testable import FRAuth
+
+class AddressTests: XCTestCase {
+    
+    func testValidAddressEncodingDecoding() {
+        guard let response = FRTestStubResponseParser("OAuth2_UserInfo_Success"),
+              let validUserInfo = response.jsonContent["responsePayload"] as? [String : Any],
+              let validAddress = validUserInfo["address"] as? [String : Any] else {
+            XCTFail("[UserInfoTests] Failed to load OAuth2_UserInfo_Success for mock response")
+            return
+        }
+        
+        let originalAddress = Address(validAddress)
+        
+        // Test encoding with secure coding
+        let data = try! NSKeyedArchiver.archivedData(withRootObject: originalAddress, requiringSecureCoding: true)
+        XCTAssertNotNil(data)
+        
+        // Test decoding
+        let decodedAddress = try! NSKeyedUnarchiver.unarchivedObject(ofClass: Address.self, from: data)
+        XCTAssertNotNil(decodedAddress)
+        
+        // Verify data integrity
+        XCTAssertEqual(decodedAddress?.streetAddress, "201 Mission St")
+        XCTAssertEqual(decodedAddress?.locality, "San Francisco")
+        XCTAssertEqual(decodedAddress?.region, "CA")
+        XCTAssertEqual(decodedAddress?.postalCode, "94105")
+        XCTAssertEqual(decodedAddress?.country, "US")
+    }
+    
+    func testEmptyAddressEncodingDecoding() {
+        let emptyAddress: [String: Any] = [:]
+        let address = Address(emptyAddress)
+        
+        let data = try! NSKeyedArchiver.archivedData(withRootObject: address, requiringSecureCoding: true)
+        let decodedAddress = try! NSKeyedUnarchiver.unarchivedObject(ofClass: Address.self, from: data)
+        
+        XCTAssertNotNil(decodedAddress)
+        XCTAssertNil(decodedAddress?.streetAddress)
+        XCTAssertNil(decodedAddress?.locality)
+    }
+    
+    func testRejectMaliciousAddressObjects() {
+        let maliciousAddress: [String: Any] = [
+            "street_address": "123 Main St",
+            "malicious_code": NSObject(), // Should be rejected
+            "locality": "Anytown"
+        ]
+        
+        let address = Address(maliciousAddress)
+        
+        // Should fail with secure coding
+        XCTAssertThrowsError(try NSKeyedArchiver.archivedData(withRootObject: address, requiringSecureCoding: true)) { _ in }
+    }
+    
+    func testRejectNestedMaliciousObjects() {
+        let nestedMaliciousAddress: [String: Any] = [
+            "street_address": "123 Main St",
+            "nested_attack": [
+                "level1": [
+                    "level2": NSObject() // Deeply nested malicious object
+                ]
+            ]
+        ]
+        
+        let address = Address(nestedMaliciousAddress)
+        
+        XCTAssertThrowsError(try NSKeyedArchiver.archivedData(withRootObject: address, requiringSecureCoding: true))
+    }
+    
+}

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/User/UserInfoTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/User/UserInfoTests.swift
@@ -1,0 +1,137 @@
+//
+//  UserInfoTests.swift
+//  FRAuth
+//
+//  Copyright (c) 2025 Ping Identity Corporation. All rights reserved.
+//
+//  This software may be modified and distributed under the terms
+//  of the MIT license. See the LICENSE file for details.
+//
+
+
+import XCTest
+import Foundation
+@testable import FRAuth
+
+class UserInfoTests: XCTestCase {
+    
+    func testValidUserInfoEncodingDecoding() {
+        guard let response = FRTestStubResponseParser("OAuth2_UserInfo_Success"),
+              let validUserInfo = response.jsonContent["responsePayload"] as? [String : Any] else {
+            XCTFail("[UserInfoTests] Failed to load OAuth2_UserInfo_Success for mock response")
+            return
+        }
+
+        let originalUserInfo = UserInfo(validUserInfo)
+
+        // Test encoding
+        let data = try! NSKeyedArchiver.archivedData(withRootObject: originalUserInfo, requiringSecureCoding: true)
+        XCTAssertNotNil(data)
+
+        // Test decoding
+        let decodedUserInfo = try! NSKeyedUnarchiver.unarchivedObject(ofClass: UserInfo.self, from: data)
+        XCTAssertNotNil(decodedUserInfo)
+
+        // Verify data integrity
+        XCTAssertEqual(decodedUserInfo?.sub, "james")
+        XCTAssertEqual(decodedUserInfo?.name, "James Go")
+        XCTAssertEqual(decodedUserInfo?.email, "james.go@forgerock.com")
+        XCTAssertEqual(decodedUserInfo?.emailVerified, true)
+        XCTAssertEqual(decodedUserInfo?.phoneNumberVerified, true)
+    }
+
+    func testEmptyUserInfoEncodingDecoding() {
+        let emptyUserInfo: [String: Any] = [:]
+        let userInfo = UserInfo(emptyUserInfo)
+
+        let data = try! NSKeyedArchiver.archivedData(withRootObject: userInfo, requiringSecureCoding: true)
+        let decodedUserInfo = try! NSKeyedUnarchiver.unarchivedObject(ofClass: UserInfo.self, from: data)
+
+        XCTAssertNotNil(decodedUserInfo)
+        XCTAssertNil(decodedUserInfo?.name)
+        XCTAssertNil(decodedUserInfo?.email)
+    }
+
+    func testRejectUntrustedDataTypes() {
+        // Test rejection of various untrusted data types
+        let untrustedTypes: [String: Any] = [
+            "valid_name": "John Doe",
+            "malicious_array": [NSObject()], // Arrays with objects should be rejected
+            "malicious_dict": ["key": NSObject()], // Nested objects should be rejected
+            "valid_email": "test@example.com"
+        ]
+
+        let userInfo = UserInfo(untrustedTypes)
+
+        XCTAssertThrowsError(try NSKeyedArchiver.archivedData(withRootObject: userInfo, requiringSecureCoding: true))
+    }
+
+    func testRejectInvalidDateFormats() {
+        let invalidDateUserInfo: [String: Any] = [
+            "name": "John Doe",
+            "birthdate": "not-a-date", // Invalid date format
+        ]
+
+        let userInfo = UserInfo(invalidDateUserInfo)
+        XCTAssertNil(userInfo.birthDate) // Invalid date should result in nil
+    }
+
+    func testNilValueHandling() {
+        // Test that nil values are handled properly
+        let userInfoWithNils: [String: Any] = [
+            "name": "John Doe",
+            "email": NSNull(), // Explicit null value
+            "phone_number": "" // Empty string
+        ]
+
+        let userInfo = UserInfo(userInfoWithNils)
+        let data = try! NSKeyedArchiver.archivedData(withRootObject: userInfo, requiringSecureCoding: true)
+        let decoded = try! NSKeyedUnarchiver.unarchivedObject(ofClass: UserInfo.self, from: data)
+
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?.name, "John Doe")
+        // Email should be nil due to NSNull
+        XCTAssertNil(decoded?.email)
+    }
+
+    func testBooleanTypeValidation() {
+        let booleanUserInfo: [String: Any] = [
+            "name": "John Doe",
+            "email_verified": 1, // Number instead of boolean
+            "phone_number_verified": "true" // String instead of boolean
+        ]
+
+        let userInfo = UserInfo(booleanUserInfo)
+        let data = try! NSKeyedArchiver.archivedData(withRootObject: userInfo, requiringSecureCoding: true)
+        let decoded = try! NSKeyedUnarchiver.unarchivedObject(ofClass: UserInfo.self, from: data)
+
+        XCTAssertNotNil(decoded)
+        // Should handle type conversion gracefully
+        XCTAssertFalse(decoded?.phoneNumberVerified ?? true) // Should default to false for invalid types
+    }
+
+    func testUserInfoWithAddressEncodingDecoding() {
+        // Test UserInfo containing Address object
+        let addressData: [String: Any] = [
+            "street_address": "123 Main St",
+            "locality": "Anytown",
+            "postal_code": "12345"
+        ]
+
+        let userInfoData: [String: Any] = [
+            "name": "John Doe",
+            "email": "john@example.com",
+            "address": addressData
+        ]
+
+        let userInfo = UserInfo(userInfoData)
+
+        let data = try! NSKeyedArchiver.archivedData(withRootObject: userInfo, requiringSecureCoding: true)
+        let decoded = try! NSKeyedUnarchiver.unarchivedObject(ofClass: UserInfo.self, from: data)
+
+        XCTAssertNotNil(decoded)
+        XCTAssertEqual(decoded?.name, "John Doe")
+        XCTAssertNotNil(decoded?.address)
+        XCTAssertEqual(decoded?.address?.streetAddress, "123 Main St")
+    }
+}


### PR DESCRIPTION
[SDKS-4346](https://pingidentity.atlassian.net/browse/SDKS-4346) [iOS] [Legacy SDK] [CWE-502] Fix Decoding Methods in NSSecureCoding Implementation

1. Fix decoding for Address and UserInfo
2. Add Unit tests

PS. During implementation I noticed the following:
1. Archiving/Unarchiving is never used for those classes in the SDK
3. Address class had a bug, and would always initialize to nil from a decoder (but as it isn't used we never caught it)