### PR TITLE
[fix] Add @MainActor and fix availability for Xcode 26.4 compatibility

### DIFF
--- a/FRAuth/FRAuth/SocialLogin/AppleSignInHandler.swift
+++ b/FRAuth/FRAuth/SocialLogin/AppleSignInHandler.swift
@@ -120,13 +120,13 @@ public class AppleSignInHandler: NSObject, IdPHandler {
 }
 
 
+@available(iOS 13.0, *)
 extension AppleSignInHandler: ASAuthorizationControllerDelegate {
-    @available(iOS 13.0, *)
-    public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+    @MainActor public func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
         switch authorization.credential {
         case let appleIDCredential as ASAuthorizationAppleIDCredential:
             FRLog.v("ASAuthorizationAppleIDCredential received: \(appleIDCredential)")
-            
+
             if self.acceptsJSON == true {
                 let appleSignInResponse = AppleSignInResponse(appleIDCredential)
                 guard let IDToken1tokenJSON = try? JSONEncoder().encode(appleSignInResponse), let IDToken1token = String(data: IDToken1tokenJSON, encoding: .utf8) else {
@@ -142,7 +142,7 @@ extension AppleSignInHandler: ASAuthorizationControllerDelegate {
                 }
                 self.completionCallback?(id_token, self.tokenType, nil)
             }
-            
+
             break
         case let passwordCredential as ASPasswordCredential:
             FRLog.v("ASPasswordCredential received: \(passwordCredential)")
@@ -152,24 +152,22 @@ extension AppleSignInHandler: ASAuthorizationControllerDelegate {
             break
         }
     }
-    
-    
-    @available(iOS 13.0, *)
-    public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+
+
+    @MainActor public func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
         FRLog.e("An error occurred during Sign-in With Apple: \(error.localizedDescription)")
         self.completionCallback?(nil, nil, error)
     }
 }
 
 
+@available(iOS 13.0, *)
 extension AppleSignInHandler: ASAuthorizationControllerPresentationContextProviding {
-    @available(iOS 13.0, *)
-    public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+    @MainActor public func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
         return ASPresentationAnchor()
     }
-    
-    @available(iOS 13.0, *)
-    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+
+    @MainActor public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         return ASPresentationAnchor()
     }
 }

--- a/FRAuth/FRAuth/User/Browser.swift
+++ b/FRAuth/FRAuth/User/Browser.swift
@@ -529,10 +529,10 @@ extension Browser: SFSafariViewControllerDelegate {
 
 
 //  MARK: - ASWebAuthenticationPresentationContextProviding
+@available(iOS 13.0, *)
 extension Browser: ASWebAuthenticationPresentationContextProviding {
     /// Delegation method for ASWebAuthenticationPresentationContextProviding; only available for iOS 13.0 or above
-    @available(iOS 13.0, *)
-    public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+    @MainActor public func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         if let presentingViewController = self.presentingViewController, let window = presentingViewController.view.window {
             return window
         }


### PR DESCRIPTION
## Summary

- Xcode 26.4's Swift compiler now requires `@MainActor` on methods conforming to `ASAuthorizationControllerDelegate`, `ASAuthorizationControllerPresentationContextProviding`, and `ASWebAuthenticationPresentationContextProviding`.
- Moved `@available(iOS 13.0, *)` from individual method implementations to the extension level to resolve conflicts with the iOS 12.0 minimum deployment target.
- Without these changes, the SDK fails to compile on Xcode 26.4.

### Files changed
- `FRAuth/FRAuth/SocialLogin/AppleSignInHandler.swift`
- `FRAuth/FRAuth/User/Browser.swift`

## Test plan
- [x] Build succeeds on Xcode 26.4 (iPhone 17, iOS 26.4 Simulator)
- [x] Full test suite passes (1137 passed, 29 skipped, 13 pre-existing server-dependent failures unrelated to this change)
- [x] No new warnings or errors introduced