### PR TITLE
SDKS-4922 - Improving the Biometric_allow_fallback to respect the PIN if the biom…

### DIFF
--- a/FRCore/FRCore/Authenticator/AppPinAuthenticator.swift
+++ b/FRCore/FRCore/Authenticator/AppPinAuthenticator.swift
@@ -2,7 +2,7 @@
 //  AppPinAuthenticator.swift
 //  FRCore
 //
-//  Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -40,7 +40,7 @@ public class AppPinAuthenticator {
     }
     
     
-    /// Access Control for the authetication type
+    /// Access Control for the authentication type
     open func accessControl() -> SecAccessControl? {
 #if !targetEnvironment(simulator)
         return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.applicationPassword, .privateKeyUsage], nil)

--- a/FRDeviceBinding/FRDeviceBinding/Sources/ApplicationPinDeviceAuthenticator.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/ApplicationPinDeviceAuthenticator.swift
@@ -52,7 +52,7 @@ open class ApplicationPinDeviceAuthenticator: DefaultDeviceAuthenticator, Crypto
     }
     
     
-    /// Access Control for the authetication type
+    /// Access Control for the authentication type
     open override func accessControl() -> SecAccessControl? {
         return appPinAuthenticator?.accessControl()
     }

--- a/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/DeviceBindingCallback.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/DeviceBindingCallback.swift
@@ -2,7 +2,7 @@
 //  DeviceBindingCallback.swift
 //  FRDeviceBinding
 //
-//  Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.

--- a/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/DeviceBindingCallback.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/Callbacks/DeviceBindingCallback.swift
@@ -193,7 +193,7 @@ open class DeviceBindingCallback: MultipleValuesCallback, Binding {
         
         do {
             let keyPair = try authInterface.generateKeys()
-            userKey = UserKey(id: keyPair.keyAlias, userId: userId, userName: userName, kid: UUID().uuidString, authType: deviceBindingAuthenticationType, createdAt: Date().timeIntervalSince1970)
+            userKey = UserKey(id: keyPair.keyAlias, userId: userId, userName: userName, kid: UUID().uuidString, authType: deviceBindingAuthenticationType, createdAt: Date().timeIntervalSince1970, biometricDomainState: authInterface.biometricDomainState())
             guard let userKey = userKey else {
                 throw DeviceBindingStatus.unsupported(errorMessage: "Cannot create userKey")
             }

--- a/FRDeviceBinding/FRDeviceBinding/Sources/DeviceBindingAuthenticators.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/DeviceBindingAuthenticators.swift
@@ -53,6 +53,9 @@ public protocol DeviceAuthenticator {
     /// Get the Device Binding Authentication Type
     func type() -> DeviceBindingAuthenticationType
     
+    /// Get the current biometric domain state for detecting enrollment changes
+    func biometricDomainState() -> Data?
+    
     /// initialize already created entity with useriD and Promp
     /// - Parameter userId: userId of the authentication
     /// - Parameter prompt: Prompt containing the description for authentication
@@ -100,6 +103,11 @@ open class DefaultDeviceAuthenticator: DeviceAuthenticator {
     /// Get the Device Binding Authentication Type
     open func type() -> DeviceBindingAuthenticationType {
         return .none
+    }
+    
+    /// Get the current biometric domain state. Returns nil by default.
+    open func biometricDomainState() -> Data? {
+        return nil
     }
     
     /// Remove Keys
@@ -370,15 +378,39 @@ open class BiometricAndDeviceCredential: BiometricAuthenticator {
     /// Access Control for the authetication type
     open override func accessControl() -> SecAccessControl? {
 #if !targetEnvironment(simulator)
-        return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.biometryCurrentSet, .or, .devicePasscode, .privateKeyUsage], nil)
+        return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.biometryAny, .or, .devicePasscode, .privateKeyUsage], nil)
 #else
-        return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.biometryCurrentSet, .or, .devicePasscode], nil)
+        return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.biometryAny, .or, .devicePasscode], nil)
 #endif
     }
     
     
     open override func type() -> DeviceBindingAuthenticationType {
         return .biometricAllowFallback
+    }
+    
+    
+    /// Returns the current biometric domain state from LAContext.
+    /// Used to detect biometric enrollment changes between bind and sign operations.
+    open override func biometricDomainState() -> Data? {
+        let context = LAContext()
+        context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+        return context.evaluatedPolicyDomainState
+    }
+    
+    
+    /// Override sign to validate biometric enrollment has not changed since binding.
+    /// If biometrics were enrolled at bind time and the enrollment has since changed,
+    /// the keys are deleted and `.clientNotRegistered` is thrown to trigger re-binding.
+    open override func sign(userKey: UserKey, challenge: String, expiration: Date, customClaims: [String: Any] = [:]) throws -> String {
+        if let storedState = userKey.biometricDomainState {
+            let currentState = biometricDomainState()
+            if currentState != storedState {
+                deleteKeys()
+                throw DeviceBindingStatus.clientNotRegistered
+            }
+        }
+        return try super.sign(userKey: userKey, challenge: challenge, expiration: expiration, customClaims: customClaims)
     }
 }
 

