### PR TITLE
fix: add cookie back after set sso token

### DIFF
--- a/FRAuth/FRAuth/Authentication/AuthService.swift
+++ b/FRAuth/FRAuth/Authentication/AuthService.swift
@@ -215,7 +215,7 @@ public class AuthService: NSObject {
         // Invoke request
         FRRestClient.invoke(request: request, action: action) { (result) in
             switch result {
-            case .success(let response, _):
+            case .success(let response, let httpResponse):
                 
                 // If authId received
                 if let _ = response[OpenAM.authId] {
@@ -237,7 +237,10 @@ public class AuthService: NSObject {
                         completion(token, nil, nil)
                         return
                     }
-                    keychainManager.handleSessionToken(token, tokenManager: self.tokenManager, completion: completion)
+                    keychainManager.handleSessionToken(token, tokenManager: self.tokenManager) { result, node, error in
+                        FRRestClient.parseResponseForCookie(response: response, httpResponse: httpResponse as? HTTPURLResponse)
+                        completion(result, node, error)
+                    }
                 }
                 else {
                     completion(nil, nil, nil)

--- a/FRAuth/FRAuth/Authentication/Node.swift
+++ b/FRAuth/FRAuth/Authentication/Node.swift
@@ -257,7 +257,7 @@ public class Node: NSObject {
         let thisRequest = self.buildAuthServiceRequest()
         FRRestClient.invoke(request: thisRequest, action: Action(type: .AUTHENTICATE, payload: ["tree": self.serviceName, "type": self.authIndexType])) { (result) in
             switch result {
-            case .success(let response, _):
+            case .success(let response, let httpResponse):
                 
                 // If authId received
                 if let _ = response[OpenAM.authId] {
@@ -280,7 +280,10 @@ public class Node: NSObject {
                         completion(token, nil, nil)
                         return
                     }
-                    keychainManager.handleSessionToken(token, tokenManager: self.tokenManager, completion: completion)
+                    keychainManager.handleSessionToken(token, tokenManager: self.tokenManager) { result, node, error in
+                        FRRestClient.parseResponseForCookie(response: response, httpResponse: httpResponse as? HTTPURLResponse)
+                        completion(result, node, error)
+                    }
                 }
                 else {
                     completion(nil, nil, nil)


### PR DESCRIPTION
# Description

The work done in [SDKS-3045](https://github.com/ForgeRock/forgerock-ios-sdk/pull/371) fixed a part of the issue where step up requests do not revoke the new session token but introduces a minor issue where the cookies received from the `/authorize` endpoint are first stored, and then deleted as a part of the `revokeSSOToken` in `SessionManager`. This causes all the subsequent requests made to be missing the session token cookie from the cookie store.

This change is not to be be considered for merging, only acts as a reference point to help developers point in the direction of the issue. The minor change addresses setting the cookie from the response post session token handling.