### PR TITLE
fix: preserve credentials on timeout and offline refresh errors

### DIFF
--- a/FRAuth/FRAuth.xcodeproj/project.pbxproj
+++ b/FRAuth/FRAuth.xcodeproj/project.pbxproj
@@ -175,6 +175,7 @@
 		D5791BDE25F87DE8004B487A /* PKCETests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52D164A231484D60095905A /* PKCETests.swift */; };
 		D5791BDF25F87DE8004B487A /* AccessTokenTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52D164B231484D60095905A /* AccessTokenTests.swift */; };
 		D5791BE025F87DE8004B487A /* FRUserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52D164D231484D60095905A /* FRUserTests.swift */; };
+		F9B231D82F5B2A4100A1C2D3 /* FRUserTokenRenewalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9B231D72F5B2A4100A1C2D3 /* FRUserTokenRenewalTests.swift */; };
 		D5791BE125F87DE8004B487A /* FRUserBrowserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5CDB7222527CB1800D7BA49 /* FRUserBrowserTests.swift */; };
 		D5791BE225F87DE8004B487A /* NetworkReachabilityMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52D1640231484D60095905A /* NetworkReachabilityMonitorTests.swift */; };
 		D5791BE325F87DE8004B487A /* FRBaseTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D52D165A231484D60095905A /* FRBaseTest.swift */; };
@@ -448,6 +449,7 @@
 		D52D164A231484D60095905A /* PKCETests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PKCETests.swift; sourceTree = "<group>"; };
 		D52D164B231484D60095905A /* AccessTokenTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccessTokenTests.swift; sourceTree = "<group>"; };
 		D52D164D231484D60095905A /* FRUserTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FRUserTests.swift; sourceTree = "<group>"; };
+		F9B231D72F5B2A4100A1C2D3 /* FRUserTokenRenewalTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FRUserTokenRenewalTests.swift; sourceTree = "<group>"; };
 		D52D164F231484D60095905A /* FRDeviceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FRDeviceTests.swift; sourceTree = "<group>"; };
 		D52D1650231484D60095905A /* FRDeviceIdentifierTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FRDeviceIdentifierTests.swift; sourceTree = "<group>"; };
 		D52D1651231484D60095905A /* FRDeviceCollectorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FRDeviceCollectorTests.swift; sourceTree = "<group>"; };
@@ -916,6 +918,7 @@
 			isa = PBXGroup;
 			children = (
 				D52D164D231484D60095905A /* FRUserTests.swift */,
+				F9B231D72F5B2A4100A1C2D3 /* FRUserTokenRenewalTests.swift */,
 				D5CDB7222527CB1800D7BA49 /* FRUserBrowserTests.swift */,
 			);
 			path = User;
@@ -2142,6 +2145,7 @@
 				ECDF5F4C296851DD007BB721 /* FRWebAuthnTests.swift in Sources */,
 				D5791BDF25F87DE8004B487A /* AccessTokenTests.swift in Sources */,
 				D5791BE025F87DE8004B487A /* FRUserTests.swift in Sources */,
+				F9B231D82F5B2A4100A1C2D3 /* FRUserTokenRenewalTests.swift in Sources */,
 				D5791BE125F87DE8004B487A /* FRUserBrowserTests.swift in Sources */,
 				D5791BE225F87DE8004B487A /* NetworkReachabilityMonitorTests.swift in Sources */,
 				D58BC38F2602A47600254654 /* IdPCallbackTests.swift in Sources */,