--- a/FRDeviceBinding/FRDeviceBinding/Sources/DeviceBindingAuthenticators.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/DeviceBindingAuthenticators.swift
@@ -340,7 +340,26 @@ open class BiometricOnly: BiometricAuthenticator {
 }
 
 
-/// DeviceAuthenticator adoption for biometric and Device Credential authentication
+/// DeviceAuthenticator adoption for biometric and Device Credential authentication.
+///
+/// This authenticator supports the `BIOMETRIC_ALLOW_FALLBACK` policy, allowing authentication
+/// via either biometrics (Face ID / Touch ID) or device passcode.
+///
+/// ## Security Model
+///
+/// Unlike `BiometricOnly` which uses `.biometryCurrentSet` to have the Secure Enclave
+/// hardware-invalidate keys when biometric enrollment changes, this class uses a dynamic
+/// access control policy:
+/// - **Biometrics enrolled**: `.biometryAny OR .devicePasscode` — allows both authentication methods.
+/// - **No biometrics enrolled**: `.devicePasscode` only — avoids Secure Enclave key creation failure.
+///
+/// Because `.biometryAny` does not invalidate keys on biometric enrollment changes at the
+/// hardware level, this class compensates with a software-level check using
+/// `LAContext.evaluatedPolicyDomainState`. The biometric domain state is captured at bind time
+/// and stored in the `UserKey`. During signing, the stored state is compared against the current
+/// state — if they differ (e.g., a fingerprint was added or removed), the keys are deleted and
+/// re-binding is required.
+///
 open class BiometricAndDeviceCredential: BiometricAuthenticator {
     /// local authentication policy for authentication
     var policy: LAPolicy

--- a/FRDeviceBinding/FRDeviceBinding/Sources/DeviceBindingAuthenticators.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/DeviceBindingAuthenticators.swift
@@ -44,7 +44,7 @@ public protocol DeviceAuthenticator {
     /// Check if authentication is supported
     func isSupported() -> Bool
     
-    /// Access Control for the authetication type
+    /// Access Control for the authentication type
     func accessControl() -> SecAccessControl?
     
     /// Set the Authentication Prompt
@@ -56,12 +56,12 @@ public protocol DeviceAuthenticator {
     /// Get the current biometric domain state for detecting enrollment changes
     func biometricDomainState() -> Data?
     
-    /// initialize already created entity with useriD and Promp
+    /// initialize already created entity with userID and Prompt
     /// - Parameter userId: userId of the authentication
     /// - Parameter prompt: Prompt containing the description for authentication
     func initialize(userId: String, prompt: Prompt)
     
-    /// initialize already created entity with useriD and Promp
+    /// initialize already created entity with userID and Prompt
     /// - Parameter userId: userId of the authentication
     func initialize(userId: String)
     
@@ -81,6 +81,14 @@ public protocol DeviceAuthenticator {
 }
 
 
+public extension DeviceAuthenticator {
+    /// Default implementation returns nil (no biometric state tracking).
+    func biometricDomainState() -> Data? {
+        return nil
+    }
+}
+
+
 open class DefaultDeviceAuthenticator: DeviceAuthenticator {
     /// prompt  for authentication if applicable
     var prompt: Prompt?
@@ -95,7 +103,7 @@ open class DefaultDeviceAuthenticator: DeviceAuthenticator {
         return false
     }
     
-    /// Access Control for the authetication type
+    /// Access Control for the authentication type
     open func accessControl() -> SecAccessControl? {
         return nil
     }
@@ -205,7 +213,7 @@ open class DefaultDeviceAuthenticator: DeviceAuthenticator {
     }
     
     
-    /// initialize already created entity with useriD and Promp
+    /// initialize already created entity with userID and Prompt
     /// - Parameter userId: userId of the authentication
     /// - Parameter prompt: Prompt containing the description for authentication
     open func initialize(userId: String, prompt: Prompt) {
@@ -215,7 +223,7 @@ open class DefaultDeviceAuthenticator: DeviceAuthenticator {
     }
     
     
-    /// initialize already created entity with useriD and Promp
+    /// initialize already created entity with userID and Prompt
     /// - Parameter userId: userId of the authentication
     open func initialize(userId: String) {
         
@@ -316,7 +324,7 @@ open class BiometricOnly: BiometricAuthenticator {
     }
     
     
-    /// Access Control for the authetication type
+    /// Access Control for the authentication type
     open override func accessControl() -> SecAccessControl? {
 #if !targetEnvironment(simulator)
         return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.biometryCurrentSet, .privateKeyUsage], nil)
@@ -380,7 +388,7 @@ open class BiometricAndDeviceCredential: BiometricAuthenticator {
     }
     
     
-    /// Access Control for the authetication type.
+    /// Access Control for the authentication type.
     /// Dynamically selects flags based on biometric availability:
     /// - When biometrics are enrolled: `.biometryAny OR .devicePasscode`
     /// - When only passcode is set: `.devicePasscode` only
@@ -411,7 +419,7 @@ open class BiometricAndDeviceCredential: BiometricAuthenticator {
     /// Used to detect biometric enrollment changes between bind and sign operations.
     open override func biometricDomainState() -> Data? {
         let context = LAContext()
-        context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
+        _ = context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
         return context.evaluatedPolicyDomainState
     }
     
@@ -460,7 +468,7 @@ open class None: DefaultDeviceAuthenticator, CryptoAware {
     }
     
     
-    /// Access Control for the authetication type
+    /// Access Control for the authentication type
     open override func accessControl() -> SecAccessControl? {
         return nil
     }

--- a/FRDeviceBinding/FRDeviceBinding/Sources/DeviceBindingAuthenticators.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/DeviceBindingAuthenticators.swift
@@ -356,7 +356,12 @@ open class BiometricAndDeviceCredential: BiometricAuthenticator {
 #if !targetEnvironment(simulator)
         let context = LAContext()
         context.localizedReason = prompt.description
-        keyBuilderQuery[String(kSecUseAuthenticationContext)] = context
+        // Only attach LAContext for biometric pre-authentication when biometrics
+        // are enrolled. When only passcode is set, the system will prompt for
+        // passcode automatically when the key is used for signing.
+        if context.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil) {
+            keyBuilderQuery[String(kSecUseAuthenticationContext)] = context
+        }
 #endif
         
         do {
@@ -375,13 +380,25 @@ open class BiometricAndDeviceCredential: BiometricAuthenticator {
     }
     
     
-    /// Access Control for the authetication type
+    /// Access Control for the authetication type.
+    /// Dynamically selects flags based on biometric availability:
+    /// - When biometrics are enrolled: `.biometryAny OR .devicePasscode`
+    /// - When only passcode is set: `.devicePasscode` only
+    /// This avoids Secure Enclave rejecting key creation when biometry flags
+    /// are present but no biometrics are enrolled.
     open override func accessControl() -> SecAccessControl? {
+        let laContext = LAContext()
+        let biometricsAvailable = laContext.canEvaluatePolicy(.deviceOwnerAuthenticationWithBiometrics, error: nil)
 #if !targetEnvironment(simulator)
-        return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.biometryAny, .or, .devicePasscode, .privateKeyUsage], nil)
+        let flags: SecAccessControlCreateFlags = biometricsAvailable
+            ? [.biometryAny, .or, .devicePasscode, .privateKeyUsage]
+            : [.devicePasscode, .privateKeyUsage]
 #else
-        return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, [.biometryAny, .or, .devicePasscode], nil)
+        let flags: SecAccessControlCreateFlags = biometricsAvailable
+            ? [.biometryAny, .or, .devicePasscode]
+            : [.devicePasscode]
 #endif
+        return SecAccessControlCreateWithFlags(kCFAllocatorDefault, kSecAttrAccessibleWhenPasscodeSetThisDeviceOnly, flags, nil)
     }
     
     

--- a/FRDeviceBinding/FRDeviceBinding/Sources/UserDeviceKeyService.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/UserDeviceKeyService.swift
@@ -2,7 +2,7 @@
 //  UserDeviceKeyService.swift
 //  FRDeviceBinding
 //
-//  Copyright (c) 2022 - 2025 Ping Identity Corporation. All rights reserved.
+//  Copyright (c) 2022 - 2026 Ping Identity Corporation. All rights reserved.
 //
 //  This software may be modified and distributed under the terms
 //  of the MIT license. See the LICENSE file for details.
@@ -99,11 +99,17 @@ public enum KeyFoundStatus {
 
 
 public struct UserKey: Equatable, Codable {
+    /// Unique identifier for the key, derived from the key alias (SHA256 hash of userId)
     public var id: String
+    /// The user identifier associated with this key
     public var userId: String
+    /// The display name of the user
     public var userName: String
+    /// The key identifier (UUID) used in JWS headers to identify the signing key
     public var kid: String
+    /// The authentication type used when the key was created
     public var authType: DeviceBindingAuthenticationType
+    /// The timestamp (seconds since epoch) when the key was created
     public var createdAt: Double
     /// The biometric domain state captured at bind time, used to detect biometric enrollment changes
     public var biometricDomainState: Data?

--- a/FRDeviceBinding/FRDeviceBinding/Sources/UserDeviceKeyService.swift
+++ b/FRDeviceBinding/FRDeviceBinding/Sources/UserDeviceKeyService.swift
@@ -105,4 +105,6 @@ public struct UserKey: Equatable, Codable {
     public var kid: String
     public var authType: DeviceBindingAuthenticationType
     public var createdAt: Double
+    /// The biometric domain state captured at bind time, used to detect biometric enrollment changes
+    public var biometricDomainState: Data?
 }

--- a/FRDeviceBinding/FRDeviceBindingTests/DeviceAuthenticatorTests.swift
+++ b/FRDeviceBinding/FRDeviceBindingTests/DeviceAuthenticatorTests.swift
@@ -495,4 +495,149 @@ class DeviceAuthenticatorTests: FRBaseTestCase {
         XCTAssertTrue(valid)
     }
     
+    
+    // MARK: - biometricDomainState tests
+    
+    func test_16_biometricDomainState_defaultReturnsNil() {
+        // DefaultDeviceAuthenticator base implementation should return nil
+        let noneAuthenticator = None()
+        XCTAssertNil(noneAuthenticator.biometricDomainState())
+        
+        let biometricOnly = BiometricOnly()
+        XCTAssertNil(biometricOnly.biometricDomainState())
+        
+        let appPin = ApplicationPinDeviceAuthenticator()
+        XCTAssertNil(appPin.biometricDomainState())
+    }
+    
+    
+    func test_17_biometricDomainState_biometricAndDeviceCredential() {
+        // On simulator without biometrics, evaluatedPolicyDomainState returns nil
+        let authenticator = BiometricAndDeviceCredential()
+        let state = authenticator.biometricDomainState()
+        // On simulator biometrics are not enrolled, so domain state is nil
+        XCTAssertNil(state)
+    }
+    
+    
+    func test_18_biometricDomainState_storedInUserKey() {
+        // Verify biometricDomainState can be stored and retrieved from UserKey
+        let testData = "test-biometric-state".data(using: .utf8)
+        let userKey = UserKey(id: "id", userId: "user", userName: "name", kid: "kid", authType: .biometricAllowFallback, createdAt: Date().timeIntervalSince1970, biometricDomainState: testData)
+        XCTAssertEqual(userKey.biometricDomainState, testData)
+        
+        // Verify it encodes/decodes correctly
+        let encoded = try! JSONEncoder().encode(userKey)
+        let decoded = try! JSONDecoder().decode(UserKey.self, from: encoded)
+        XCTAssertEqual(decoded.biometricDomainState, testData)
+    }
+    
+    
+    func test_19_biometricDomainState_nilInUserKey_backwardCompatibility() {
+        // Verify UserKey without biometricDomainState decodes correctly (backward compatibility)
+        let userKey = UserKey(id: "id", userId: "user", userName: "name", kid: "kid", authType: .none, createdAt: Date().timeIntervalSince1970)
+        XCTAssertNil(userKey.biometricDomainState)
+        
+        // Simulate a UserKey encoded without the biometricDomainState field
+        let json = """
+        {"id":"id","userId":"user","userName":"name","kid":"kid","authType":"NONE","createdAt":1000000}
+        """
+        let decoded = try! JSONDecoder().decode(UserKey.self, from: json.data(using: .utf8)!)
+        XCTAssertNil(decoded.biometricDomainState)
+    }
+    
+    
+    func test_20_biometricDomainState_signRejectsMismatch() {
+        // BiometricAndDeviceCredential.sign(userKey:...) should throw .clientNotRegistered
+        // when stored biometricDomainState doesn't match current state
+        let userId = "Test User Id 20"
+        let challenge = "challenge"
+        let expiration = Date().addingTimeInterval(60.0)
+        
+        let authenticator = BiometricAndDeviceCredential()
+        authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: ""))
+        
+        // Create a UserKey with a fake stored biometric state that won't match current
+        let fakeState = "fake-biometric-state".data(using: .utf8)
+        let userKey = UserKey(id: "id", userId: userId, userName: "name", kid: UUID().uuidString, authType: .biometricAllowFallback, createdAt: Date().timeIntervalSince1970, biometricDomainState: fakeState)
+        
+        do {
+            _ = try authenticator.sign(userKey: userKey, challenge: challenge, expiration: expiration, customClaims: [:])
+            XCTFail("Sign should have thrown .clientNotRegistered due to biometric state mismatch")
+        } catch let error as DeviceBindingStatus {
+            XCTAssertEqual(error, .clientNotRegistered)
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        
+        let cryptoKey = CryptoKey(keyId: userId)
+        cryptoKey.deleteKeys()
+    }
+    
+    
+    func test_21_biometricDomainState_signSkipsCheckWhenNil() {
+        // When biometricDomainState is nil in UserKey, the domain state check should be skipped.
+        // We verify this by confirming the authenticator does NOT delete keys before failing.
+        // If the domain state check were triggered, deleteKeys() would be called first.
+        let userId = "Test User Id 21"
+        let challenge = "challenge"
+        let expiration = Date().addingTimeInterval(60.0)
+        
+        let authenticator = SpyBiometricAndDeviceCredential()
+        authenticator.initialize(userId: userId, prompt: Prompt(title: "", subtitle: "", description: ""))
+        
+        // UserKey without biometricDomainState (nil) - domain state check should be skipped
+        let userKey = UserKey(id: "id", userId: userId, userName: "name", kid: UUID().uuidString, authType: .biometricAllowFallback, createdAt: Date().timeIntervalSince1970, biometricDomainState: nil)
+        
+        do {
+            _ = try authenticator.sign(userKey: userKey, challenge: challenge, expiration: expiration, customClaims: [:])
+        } catch {
+            // Expected to fail (key doesn't exist), but deleteKeys should NOT have been called
+            // because the domain state check was skipped
+            XCTAssertFalse(authenticator.deleteKeysCalled, "deleteKeys should not be called when biometricDomainState is nil")
+        }
+        
+        let cryptoKey = CryptoKey(keyId: userId)
+        cryptoKey.deleteKeys()
+    }
+    
+    
+    func test_22_biometricDomainState_protocolExtensionDefault() {
+        // Verify that a type conforming directly to DeviceAuthenticator
+        // gets the default nil implementation from the protocol extension
+        let customAuthenticator = CustomProtocolOnlyAuthenticator()
+        XCTAssertNil(customAuthenticator.biometricDomainState())
+    }
+    
+}
+
+
+/// Test authenticator conforming directly to DeviceAuthenticator protocol (not subclassing DefaultDeviceAuthenticator)
+/// Used to verify the protocol extension provides a default biometricDomainState() implementation
+private class CustomProtocolOnlyAuthenticator: DeviceAuthenticator {
+    func generateKeys() throws -> KeyPair { fatalError() }
+    func sign(keyPair: KeyPair, kid: String, userId: String, challenge: String, expiration: Date) throws -> String { fatalError() }
+    func sign(userKey: UserKey, challenge: String, expiration: Date, customClaims: [String: Any]) throws -> String { fatalError() }
+    func isSupported() -> Bool { return false }
+    func accessControl() -> SecAccessControl? { return nil }
+    func setPrompt(_ prompt: Prompt) { }
+    func type() -> DeviceBindingAuthenticationType { return .none }
+    func initialize(userId: String, prompt: Prompt) { }
+    func initialize(userId: String) { }
+    func deleteKeys() { }
+    func issueTime() -> Date { return Date() }
+    func notBeforeTime() -> Date { return Date() }
+    func validateCustomClaims(_ customClaims: [String: Any]) -> Bool { return true }
+}
+
+
+/// Spy subclass of BiometricAndDeviceCredential to track whether deleteKeys() is called
+/// during the biometric domain state check in sign(userKey:...)
+private class SpyBiometricAndDeviceCredential: BiometricAndDeviceCredential {
+    var deleteKeysCalled = false
+    
+    override func deleteKeys() {
+        deleteKeysCalled = true
+        super.deleteKeys()
+    }
 }


### PR DESCRIPTION
Improving the Biometric_allow_fallback to respect the PIN if the biometrics are not set on a device

# JIRA Ticket

SDKS-4922

# Description

## Core Changes
State Tracking: The app now captures the biometricDomainState (a unique hash of the biometric database) during the initial device binding and stores it within the UserKey object.

Validation on Sign-In: Every time a signing operation occurs, the current biometric state is compared against the stored state.

Security Enforcement: If the states do not match—indicating the biometric set has changed—the app automatically deletes the existing keys and throws a .clientNotRegistered error, forcing the user to re-bind for security.

Access Control Update: The security flags were changed from .biometryCurrentSet to .biometryAny. This moves the responsibility of invalidating keys from the iOS system to the application, allowing for a more controlled user experience (e.g., custom error messages or specific recovery flows).

# Definition of Done Checklist:

- [X] Coded to standards.
- [X] Ensure backward compatibility.
- [X] API reference docs is created or updated, if applicable.
- [X] Unit tests are written or updated.
- [X] Integration tests are written, if applicable.