### PR TITLE
feat: exclude revoke session call when new sso token received

### DIFF
--- a/FRAuth/FRAuth/Authentication/Node.swift
+++ b/FRAuth/FRAuth/Authentication/Node.swift
@@ -293,7 +293,7 @@ public class Node: NSObject {
                             var revokeError: Error?
                             
                             // 2. Call the async function.
-                            tokenManager.revokeAndEndSession { error in
+                            tokenManager.revoke { error in
                                 FRLog.i("OAuth2 token set revocation finished. Error: \(error?.localizedDescription ?? "none")")
                                 // Capture the result and signal completion.
                                 revokeError = error

--- a/FRAuth/FRAuth/Manager/TokenManager.swift
+++ b/FRAuth/FRAuth/Manager/TokenManager.swift
@@ -191,6 +191,7 @@ struct TokenManager {
                 self.oAuth2Client.revoke(accessToken: token) { (error) in
                     completion(error)
                 }
+                completion(nil)
             }
             else {
                 completion(TokenError.nullToken)


### PR DESCRIPTION
Post the AM update that happened on the morning of 15th April 2026, few of the flows in the SDK broke down. It was later discovered that the cause behind it was the new session token that gets issued at the end of an authentication tree gets revoked because it is attached to the end session request that is made after a new token is received. This behaviour is a mis-match between the iOS and Android SDK and the Android SDK only makes the /revoke request and not the /endSession request whereas the iOS SDK makes them both. This change fixes that to align the behaviour between the 2 SDK and fix the issue caused after the backend update.