--- a/FRAuth/FRAuth/Manager/TokenManager.swift
+++ b/FRAuth/FRAuth/Manager/TokenManager.swift
@@ -256,7 +256,13 @@ struct TokenManager {
         if let ssoToken = self.keychainManager.getSSOToken() {
             self.oAuth2Client.exchangeToken(token: ssoToken) { (token, error) in
                 do {
-                    if error is OAuth2Error || error is AuthApiError {
+                    if let error, self.isNetworkTransportError(error) {
+                        FRLog.w(
+                            "Network transport error during /authorize flow with SSO Token; preserving credentials for retry - \(error.localizedDescription)"
+                        )
+                        completion(nil, error)
+                    }
+                    else if error is OAuth2Error || error is AuthApiError {
                         FRLog.i("OAuth2Error or AuthApiError received while /authorize flow with SSO Token; no more valid credentials and user authentication is required.")
                         FRLog.w("Removing all credentials and state")
                         self.clearCredentials()
@@ -445,6 +451,14 @@ struct TokenManager {
     private func _handleRefreshToken(token: AccessToken, completion: @escaping TokenCompletionCallback) {
         self.refreshUsingRefreshToken(token: token) { (refreshedToken, refreshError) in
             guard let refreshedToken = refreshedToken else {
+                if let refreshError, self.isNetworkTransportError(refreshError) {
+                    FRLog.w(
+                        "refresh_token grant failed due to network transport error; preserving credentials for retry - \(refreshError.localizedDescription)"
+                    )
+                    completion(nil, refreshError)
+                    return
+                }
+
                 if let tokenError = refreshError as? TokenError, case .nullRefreshToken = tokenError {
                     FRLog.w("No refresh_token found; exchanging SSO Token for OAuth2 tokens")
                 } else if let oAuthError = refreshError as? OAuth2Error, case .invalidGrant = oAuthError {
@@ -455,5 +469,30 @@ struct TokenManager {
             }
             completion(refreshedToken, refreshError)
         }
+    }
+
+    /// Detect network transport failures where credentials should be preserved for retry.
+    ///
+    /// Any error in `NSURLErrorDomain` represents a transport-level failure (no internet,
+    /// timeout, connection lost, DNS, TLS), not an OAuth2 credential rejection.
+    /// Also checks inside `AuthApiError.apiRequestFailure` for a wrapped transport error.
+    private func isNetworkTransportError(_ error: Error) -> Bool {
+        if self.isURLErrorDomain(error) {
+            return true
+        }
+
+        guard let authApiError = error as? AuthApiError,
+              case let .apiRequestFailure(_, _, underlyingError) = authApiError else {
+            return false
+        }
+
+        return self.isURLErrorDomain(underlyingError)
+    }
+
+    private func isURLErrorDomain(_ error: Error?) -> Bool {
+        guard let error else {
+            return false
+        }
+        return (error as NSError).domain == URLError.errorDomain
     }
 }

--- a/FRAuth/FRAuth/Manager/TokenManager.swift
+++ b/FRAuth/FRAuth/Manager/TokenManager.swift
@@ -471,28 +471,40 @@ struct TokenManager {
         }
     }
 
-    /// Detect network transport failures where credentials should be preserved for retry.
+    /// Detect retryable network transport failures where credentials should be preserved.
     ///
-    /// Any error in `NSURLErrorDomain` represents a transport-level failure (no internet,
-    /// timeout, connection lost, DNS, TLS), not an OAuth2 credential rejection.
+    /// This classifier intentionally uses a strict whitelist of retryable `URLError.Code`
+    /// values rather than all `NSURLErrorDomain` errors:
+    /// `notConnectedToInternet`, `networkConnectionLost`, `timedOut`,
+    /// `cannotFindHost`, `cannotConnectToHost`, and `dnsLookupFailed`.
     /// Also checks inside `AuthApiError.apiRequestFailure` for a wrapped transport error.
     private func isNetworkTransportError(_ error: Error) -> Bool {
-        if self.isURLErrorDomain(error) {
-            return true
-        }
-
+        let resolved = underlyingTransportError(from: error)
+        guard let urlError = resolved as? URLError else { return false }
+        return Self.retryableTransportCodes.contains(urlError.code)
+    }
+    
+    /// Extracts the underlying transport error from an `AuthApiError.apiRequestFailure`,
+    /// or returns the error itself if it's not wrapped.
+    private func underlyingTransportError(from error: Error) -> Error {
         guard let authApiError = error as? AuthApiError,
-              case let .apiRequestFailure(_, _, underlyingError) = authApiError else {
-            return false
+              case let .apiRequestFailure(_, _, underlyingError) = authApiError,
+              let underlyingError else {
+            return error
         }
-
-        return self.isURLErrorDomain(underlyingError)
+        return underlyingError
     }
-
-    private func isURLErrorDomain(_ error: Error?) -> Bool {
-        guard let error else {
-            return false
-        }
-        return (error as NSError).domain == URLError.errorDomain
-    }
+    
+    /// Retry-safe URL loading failures that represent transient transport conditions.
+    ///
+    /// These codes indicate temporary connectivity/path issues where local credentials remain valid,
+    /// so token renewal should fail fast and allow callers to retry without destructive cleanup.
+    private static let retryableTransportCodes: Set<URLError.Code> = [
+        .notConnectedToInternet,
+        .networkConnectionLost,
+        .timedOut,
+        .cannotFindHost,
+        .cannotConnectToHost,
+        .dnsLookupFailed
+    ]
 }

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Model/User/FRUserTokenRenewalTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Model/User/FRUserTokenRenewalTests.swift
@@ -1376,4 +1376,63 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
             XCTFail("Failed to retrieve KeychainManager")
         }
     }
+
+    func test_32_FRUser_GetAccessToken_RefreshTokenGrant_NetworkConnectionLost_PreservesCredentials() {
+
+        // Start SDK
+        self.startSDK()
+
+        // Perform login first
+        self.performLogin()
+
+        // Use a custom transport failure for refresh_token request.
+        self.loadMockResponses(["OAuth2_Token_Refresh_Success"])
+        guard let mockResponse = FRTestNetworkStubProtocol.mockedResponses.last else {
+            XCTFail("Failed to load mock response")
+            return
+        }
+        mockResponse.response = nil
+        mockResponse.responsePayload = nil
+        mockResponse.redirectRequest = nil
+        mockResponse.error = URLError(.networkConnectionLost)
+
+
+        // Validate FRUser.currentUser
+        guard let user = FRUser.currentUser else {
+            XCTFail("Failed to perform user login")
+            return
+        }
+
+        // Expire access_token to enforce refresh_token grant.
+        guard let at1 = user.token else {
+            XCTFail("Failed to fetch AccessToken")
+            return
+        }
+        at1.expiresIn = 0
+        if let tokenManager = self.config.tokenManager {
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
+        }
+
+        let ex = self.expectation(description: "Get Access Token")
+        user.getAccessToken { (user, error) in
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+
+            let nsError = error as NSError?
+            XCTAssertEqual(nsError?.domain, NSURLErrorDomain)
+            XCTAssertEqual(nsError?.code, NSURLErrorNetworkConnectionLost)
+
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+
+
+        if let keychainManager = FRAuth.shared?.keychainManager {
+            XCTAssertNotNil(try? keychainManager.getAccessToken())
+            XCTAssertNotNil(keychainManager.getSSOToken())
+        }
+        else {
+            XCTFail("Failed to retrieve KeychainManager")
+        }
+    }
 }

--- a/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Model/User/FRUserTokenRenewalTests.swift
+++ b/FRAuth/FRAuthTests/FRAuthSwiftTests/FRAuth/Model/User/FRUserTokenRenewalTests.swift
@@ -10,6 +10,7 @@
 
 
 import XCTest
+@testable import FRAuth
 
 class FRUserTokenRenewalTests: FRAuthBaseTest {
 
@@ -45,7 +46,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         do {
@@ -84,7 +85,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         let ex = self.expectation(description: "Get User Info")
@@ -124,13 +125,13 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
             // Persist original AccessToken
             // Manually update token lifetime to force token refresh
             at.expiresIn = 0
-            try tokenManager.persist(token: at)
+            try tokenManager.keychainManager.setAccessToken(token: at)
         }
         catch {
             XCTFail("Failed to store AccessToken object: \(error.localizedDescription)")
         }
         
-        let user = FRUser(token: at, serverConfig: serverConfig)
+        let user = FRUser(token: at)
         
         let ex = self.expectation(description: "Get User Info")
         user.getAccessToken { (user, error) in
@@ -180,13 +181,13 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
             // Persist original AccessToken
             // Manually update token lifetime to force token refresh
             at.expiresIn = 0
-            try tokenManager.persist(token: at)
+            try tokenManager.keychainManager.setAccessToken(token: at)
         }
         catch {
             XCTFail("Failed to store AccessToken object: \(error.localizedDescription)")
         }
         
-        var user = FRUser(token: at, serverConfig: serverConfig)
+        var user = FRUser(token: at)
         
         do {
             user = try user.getAccessToken()
@@ -231,7 +232,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         }
         
         // Do not persist token, or user object to test no token from Keychain storage
-        var user = FRUser(token: at, serverConfig: serverConfig)
+        var user = FRUser(token: at)
         
         do {
             user = try user.getAccessToken()
@@ -275,7 +276,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         }
         
         // Do not persist token, or user object to test no token from Keychain storage
-        let user = FRUser(token: at, serverConfig: serverConfig)
+        let user = FRUser(token: at)
         
         let ex = self.expectation(description: "Get User Info")
         user.getAccessToken { (user, error) in
@@ -327,7 +328,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         let oldRefreshToken = at1.refreshToken
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         do {
@@ -370,7 +371,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         let oldRefreshToken = at1.refreshToken
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         let ex = self.expectation(description: "Get Access Token")
@@ -414,7 +415,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         let oldRefreshToken = at1.refreshToken
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         do {
@@ -457,7 +458,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         let oldRefreshToken = at1.refreshToken
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         let ex = self.expectation(description: "Get Access Token")
@@ -503,7 +504,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         // Expire access_token to enforce refresh_token grant which will fail with OAuth2Error.invalidGrant, and proceed with authorize flow with SSO token
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         let ex = self.expectation(description: "Get Access Token")
@@ -543,7 +544,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         // Expire access_token to enforce refresh_token grant which will fail with other than OAuth2Error.invalidGrant
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         let ex = self.expectation(description: "Get Access Token")
@@ -596,7 +597,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         // Expire access_token to enforce refresh_token grant which will fail with other than OAuth2Error.invalidGrant
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         let ex = self.expectation(description: "Get Access Token")
@@ -649,7 +650,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         // Expire access_token to enforce refresh_token grant which will fail with other than OAuth2Error.invalidGrant
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         let ex = self.expectation(description: "Get Access Token")
@@ -702,7 +703,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         // Expire access_token to enforce refresh_token grant which will fail with OAuth2Error.invalidGrant, and proceed with authorize flow with SSO token
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         do {
@@ -742,7 +743,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         // Expire access_token to enforce refresh_token grant which will fail with other than OAuth2Error.invalidGrant
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         do {
@@ -784,7 +785,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         // Expire access_token to enforce refresh_token grant which will fail with other than OAuth2Error.invalidGrant
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         do {
@@ -826,7 +827,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         // Expire access_token to enforce refresh_token grant which will fail with other than OAuth2Error.invalidGrant
         at1.expiresIn = 0
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         
@@ -1185,7 +1186,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         // Manually change SSO Token associated with AccessToken to invalidate OAuth2 token, and force to go through /authorize flow
         at1.sessionToken = "different_sso_token"
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         let ex = self.expectation(description: "Get Access Token")
@@ -1225,7 +1226,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         // Manually change SSO Token associated with AccessToken to invalidate OAuth2 token, and force to go through /authorize flow
         at1.sessionToken = "different_sso_token"
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         do {
@@ -1265,7 +1266,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         // Manually change SSO Token associated with AccessToken to invalidate OAuth2 token, and force to go through /authorize flow
         at1.sessionToken = "different_sso_token"
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         let ex = self.expectation(description: "Get Access Token")
@@ -1305,7 +1306,7 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
         // Manually change SSO Token associated with AccessToken to invalidate OAuth2 token, and force to go through /authorize flow
         at1.sessionToken = "different_sso_token"
         if let tokenManager = self.config.tokenManager {
-            try? tokenManager.persist(token: at1)
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
         }
         
         do {
@@ -1316,5 +1317,63 @@ class FRUserTokenRenewalTests: FRAuthBaseTest {
             XCTFail("Failed with unexpected error: \(error.localizedDescription)")
         }
     }
-    
+
+    func test_31_FRUser_GetAccessToken_RefreshTokenGrant_NoInternet_PreservesCredentials() {
+
+        // Start SDK
+        self.startSDK()
+
+        // Perform login first
+        self.performLogin()
+
+        // Use a custom transport failure for refresh_token request.
+        self.loadMockResponses(["OAuth2_Token_Refresh_Success"])
+        guard let mockResponse = FRTestNetworkStubProtocol.mockedResponses.last else {
+            XCTFail("Failed to load mock response")
+            return
+        }
+        mockResponse.response = nil
+        mockResponse.responsePayload = nil
+        mockResponse.redirectRequest = nil
+        mockResponse.error = URLError(.notConnectedToInternet)
+
+
+        // Validate FRUser.currentUser
+        guard let user = FRUser.currentUser else {
+            XCTFail("Failed to perform user login")
+            return
+        }
+
+        // Expire access_token to enforce refresh_token grant.
+        guard let at1 = user.token else {
+            XCTFail("Failed to fetch AccessToken")
+            return
+        }
+        at1.expiresIn = 0
+        if let tokenManager = self.config.tokenManager {
+            try? tokenManager.keychainManager.setAccessToken(token: at1)
+        }
+
+        let ex = self.expectation(description: "Get Access Token")
+        user.getAccessToken { (user, error) in
+            XCTAssertNil(user)
+            XCTAssertNotNil(error)
+
+            let nsError = error as NSError?
+            XCTAssertEqual(nsError?.domain, NSURLErrorDomain)
+            XCTAssertEqual(nsError?.code, NSURLErrorNotConnectedToInternet)
+
+            ex.fulfill()
+        }
+        waitForExpectations(timeout: 60, handler: nil)
+
+
+        if let keychainManager = FRAuth.shared?.keychainManager {
+            XCTAssertNotNil(try? keychainManager.getAccessToken())
+            XCTAssertNotNil(keychainManager.getSSOToken())
+        }
+        else {
+            XCTFail("Failed to retrieve KeychainManager")
+        }
+    }
 }

--- a/e2e/FRExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/e2e/FRExample.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -101,15 +101,6 @@
       }
     },
     {
-      "identity" : "promises",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/google/promises.git",
-      "state" : {
-        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
-        "version" : "2.4.0"
-      }
-    },
-    {
       "identity" : "recaptcha-enterprise-mobile-sdk",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/GoogleCloudPlatform/recaptcha-enterprise-mobile-sdk",


### PR DESCRIPTION
This PR fixes an auth reliability issue where temporary network failures during token renewal could force a full logout.

## Problem

 When getAccessToken() triggered renewal and the request failed due to transport conditions (no internet or timeout), the flow treated that failure like an unrecoverable auth rejection and cleared local auth state.

  That converted a transient outage into a permanent logout, requiring full re-authentication even
  though credentials could still be valid.

  ## Context

  - Clearing tokens on transport failure degrades user experience and causes unnecessary re-login.
  - SDK consumers need the original failure reason to handle retry UX correctly.

  ## What changed

For transport-level failures (offline/timeout), token renewal is now non-destructive:
  - local auth state is preserved
  - the original network error is returned to the caller

Behavior for true authentication failures (for example invalid/unauthorized token scenarios) is unchanged.

  ## Impact

  Users are no longer logged out because of temporary network problems, and clients can show retry UX based on the actual failure.